### PR TITLE
Fix README instructions to use NSFlow from git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ git clone https://github.com/leaf-ai/nsflow.git
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+pip install -r requirements-private.txt
 ```
 
 #### **Step 3: Run Everything with a Single Command**
 ```bash
-python -m nsflow run
+python -m nsflow.run
 ```
 
 By default, this will start:


### PR DESCRIPTION
Had to fix the README instructions to run NSFlow for the first time:
- the command was wrong
- we have to install `neuro-san` and the other private dependencies