### PR TITLE
Fix node overlap in build_nodes_and_edges() with radial layout

### DIFF
--- a/nsflow/backend/utils/agentutils/ns_network_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_network_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 # END COPYRIGHT
+import math
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -69,6 +70,11 @@ class NsNetworkUtils:
                 for child in origin_to_tools.get(current_node, []):
                     stack.append((child, current_depth + 1))
 
+        # Step 2.5: Calculate radial positions so nodes don't overlap
+        positions = NsNetworkUtils._calculate_radial_positions(
+            all_nodes, depth_map, parent_map, origin_to_tools
+        )
+
         # Step 3: Build node dicts
         for node in all_nodes:
             children = origin_to_tools.get(node, [])
@@ -84,7 +90,7 @@ class NsNetworkUtils:
                         "dropdown_tools": [],
                         "sub_networks": [],
                     },
-                    "position": {"x": 100, "y": 100},
+                    "position": positions.get(node, {"x": 400, "y": 400}),
                 }
             )
 
@@ -234,6 +240,96 @@ class NsNetworkUtils:
     def get_children(data: Dict[str, Any]) -> List[str]:
         """Get down-chain agents for any agent in the network"""
         return list(data.get("tools") or data.get("down_chains") or [])
+
+    # Estimated node dimensions for overlap prevention
+    _NODE_WIDTH = 250
+    _NODE_HEIGHT = 60
+    _PADDING = 80
+
+    @staticmethod
+    def _calculate_radial_positions(
+        all_nodes: set,
+        depth_map: Dict[str, int],
+        parent_map: Dict[str, str],
+        origin_to_tools: Dict[str, List[str]],
+    ) -> Dict[str, Dict[str, int]]:
+        """
+        Calculate radial positions for nodes: root at center, children in
+        concentric rings.  Adapts automatically to any number of nodes at each
+        depth level.  All returned coordinates are guaranteed positive.
+        """
+        if not all_nodes:
+            return {}
+
+        positions: Dict[str, Dict[str, int]] = {}
+
+        # Group nodes by depth
+        depth_groups: Dict[int, List[str]] = {}
+        for node in all_nodes:
+            d = depth_map.get(node, 0)
+            depth_groups.setdefault(d, []).append(node)
+
+        # Sort each group for deterministic ordering
+        for d in depth_groups:
+            depth_groups[d].sort()
+
+        max_depth = max(depth_groups.keys()) if depth_groups else 0
+
+        # Calculate radius for each ring so nodes never overlap.
+        # Arc distance between adjacent nodes must be >= NODE_WIDTH.
+        # arc = 2*pi*r / n  =>  r = n * NODE_WIDTH / (2*pi)
+        nw = NsNetworkUtils._NODE_WIDTH
+        nh = NsNetworkUtils._NODE_HEIGHT
+        min_gap = max(nw, nh) + NsNetworkUtils._PADDING  # min arc between nodes
+
+        # Use origin (0, 0); we shift to positive coordinates at the end.
+        cx, cy = 0, 0
+
+        # Place depth-0 nodes (roots) at center
+        roots = depth_groups.get(0, [])
+        if len(roots) == 1:
+            positions[roots[0]] = {"x": cx, "y": cy}
+        else:
+            r = max(200, len(roots) * min_gap / (2 * math.pi))
+            for i, node in enumerate(roots):
+                angle = 2 * math.pi * i / len(roots) - math.pi / 2
+                positions[node] = {
+                    "x": int(cx + r * math.cos(angle)),
+                    "y": int(cy + r * math.sin(angle)),
+                }
+
+        # Place nodes at each subsequent depth in concentric rings
+        base_ring_radius = 350
+        for depth in range(1, max_depth + 1):
+            ring_nodes = depth_groups.get(depth, [])
+            if not ring_nodes:
+                continue
+
+            n = len(ring_nodes)
+            # Radius = max of (base for this depth, minimum to avoid overlap)
+            min_r_for_spacing = n * min_gap / (2 * math.pi)
+            radius = max(base_ring_radius * depth, min_r_for_spacing)
+
+            for i, node in enumerate(ring_nodes):
+                angle = 2 * math.pi * i / n - math.pi / 2
+                positions[node] = {
+                    "x": int(cx + radius * math.cos(angle)),
+                    "y": int(cy + radius * math.sin(angle)),
+                }
+
+        # Shift all positions so every coordinate is positive with padding
+        if positions:
+            min_x = min(p["x"] for p in positions.values())
+            min_y = min(p["y"] for p in positions.values())
+            pad = NsNetworkUtils._PADDING
+            shift_x = -min_x + pad if min_x < pad else 0
+            shift_y = -min_y + pad if min_y < pad else 0
+            if shift_x or shift_y:
+                for p in positions.values():
+                    p["x"] += shift_x
+                    p["y"] += shift_y
+
+        return positions
 
     @staticmethod
     def _calculate_positions(


### PR DESCRIPTION
## Description

All nodes in `build_nodes_and_edges()` were assigned the same hardcoded position `(100, 100)`, causing them to randomly render stacked on top of each other. The class already had a `_calculate_positions()` method (used by `partial_build_nodes_and_edges()`) but `build_nodes_and_edges()` never called it.

## Problem

When viewing an agent network in the nsflow GUI, all nodes are rendered at the same position `(100, 100)`**, causing them to stack on top of each other. Only a few nodes are visible (the ones rendered last in the DOM), and different nodes
appear each restart because Python `set` iteration order is non-deterministic.

This affects any agent network using the main connectivity endpoint (`GET /api/v1/connectivity/{network_name}`), which calls
`NsNetworkUtils.build_nodes_and_edges()`.

## Fixes 

- Added `_calculate_radial_positions()` static method that places the root node at the center and distributes children in concentric rings based on depth
- Radius scales dynamically: `max(base_radius * depth, n * min_gap / 2π)` — adapts to any number of nodes
- Nodes are sorted alphabetically within each ring for deterministic layout across restarts
- All coordinates are shifted to guarantee positive values
- Wired the new method into `build_nodes_and_edges()` replacing the hardcoded position

## Impact

- Any agent network with more than ~5 nodes was sometimes (randomly) unusable in the graph view — now renders correctly
- Verified with 3, 7, and 15-node networks with zero visual overlaps
- Only 1 file changed: `nsflow/backend/utils/agentutils/ns_network_utils.py` (97 additions, 1 deletion)
- No breaking changes — the method signature and return format remain identical

## Layout behavior

- Root node (front man, depth 0): placed at center
- Children (depth 1): distributed in a circle around the root
- Deeper nodes (depth 2+): placed in larger concentric rings
- Radius scales dynamically: computed as `max(base_radius * depth, n * min_gap / 2pi)`, ensuring nodes never overlap regardless of how many there are
- All coordinates are guaranteed positive: after computing the radial layout, all positions are shifted so the minimum x and y are at least `_PADDING` (80px)
- Deterministic ordering: nodes are sorted alphabetically within each ring, so the layout is identical across restarts
- Dynamic: adding or removing tools automatically recalculates all positions; the ring radius grows to accommodate more nodes


## Type of Change

- [X ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [X ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

### Verified test results

**15-node network** (1 front man + 14 children):

```
  activity_tracker               (  796,    80)
  anomaly_detector               ( 1115,   153)
  data_flow_analyzer             ( 1370,   357)
  digital_twin                   ( 1512,   652)
  enterprise_dashboard      (  796,   815)   ← center (front man)
  handoff_analyzer               ( 1512,   978)
  peer_comparator                ( 1370,  1273)
  personal_analyst               ( 1115,  1477)
  process_miner                  (  796,  1550)
  process_optimizer              (  477,  1477)
  profile_analyzer               (  222,  1273)
  recommendation_engine          (   80,   978)
  scenario_analyst               (   80,   652)
  team_aggregator                (  222,   357)
  workflow_analyzer              (  477,   153)

All coordinates positive: YES
Visual overlaps (250x60px nodes): 0
```

**7-node network** (1 front man + 6 children):

```
  a               (  383,    80)
  b               (  686,   255)
  c               (  686,   604)
  d               (  383,   780)
  e               (   80,   605)
  f               (   80,   255)
  front_man       (  383,   430)   ← center

All coordinates positive: YES
Visual overlaps: 0
```

**3-node network** (1 root + 2 children):

```
  child_a         (   80,    80)
  child_b         (   80,   780)
  root            (   80,   430)   ← center

All coordinates positive: YES
Visual overlaps: 0

## Note on other affected endpoints

The same hardcoded `(100, 100)` position issue exists in other files/endpoints that may need similar fixes:

- `agent_network_utils.py` → `process_agent()` (line 207) — used by `/compact_connectivity/`
- `editor_endpoints.py` → multiple endpoints (lines 729, 1144) — used by the editor view

I will take a look at these in the future. 

---
