### PR TITLE
Fix LLM config rendering and stale agent details on network switch

### DIFF
--- a/nsflow/frontend/src/components/AgentNode.tsx
+++ b/nsflow/frontend/src/components/AgentNode.tsx
@@ -26,6 +26,22 @@ import { ExpandMore as ExpandMoreIcon, CheckBox as CheckBoxIcon,
   ContentCopy as CopyIcon } from "@mui/icons-material";
 import { useApiPort } from "../context/ApiPortContext";
 
+// Renders an llm_config dict inline. Arrays (e.g. `fallbacks`) become a comma-joined
+// "provider / model" list; other nested objects fall back to JSON. Prevents "[object Object]".
+const LlmConfigDisplay: React.FC<{ config: Record<string, unknown> }> = ({ config }) => {
+  const theme = useTheme();
+  const isObj = (v: unknown): v is Record<string, unknown> => v !== null && typeof v === "object";
+  const summarize = (f: Record<string, unknown>) =>
+    [f.class ?? f.provider, f.model_name ?? f.model].filter(Boolean).join(" / ") || JSON.stringify(f);
+  const renderValue = (v: unknown): string =>
+    Array.isArray(v) ? v.map((i) => (isObj(i) ? summarize(i) : String(i))).join(", ")
+    : isObj(v) ? JSON.stringify(v)
+    : String(v);
+
+  const text = Object.entries(config).map(([k, v]) => `${k}: ${renderValue(v)}`).join(", ");
+  return <Typography variant="caption" sx={{ color: theme.palette.text.secondary }}>{text}</Typography>;
+};
+
 // Define the structure of the `data` prop
 interface AgentNodeData {
   id: string;
@@ -335,17 +351,13 @@ const AgentNode: React.FC<AgentNodeProps> = ({ data }) => {
             <Box>
               {agentDetails.llm_config && (
                 <Box sx={{ mb: 1 }}>
-                  <Typography variant="caption" sx={{ 
-                    fontWeight: 600, 
-                    color: theme.palette.text.primary 
+                  <Typography variant="caption" sx={{
+                    fontWeight: 600,
+                    color: theme.palette.text.primary
                   }}>
                     LLM Config:{" "}
                   </Typography>
-                  <Typography variant="caption" sx={{ color: theme.palette.text.secondary }}>
-                    {Object.entries(agentDetails.llm_config)
-                      .map(([key, val]) => `${key}: ${val}`)
-                      .join(", ")}
-                  </Typography>
+                  <LlmConfigDisplay config={agentDetails.llm_config} />
                 </Box>
               )}
               {agentDetails.function && (


### PR DESCRIPTION
Issue #197 

## Summary
- Render `llm_config` arrays (e.g. `fallbacks`) as readable `provider / model` strings instead of `[object Object],[object Object]`

before:
<img width="1721" height="997" alt="Screenshot 2026-06-08 at 3 35 46 PM" src="https://github.com/user-attachments/assets/439846ca-a53a-42a5-b33d-6f1c33baa7a4" />

after:
<img width="1728" height="1000" alt="image" src="https://github.com/user-attachments/assets/4020fec9-7126-410d-8194-d10bebfa5668" />

