### PR TITLE
Bump build-common to 1.0.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # cognizant-ai-lab/build-common 1.0.0 -- setup-python-env
+      # cognizant-ai-lab/build-common 1.0.5 -- setup-python-env
       - name: Set up Python and install build tools
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@550f3d7338e598c813b9580a238141328f7baaaa
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -33,10 +33,10 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
-      # cognizant-ai-lab/build-common 1.0.0 -- slack-notify
+      # cognizant-ai-lab/build-common 1.0.5 -- slack-notify
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@550f3d7338e598c813b9580a238141328f7baaaa
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # cognizant-ai-lab/build-common 1.0.5 -- setup-python-env
+      # cognizant-ai-lab/build-common 1.0.7 -- setup-python-env
       - name: Set up Python and install build tools
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@550f3d7338e598c813b9580a238141328f7baaaa
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -33,10 +33,10 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
-      # cognizant-ai-lab/build-common 1.0.5 -- slack-notify
+      # cognizant-ai-lab/build-common 1.0.7 -- slack-notify
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@550f3d7338e598c813b9580a238141328f7baaaa
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@3ead7f681f92044709ffc3a533f41c3f48230cfd
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ permissions:
 jobs:
   test:
     if: github.repository == 'cognizant-ai-lab/nsflow'
-    # 1.0.5
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
+    # 1.0.7
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
     with:
       python-version: '3.12'
       # No lint or test steps in original workflow

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ permissions:
 jobs:
   test:
     if: github.repository == 'cognizant-ai-lab/nsflow'
-    # 1.0.0
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
+    # 1.0.5
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
     with:
       python-version: '3.12'
       # No lint or test steps in original workflow


### PR DESCRIPTION
## Description

Bumps all `cognizant-ai-lab/build-common` action references from 1.0.0 (`455db3cc`) to 1.0.7 (`3ead7f68`). This keeps the repo on the latest released version of the shared CI infrastructure.

## Impact

CI workflows will use the latest build-common actions. No functional change to the application.

## Type of Change

- [x] Dependency upgrade

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation

---

Link to Devin session: https://app.devin.ai/sessions/5af2ecdfbaf04a0cb7bbf4cfa9f469c4
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/nsflow/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->