### PR TITLE
Discover MCP auth URLs from sly_data_schema, unioned with tool refs

### DIFF
--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -481,17 +481,26 @@ class NsWebsocketUtils:
 
     def get_network_mcp_urls(self):
         """
-        Collect the MCP server URLs referenced by this network's tools.
+        Collect the MCP server URLs this network expects auth headers for.
+
+        Two signals are combined:
+
+        1. The network's declared ``sly_data_schema`` - the MCP URLs listed under
+           ``tools[].function.sly_data_schema.properties.http_headers.properties``.
+           This is the explicit contract: a network that requires authenticated
+           MCP access advertises exactly which URLs need ``http_headers`` (see
+           neuro-san ``mcp_github.hocon``). We check this first.
+        2. The MCP URLs the tools actually reference (a dict tool's ``url`` or a
+           bare ``http(s)`` string in a ``tools`` list), so networks that don't
+           spell out a schema are still covered.
 
         Loads the network through ``AgentNetworkUtils.get_agent_network`` - the
-        same restore path the rest of the app uses - rather than parsing the
-        HOCON directly. That returns a plain, fully-resolved config dict (its
-        commondefs/defaults filter chain has run, so a ``url`` defined via a
-        commondef is already substituted) and transparently handles missing or
-        remote networks by raising.
+        same restore path the rest of the app uses - so the config is plain and
+        fully resolved (commondefs/defaults applied), and missing/remote networks
+        raise.
 
-        :return: A set of URLs, or None if the network is not readable locally
-                 (e.g. an invalid name or a network that lives on a remote
+        :return: The union of URLs from both signals, or None if the network is
+                 not readable locally (invalid name, or a network on a remote
                  neuro-san server), signalling the caller to fall back to all
                  connections.
         """
@@ -506,6 +515,10 @@ class NsWebsocketUtils:
 
         urls: set = set()
 
+        # 1) Schema-declared URLs (the explicit auth contract).
+        self._collect_schema_http_header_urls(config, urls)
+
+        # 2) URLs the tools reference, combined with the above.
         def _walk(node):
             if isinstance(node, dict):
                 # Dictionary-reference MCP tool: {"url": "https://.../mcp", ...}.
@@ -527,6 +540,33 @@ class NsWebsocketUtils:
 
         _walk(config.get("tools", []))
         return urls
+
+    @staticmethod
+    def _collect_schema_http_header_urls(config: Any, urls: set) -> None:
+        """
+        Add MCP URLs declared in any tool's ``sly_data_schema`` to ``urls``.
+
+        Reads ``tools[].function.sly_data_schema.properties.http_headers.properties``
+        - each key there is an MCP URL the network advertises it needs an
+        ``http_headers`` entry for. Every level is type-guarded so a partial or
+        unconventional schema is simply skipped rather than raising.
+        """
+        tools = config.get("tools") if isinstance(config, dict) else None
+        if not isinstance(tools, list):
+            return
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function")
+            schema = function.get("sly_data_schema") if isinstance(function, dict) else None
+            props = schema.get("properties") if isinstance(schema, dict) else None
+            http_headers = props.get("http_headers") if isinstance(props, dict) else None
+            header_props = http_headers.get("properties") if isinstance(http_headers, dict) else None
+            if not isinstance(header_props, dict):
+                continue
+            for url in header_props:
+                if isinstance(url, str) and url.startswith(("http://", "https://")):
+                    urls.add(url)
 
     @classmethod
     def get_latest_sly_data(cls, network_name: str, session_id: str = None) -> dict:

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -128,6 +128,52 @@ def test_get_urls_multiple(monkeypatch):
     }
 
 
+def _schema_tool(url):
+    """A front-man tool declaring an http_headers sly_data_schema for `url`."""
+    return {
+        "name": "front",
+        "function": {
+            "sly_data_schema": {
+                "type": "object",
+                "properties": {
+                    "http_headers": {
+                        "type": "object",
+                        "properties": {url: {"type": "object"}},
+                    }
+                },
+            }
+        },
+    }
+
+
+def test_get_urls_from_sly_data_schema(monkeypatch):
+    # The schema's http_headers properties keys are collected as MCP URLs.
+    config = {"tools": [_schema_tool("https://api.githubcopilot.com/mcp")]}
+    _patch_network(monkeypatch, config=config)
+    assert _utils().get_network_mcp_urls() == {"https://api.githubcopilot.com/mcp"}
+
+
+def test_get_urls_unions_schema_and_tool_refs(monkeypatch):
+    # Schema-declared URL + a separate tool url-reference are combined.
+    schema = _schema_tool("https://api.githubcopilot.com/mcp")
+    config = {"tools": [schema, {"name": "getter", "url": "https://other.example.com/mcp"}]}
+    _patch_network(monkeypatch, config=config)
+    assert _utils().get_network_mcp_urls() == {
+        "https://api.githubcopilot.com/mcp", "https://other.example.com/mcp",
+    }
+
+
+def test_get_urls_tolerates_partial_schema(monkeypatch):
+    # A malformed/partial sly_data_schema is skipped, not raised on.
+    config = {"tools": [
+        {"name": "a", "function": {"sly_data_schema": "not-a-dict"}},
+        {"name": "b", "function": {"sly_data_schema": {"properties": {"http_headers": 5}}}},
+        {"name": "c", "function": {}},
+    ]}
+    _patch_network(monkeypatch, config=config)
+    assert _utils().get_network_mcp_urls() == set()
+
+
 def test_get_urls_remote_or_missing_network_returns_none(monkeypatch):
     # get_agent_network raising (invalid/remote/unreadable) -> None (caller fallback).
     _patch_network(monkeypatch, raise_exc=FileNotFoundError("not local"))


### PR DESCRIPTION


<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description
`get_network_mcp_urls` now checks each tool's `function.sly_data_schema.properties.http_headers.properties` first - the network's explicit declaration of which MCP URLs need auth headers (e.g. mcp_github.hocon) - and unions it with the existing tool url/string-ref discovery. Injection therefore targets servers the network either declares in its schema or references in a tool. Schema parsing is fully type-guarded so a partial schema is skipped, not raised on. Adds tests.

Fixes #212 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
