### PR TITLE
Fix not read from progress report

### DIFF
--- a/nsflow/frontend/src/components/TabbedChatPanel.tsx
+++ b/nsflow/frontend/src/components/TabbedChatPanel.tsx
@@ -194,6 +194,14 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
               payload = undefined;
             }
           }
+        } else if (typeof msg === "string") {
+          // AGENT_PROGRESS events arrive as a JSON string: '{"progress": {...}}'
+          try {
+            const parsed = JSON.parse(msg);
+            payload = "progress" in parsed ? parsed.progress : parsed;
+          } catch {
+            payload = undefined;
+          }
         }
 
         if (payload) {


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

The backend sends AGENT_PROGRESS events (from ProgressHandler.report_progress)
as a JSON string `{"progress": {...}}`, while AGENT tool-result events are sent
as an object `{"text": {...}}`. The frontend only handled the object case, so
explicit progress reports were silently dropped and the graph was driven solely
by the tool return value. Add a string-message branch that parses and extracts
the `progress` field so the graph updates from the intended progress report.

Fixes #186 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
