### PR TITLE
#131 Pin leaf-common to version 1.2.34 to avoid buggy 1.2.35

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fastapi-cors>=0.0.6
 fastapi>=0.115.8
 aiofiles>=24.1.0
 graphviz==0.20.3
-leaf-common==1.2.34  # Version 1.3.35 is breaking. See https://github.com/cognizant-ai-lab/nsflow/issues/131
+leaf-common==1.2.34  # Version 1.2.35 is breaking. See https://github.com/cognizant-ai-lab/nsflow/issues/131
 nbformat>=5.10.4
 pydantic>=2.9.2
 pyhocon>=0.3.61


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description
Pin leaf-common to version 1.2.34 to avoid buggy 1.2.35

Fixes #131  

## Impact

## Screenshots / Logs / Examples (optional)


## Type of Change

- [X] Bug fix
- [ ] New feature
- [X] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
