### PR TITLE
Append to PYTHONPATH instead of overwriting

### DIFF
--- a/nsflow/run.py
+++ b/nsflow/run.py
@@ -215,7 +215,11 @@ The type of connection to initiate. Choices are to connect to:
 
     def set_environment_variables(self):
         """Set required environment variables based on active mode."""
-        os.environ["PYTHONPATH"] = self.root_dir
+        existing_pythonpath = os.environ.get("PYTHONPATH", "")
+        if existing_pythonpath:
+            os.environ["PYTHONPATH"] = self.root_dir + os.pathsep + existing_pythonpath
+        else:
+            os.environ["PYTHONPATH"] = self.root_dir
 
         # Common envs
         common_env = {


### PR DESCRIPTION
## Description

`set_environment_variables()` in `run.py` was unconditionally overwriting `PYTHONPATH` with just the nsflow root directory. This discarded any user-configured paths, which caused `ImportError` when pointing nsflow at external resources (e.g. neuro-san-studio's `middleware/` or `coded_tools/` directories).

The fix preserves existing `PYTHONPATH` entries by prepending the nsflow root instead of replacing the entire variable.

## Impact

Users who set `PYTHONPATH` (via shell, `.env`, etc.) to include paths like neuro-san-studio will no longer have those paths silently dropped when nsflow spawns its subprocesses.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

## Review Notes

- The nsflow root is **prepended** so it retains highest priority, matching the original intent.
- `os.pathsep` is used for cross-platform correctness (`:` on Unix, `;` on Windows).

Link to Devin session: https://app.devin.ai/sessions/94dddc0113564dfb8867d128a8555926
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/nsflow/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
