### PR TITLE
Support connectivity-list format for agent_network_definition

### DIFF
--- a/nsflow/backend/api/v1/agent_flows.py
+++ b/nsflow/backend/api/v1/agent_flows.py
@@ -69,8 +69,12 @@ async def build_connectivity_from_json(request: Request):
     Accepts ONE of:
       A) connectivity_info: [{ "origin": str, "tools": [str, ...] }, ...]
          -> NsNetworkUtils.build_nodes_and_edges(...)
-      B) agent_network_definition: { "<agent>": { "down_chains": [...], "instructions": str }, ... }
-         + optional agent_network_name
+      B) agent_network_definition: dict or connectivity-style list
+           - dict form:  { "<agent>": { "down_chains": [...], "instructions": str }, ... }
+           - list form:  [{ "origin": str, "tools": [...], "instructions": str, ... }, ...]
+             (entries whose "origin" starts with "/" are treated as external agents and excluded
+             from top-level keys; only "tools", "instructions", and "description" are copied)
+         + optional agent_network_name (str)
          -> NsNetworkUtils.partial_build_nodes_and_edges(...)
     """
     try:

--- a/nsflow/backend/api/v1/agent_flows.py
+++ b/nsflow/backend/api/v1/agent_flows.py
@@ -79,13 +79,16 @@ async def build_connectivity_from_json(request: Request):
         raise HTTPException(status_code=422, detail="Body must be valid JSON") from e
 
     has_conn = isinstance(data.get("connectivity_info"), list)
-    has_state = isinstance(data.get("agent_network_definition"), dict)
+    has_state = isinstance(data.get("agent_network_definition"), (dict, list))
 
     # require exactly one of the two inputs
     if has_conn == has_state:
         raise HTTPException(
             status_code=422,
-            detail="Provide exactly one of 'connectivity_info' (list) or 'agent_network_definition' (dict).",
+            detail=(
+                "Provide exactly one of 'connectivity_info' (list) or "
+                "'agent_network_definition' (dict or connectivity-style list)."
+            ),
         )
 
     try:
@@ -130,10 +133,10 @@ async def get_agent_details_from_json(agent_name: str, request: Request):
         raise HTTPException(status_code=422, detail="Body must be valid JSON") from e
 
     agent_def = data.get("agent_network_definition")
-    if not isinstance(agent_def, dict):
+    if not isinstance(agent_def, (dict, list)):
         raise HTTPException(
             status_code=422,
-            detail="Missing or invalid 'agent_network_definition' (dict required).",
+            detail="Missing or invalid 'agent_network_definition' (dict or connectivity-style list required).",
         )
 
     try:

--- a/nsflow/backend/utils/agentutils/ns_network_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_network_utils.py
@@ -107,8 +107,11 @@ class NsNetworkUtils:
         nodes: List[Dict] = []
         edges: List[Dict] = []
 
-        # Extract agent network definition
-        agent_definition = state_dict.get("agent_network_definition", {})
+        # Extract agent network definition (accept dict or list/connectivity format)
+        raw_definition = state_dict.get("agent_network_definition", {})
+        if isinstance(raw_definition, list):
+            raw_definition = NsNetworkUtils.list_def_to_dict(raw_definition)
+        agent_definition = raw_definition
         network_name = state_dict.get("agent_network_name", "unknown_network")
 
         if not agent_definition:
@@ -320,10 +323,38 @@ class NsNetworkUtils:
         return components
 
     @staticmethod
-    def normalize_agent_def(agent_def: Dict[str, dict]) -> Dict[str, dict]:
+    def list_def_to_dict(
+        list_def: List[Dict[str, Any]],
+        include_keys: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         """
-        Canonicalize children under 'down_chains' (accepts 'tools' or 'down_chains').
+        Convert list-format (connectivity-style) agent definition to dict-format.
+        Entries whose 'origin' starts with '/' are external agents — they are
+        referenced inside tools lists but never appear as top-level dict keys.
+        Only keys present in include_keys (and non-empty) are copied.
         """
+        if include_keys is None:
+            include_keys = ["tools", "instructions", "description"]
+        result: Dict[str, Any] = {}
+        for entry in list_def or []:
+            name = entry.get("origin")
+            if not name or name.startswith("/"):
+                continue
+            value: Dict[str, Any] = {}
+            for key in include_keys:
+                if key in entry and entry[key]:
+                    value[key] = entry[key]
+            result[name] = value
+        return result
+
+    @staticmethod
+    def normalize_agent_def(agent_def) -> Dict[str, dict]:
+        """
+        Canonicalize children under 'down_chains'.
+        Accepts dict-format or list-format (connectivity-style with 'origin' keys).
+        """
+        if isinstance(agent_def, list):
+            agent_def = NsNetworkUtils.list_def_to_dict(agent_def)
         normalized: Dict[str, dict] = {}
         for name, data in (agent_def or {}).items():
             d = dict(data or {})

--- a/nsflow/backend/utils/agentutils/ns_network_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_network_utils.py
@@ -14,7 +14,7 @@
 #
 # END COPYRIGHT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 
 @dataclass
@@ -108,11 +108,11 @@ class NsNetworkUtils:
         edges: List[Dict] = []
 
         # Extract agent network definition (accept dict or list/connectivity format)
-        raw_definition = state_dict.get("agent_network_definition", {})
+        raw_definition: Union[Dict[str, Any], List[Dict[str, Any]]] = state_dict.get("agent_network_definition", {})
         if isinstance(raw_definition, list):
             raw_definition = NsNetworkUtils.list_def_to_dict(raw_definition)
-        agent_definition = raw_definition
-        network_name = state_dict.get("agent_network_name", "unknown_network")
+        agent_definition: Dict[str, Any] = raw_definition
+        network_name: str = state_dict.get("agent_network_name", "unknown_network")
 
         if not agent_definition:
             return {
@@ -337,13 +337,13 @@ class NsNetworkUtils:
             include_keys = ["tools", "instructions", "description"]
         result: Dict[str, Any] = {}
         for entry in list_def or []:
-            name = entry.get("origin")
+            name: str = entry.get("origin")
             if not name or name.startswith("/"):
                 continue
             value: Dict[str, Any] = {}
             for key in include_keys:
-                if key in entry and entry[key]:
-                    value[key] = entry[key]
+                if key in entry and entry.get(key):
+                    value[key] = entry.get(key)
             result[name] = value
         return result
 

--- a/nsflow/frontend/src/utils/progressHelper.ts
+++ b/nsflow/frontend/src/utils/progressHelper.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 export type ProgressPayload = {
-  agent_network_definition?: Record<string, any>;
+  agent_network_definition?: Record<string, any> | Array<Record<string, any>>;
   agent_network_name?: string;
 };
 
@@ -43,12 +43,26 @@ export function asObjectText(text: string | object): Record<string, any> | undef
   return undefined;
 }
 
+/** Normalize an object that may use `connectivity_info` into a ProgressPayload. */
+function normalizePayloadObj(obj: Record<string, any>): ProgressPayload | undefined {
+  if ("agent_network_definition" in obj || "agent_network_name" in obj) {
+    return obj as ProgressPayload;
+  }
+  if ("connectivity_info" in obj && Array.isArray(obj.connectivity_info)) {
+    return {
+      agent_network_definition: obj.connectivity_info as Array<Record<string, any>>,
+      agent_network_name: obj.agent_network_name,
+    };
+  }
+  return undefined;
+}
+
 /**
  * Extract a { agent_network_definition, agent_network_name } payload from:
  * - a ChatContext Message-like object: { text: string|object }
  * - a raw object
  * - a code-fenced JSON string
- * Also accepts { message: {...} } wrapping.
+ * Also accepts { message: {...} } wrapping and connectivity_info list format.
  */
 export function extractProgressPayload(
   src?: { text: string | object } | string | object
@@ -60,14 +74,12 @@ export function extractProgressPayload(
     const obj = asObjectText((src as any).text);
     if (!obj) return undefined;
 
-    if ("agent_network_definition" in obj || "agent_network_name" in obj) {
-      return obj as ProgressPayload;
-    }
+    const direct = normalizePayloadObj(obj);
+    if (direct) return direct;
+
     if ("message" in obj && typeof (obj as any).message === "object") {
-      const inner = (obj as any).message;
-      if ("agent_network_definition" in inner || "agent_network_name" in inner) {
-        return inner as ProgressPayload;
-      }
+      const inner = normalizePayloadObj((obj as any).message);
+      if (inner) return inner;
     }
     return undefined;
   }
@@ -76,14 +88,12 @@ export function extractProgressPayload(
   const obj = typeof src === "string" ? asObjectText(src) : (src as any);
   if (!obj || typeof obj !== "object") return undefined;
 
-  if ("agent_network_definition" in obj || "agent_network_name" in obj) {
-    return obj as ProgressPayload;
-  }
+  const direct = normalizePayloadObj(obj);
+  if (direct) return direct;
+
   if ("message" in obj && typeof obj.message === "object") {
-    const inner = obj.message;
-    if ("agent_network_definition" in inner || "agent_network_name" in inner) {
-      return inner as ProgressPayload;
-    }
+    const inner = normalizePayloadObj(obj.message);
+    if (inner) return inner;
   }
   return undefined;
 }


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Issues:
`AND` progressively send progress message containing `agent_network_definition` so `nsflow` can show network getting built. However, if the format of report is set to `connectivity` instead of `internal`, `nsflow` fails to render the image.

Example of formats:

internal
```
{
    "a": {"instructions": "foo", "description": "bar", "tools": ["b", "/c"]},
    "b": {}
}
```

connectivity
```
[
 {'origin': 'a', 'tools': ['b', '/c'], 'display_as': 'llm_agent', 'instructions': 'foo', 'description': 'bar'},
 {'origin': 'b', 'tools': [], 'display_as': 'langchain_tool'},
 {'origin': '/c', 'tools': [], 'display_as': 'external_agent'}
]
```

Fixs:
- Added support for the connectivity-style list format (`[{"origin": "a", "tools": [...], ...}]`) as an alternative to the dict format for `agent_network_definition`, alongside the existing dict format.
- Backend: added `NsNetworkUtils.list_def_to_dict()` (following `ConnectivityDictionaryConverter` in neuro-san-studios rules — skip /-prefixed external agents, copy only allowed keys) and updated `partial_build_nodes_and_edges`, `normalize_agent_def`, and the `agent_flows.py` API endpoints to accept either format.
- Frontend: updated `extractProgressPayload` to also recognize progress messages that use `connectivity_info` (the list format's key) and normalize them into `agent_network_definition`, so the editor graph updates incrementally as each progress message arrives.

Fixes #188  

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
