### PR TITLE
Fix music_nerd_pro not returning answer

### DIFF
--- a/nsflow/backend/utils/agentutils/async_streaming_input_processor.py
+++ b/nsflow/backend/utils/agentutils/async_streaming_input_processor.py
@@ -80,7 +80,7 @@ class AsyncStreamingInputProcessor(StreamingInputProcessor):
 
             # Update the state if there is something to update it with
             chat_context = self.processor.get_chat_context()
-            last_chat_response = self.processor.get_answer()
+            last_chat_response = self.processor.get_compiled_answer()
             returned_sly_data: Dict[str, Any] = self.processor.get_sly_data()
             origin_str = Origination.get_full_name_from_origin(self.processor.get_answer_origin())
 


### PR DESCRIPTION


<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Networks with `"structure_formats": "json"` do not have any responses.

Use `get_compiled_answer()` which return both text and structure instead of `get_answer()` which only return text to get the `last_chat_response` in `AsyncStreamingInputProcessor.async_process_once()`.

Fixes #128 

## Impact

Networks that only return structure will have responses.

## Screenshots / Logs / Examples (optional)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
