### PR TITLE
Use pypi Trusted Publishing as per best practice

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build and Publish
     runs-on: ubuntu-latest
     environment: pypi  # Match this to your configured GitHub Environment.
-      permissions:
-    id-token: write #Mandatory for PyPi Trusted Publishing (configured at pypi.org)
+    permissions:
+      id-token: write #Mandatory for PyPi Trusted Publishing (configured at pypi.org)
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Based on best practice as outlined in this blog post. Hat tip to @sidcog for pointing this out to me.

https://blog.pypi.org/posts/2025-09-16-github-actions-token-exfiltration/

This PR gets us away from a long-lived token and instead uses pypi's Trusted Publishing mechanism. The change is three parts.

    Configure project at pypi.org to use Trusted Publishing
    Give the workflow the necessary permissions to use Trusted Publishing
    Remove the long-lived token from the workflow
