### PR TITLE
Distinguish between gRPC and HTTP ports and default to gRPC port 30011

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,7 @@ AGENT_MANIFEST_FILE=registries/manifest.hocon
 AGENT_TOOL_PATH=coded_tools
 
 # Examples of a hosted neuro-san server hostname
-NS_SERVER_HOST=127.0.0.1
-# NS_SERVER_HOST=44.246.165.183
+NEURO_SAN_SERVER_HOST=127.0.0.1
 
 # Examples of a neuro-san server port
-NS_SERVER_PORT=30011
-# NS_SERVER_PORT=30015
+NEURO_SAN_GRPC_SERVER_PORT=30011

--- a/nsflow/backend/main.py
+++ b/nsflow/backend/main.py
@@ -43,7 +43,7 @@ def initialize_ns_config_from_env():
         logging.info("CLIENT-ONLY mode detected. Starting client with default neuro-san configs.")
     default_connection = os.getenv("NEURO_SAN_SERVER_CONNECTION", "grpc")
     default_host = os.getenv("NEURO_SAN_SERVER_HOST", "localhost")
-    default_port = int(os.getenv("NEURO_SAN_SERVER_PORT", "30015"))
+    default_port = int(os.getenv("NEURO_SAN_GRPC_SERVER_PORT", "30011"))
     NsConfigsRegistry.set_current(default_connection, default_host, default_port)
     logging.info("[Startup] Default NsConfig set to %s://%s:%s", default_connection, default_host, default_port)
 

--- a/nsflow/run.py
+++ b/nsflow/run.py
@@ -43,7 +43,7 @@ class NsFlowRunner:
         # Default Configuration
         self.config: Dict[str, Any] = {
             "server_host": os.getenv("NEURO_SAN_SERVER_HOST", "localhost"),
-            "server_port": int(os.getenv("NEURO_SAN_SERVER_PORT", "30015")),
+            "server_port": int(os.getenv("NEURO_SAN_GRPC_SERVER_PORT", "30011")),
             "server_connection": str(os.getenv("NEURO_SAN_SERVER_CONNECTION", "grpc")),
             "manifest_update_period_seconds": int(os.getenv("AGENT_MANIFEST_UPDATE_PERIOD_SECONDS", "5")),
             "default_sly_data": str(os.getenv("DEFAULT_SLY_DATA", "")),
@@ -199,7 +199,7 @@ The type of connection to initiate. Choices are to connect to:
 
         server_env = {
             "NEURO_SAN_SERVER_HOST": "server_host",
-            "NEURO_SAN_SERVER_PORT": "server_port",
+            "NEURO_SAN_GRPC_SERVER_PORT": "server_port",
             "AGENT_TOOL_PATH": "agent_tool_path",
             "NSFLOW_SERVER_ONLY": "server_only",
             "DEFAULT_SLY_DATA": "default_sly_data"


### PR DESCRIPTION
- Updated env variables to distinguish between gRPC and HTTP ports for the neuro-san server.
- Defaulting to gRPC port 30011 to match `neuro-san` and `neuro-san-studio`'s default gRPC port.