### PR TITLE
add token accounting that shows up in logs

### DIFF
--- a/nsflow/frontend/src/components/LogsPanel.tsx
+++ b/nsflow/frontend/src/components/LogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { FaDownload } from "react-icons/fa";
 import { useApiPort } from "../context/ApiPortContext";
 import { useChatContext } from "../context/ChatContext";
@@ -18,9 +18,13 @@ const LogsPanel = () => {
     { timestamp: getCurrentTimestamp(), source: "Frontend", message: "System initialized." },
     { timestamp: getCurrentTimestamp(), source: "Frontend", message: "Frontend app loaded successfully." },
   ]);
-  const { 
-    activeNetwork,
-   } = useChatContext();
+  const { activeNetwork} = useChatContext();
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Auto-scroll to latest message
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logs]);
 
   useEffect(() => {
     if (!apiPort || !activeNetwork) return; // Prevents WebSocket from connecting before port is set
@@ -89,6 +93,7 @@ const LogsPanel = () => {
         ) : (
           <p className="text-gray-400">No logs available.</p>
         )}
+        <div ref={messagesEndRef} />
       </div>
     </div>
   );


### PR DESCRIPTION
As the title suggests, we show token accounting int he logs. 
Example logs:

> [2025-03-31 20:48:35] (NeuroSan): {"token_accounting": {"completion_tokens": 1154.0, "total_tokens": 15592.0, "caveats": ["Only doing token accounting for OpenAI and Anthropic models for now.", "Each LLM Branch Node also includes accounting for each of its callees."], "prompt_tokens": 14438.0, "successful_requests": 6.0, "total_cost": 0.047635000000000004}}