### PR TITLE
Update default toolbox path after neuro-san-studio move

### DIFF
--- a/nsflow/backend/utils/editor/toolbox_service.py
+++ b/nsflow/backend/utils/editor/toolbox_service.py
@@ -33,7 +33,7 @@ class ToolboxService:
     def __init__(self, toolbox_info_file: Optional[str] = None):
         """Initialize toolbox service with optional toolbox info file path"""
         self.toolbox_info_file = toolbox_info_file or os.getenv(
-            "AGENT_TOOLBOX_INFO_FILE", "toolbox/toolbox_info.hocon"
+            "AGENT_TOOLBOX_INFO_FILE", "neuro_san_studio/toolbox/toolbox_info.hocon"
         )
 
     def get_available_tools(self) -> Union[Dict[str, Any], str]:


### PR DESCRIPTION
## Description

Update the default `AGENT_TOOLBOX_INFO_FILE` fallback path from `toolbox/toolbox_info.hocon` to `neuro_san_studio/toolbox/toolbox_info.hocon`.

The toolbox directory was moved in cognizant-ai-lab/neuro-san-studio#1012 (fixes cognizant-ai-lab/neuro-san-studio#946). Without this change, nsflow's `ToolboxService` defaults to a path that no longer exists.

## Impact

After neuro-san-studio merges PR #1012, the old `toolbox/` directory will no longer exist. This PR ensures nsflow's fallback default resolves correctly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

Link to Devin session: https://app.devin.ai/sessions/558a3461762c418cba12ecf7874bcc89
Requested by: @shrushtiimehta