### PR TITLE
Migrate publish.yml to build-common actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,46 +11,32 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi  # Match this to your configured GitHub Environment.
     permissions:
-      id-token: write #Mandatory for PyPi Trusted Publishing (configured at pypi.org)
+      id-token: write  # Mandatory for PyPI Trusted Publishing
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # actions/checkout v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Python and install build tools
+        # cognizant-ai-lab/build-common setup-python-env 1.0.0
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
         with:
           python-version: '3.10'
-
-      - name: Install build tools
-        run: |
-          pip install --upgrade pip
-          pip install build
+          requirements-file: ''
+          install-extras: 'build'
 
       - name: Build wheel and sdist
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # pypa/gh-action-pypi-publish v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
-      - name: Notify Slack on success
-        if: success()
-        uses: slackapi/slack-github-action@v1.24.0
+      - name: Notify Slack
+        if: ${{ !cancelled() }}
+        # cognizant-ai-lab/build-common slack-notify 1.0.0
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
         with:
-          payload: |
-            {
-              "text": "✅ *Publish Action Passed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on failure
-        if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            {
-              "text": "❌ *Publish Action Failed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

Migrates `publish.yml` to use shared `build-common` composite actions (`setup-python-env`, `slack-notify`) instead of inline steps. Pins all GitHub Actions to exact commit SHAs with descriptive version comments. Collapses two separate Slack notification steps (success/failure) into a single step using the `slack-notify` composite action.

## Impact

- **`actions/checkout` v4 → v6.0.2**: Major version bump. Low risk for this workflow (no submodules or special checkout options).
- **Slack message format**: The old emoji-prefixed custom text payloads are replaced by the `slack-notify` action's standardized format via `build-payload.sh`.
- **`pypa/gh-action-pypi-publish`**: Pinned from `release/v1` branch to v1.14.0 SHA.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

## Human Review Checklist

- [ ] Verify the `actions/checkout` v4 → v6 major version bump does not introduce breaking changes for this workflow
- [ ] Confirm `setup-python-env` with `requirements-file: ''` correctly skips dependency installation and only installs the `build` extra via `install-extras`
- [ ] Confirm the new Slack notification format from `slack-notify` is acceptable (replaces custom emoji-prefixed payloads)
- [ ] This workflow triggers only on `release: published` -- PR CI will **not** exercise it. Recommend verifying via a test release or temporary `workflow_dispatch` trigger

Link to Devin session: https://app.devin.ai/sessions/cd6e25b4677843ff9fca1ecffd248803
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/nsflow/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
