### PR TITLE
Migrate tests.yml to build-common quality gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,46 +13,16 @@ permissions:
 jobs:
   test:
     if: github.repository == 'cognizant-ai-lab/nsflow'
-    runs-on: ubuntu-latest
-    container:
-      image: python:3.12-slim
-    env:
+    # 1.0.0
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
+    with:
+      python-version: '3.12'
+      # No lint or test steps in original workflow
+      lint-command-override: 'true'
+      run-shellcheck: false
+      run-pytest: false
+      check-readme-pypi: true
+    secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          pip install -r requirements-build.txt
-          pip install -r requirements.txt
-
-      - name: Show installed packages
-        run: pip freeze
-
-      - name: Check README renders correctly on PyPI
-        run: |
-          pip install readme_renderer readme_renderer[md]
-          python -m readme_renderer README.md
-
-
-      - name: Notify Slack on success
-        if: success() && env.SLACK_WEBHOOK_URL != ''
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            { 
-              "text": "✅ *Tests Passed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
-            }
-
-      - name: Notify Slack on failure
-        if: failure() && env.SLACK_WEBHOOK_URL != ''
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            {
-              "text": "❌ *Tests Failed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
-            }
 
 


### PR DESCRIPTION
## Description

Replaces the inline workflow steps with a `workflow_call` to the shared `_python-quality-gate.yml` reusable workflow from `build-common` (pinned to SHA `455db3c`, tag 1.0.0).

The original workflow had no lint or test steps -- only dependency installation, a README PyPI rendering check, and Slack notifications. All are preserved through quality gate inputs: `lint-command-override` disables lint, `run-pytest: false` disables tests, `check-readme-pypi: true` keeps the README check, and Slack is enabled by default.

## Impact

- **Container to ubuntu-latest**: The old workflow ran inside `python:3.12-slim`; the quality gate runs on `ubuntu-latest` with `actions/setup-python`. Low risk for a README rendering check.
- **Slack message format**: The old workflow used custom emoji-prefixed text payloads. The `slack-notify` composite action generates its own format via `build-payload.sh`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

## Human Review Checklist

- [ ] Verify `lint-command-override: 'true'` (shell no-op) correctly skips all individual lint steps in the quality gate workflow
- [ ] Confirm the `python:3.12-slim` container → `ubuntu-latest` runner change is acceptable
- [ ] Confirm the new Slack notification format from `slack-notify` is acceptable for your channel
- [ ] Trigger a CI run on this branch to validate the quality gate passes end-to-end

Link to Devin session: https://app.devin.ai/sessions/c7476641f65740d4848312b80a0198cb
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/nsflow/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
