### PR TITLE
Migrate publish.yml to build-common actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,46 +11,32 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi  # Match this to your configured GitHub Environment.
     permissions:
-      id-token: write #Mandatory for PyPi Trusted Publishing (configured at pypi.org)
+      id-token: write  # Mandatory for PyPI Trusted Publishing
 
     steps:
+      # actions/checkout v6.0.2
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      # cognizant-ai-lab/build-common 1.0.0 -- setup-python-env
+      - name: Set up Python and install build tools
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
         with:
           python-version: '3.10'
-
-      - name: Install build tools
-        run: |
-          pip install --upgrade pip
-          pip install build
+          requirements-file: ''
+          install-extras: 'build'
 
       - name: Build wheel and sdist
         run: python -m build
 
+      # pypa/gh-action-pypi-publish v1.14.0
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
-      - name: Notify Slack on success
-        if: success()
-        uses: slackapi/slack-github-action@v1.24.0
+      # cognizant-ai-lab/build-common 1.0.0 -- slack-notify
+      - name: Notify Slack
+        if: ${{ !cancelled() }}
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
         with:
-          payload: |
-            {
-              "text": "✅ *Publish Action Passed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on failure
-        if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            {
-              "text": "❌ *Publish Action Failed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

Replaces inline setup-python, pip-install, and dual Slack notification steps with shared composite actions from `build-common` (`setup-python-env`, `slack-notify`). Pins all GitHub Actions to exact commit SHAs instead of floating tags/branches. Upgrades `actions/checkout` from v4 to v6.0.2 and `pypa/gh-action-pypi-publish` from `release/v1` branch to v1.14.0.

## Impact

- **`actions/checkout` v4 → v6.0.2**: Major version bump (pinned to SHA). Low risk since no submodules or special checkout options are used.
- **`setup-python-env` replaces manual steps**: `setup-python@v5` + `pip install build` replaced by composite action with `requirements-file: ''` (skips dependency installation) and `install-extras: 'build'`.
- **`pypa/gh-action-pypi-publish`**: Pinned from `release/v1` floating branch to v1.14.0 SHA.
- **Slack notification**: Two separate success/failure steps with custom emoji payloads consolidated into a single `slack-notify` step. The message format will differ from the old custom payloads.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

### Notes
- The `id-token: write` permission for PyPI Trusted Publishing is preserved unchanged.
- Slack notification now fires on both success and failure via `!cancelled()`, matching the build-common convention used across other migrated repos.

Link to Devin session: https://app.devin.ai/sessions/c4446c588f62442c946a104532c18a3c
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/nsflow/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
