### PR TITLE
Prompt users to connect required MCP servers, with schema-based URL discovery

### DIFF
--- a/nsflow/backend/api/v1/mcp_oauth_endpoints.py
+++ b/nsflow/backend/api/v1/mcp_oauth_endpoints.py
@@ -255,10 +255,10 @@ async def delete_connection(server_url: str = Query(...)):
 @router.get("/required/{network_name:path}")
 async def required_mcp_connections(network_name: str):
     """
-    Report the MCP servers a network requires (declared in its sly_data_schema or
-    referenced by its tools) that the user has not yet connected. The frontend
-    uses this to prompt the user to authenticate in the Connectors tab before
-    chatting with a network that needs MCP auth.
+    Report the MCP server URLs a network declares it needs auth headers for (via its
+    ``sly_data_schema`` http_headers properties) that the user has not yet connected.
+    The frontend uses this to prompt the user to authenticate in the Connectors tab
+    before chatting with a network that needs MCP auth.
     """
     # Imported here to avoid pulling the (heavy) websocket utils at module import.
     from nsflow.backend.utils.agentutils.ns_websocket_utils import NsWebsocketUtils

--- a/nsflow/backend/api/v1/mcp_oauth_endpoints.py
+++ b/nsflow/backend/api/v1/mcp_oauth_endpoints.py
@@ -250,3 +250,25 @@ async def delete_connection(server_url: str = Query(...)):
     removed = await FileTokenStorage.remove(normalized)
     # Echo back the normalized value actually used for deletion, not the raw query.
     return JSONResponse(content={"removed": removed, "server_url": normalized})
+
+
+@router.get("/required/{network_name:path}")
+async def required_mcp_connections(network_name: str):
+    """
+    Report the MCP servers a network requires (declared in its sly_data_schema or
+    referenced by its tools) that the user has not yet connected. The frontend
+    uses this to prompt the user to authenticate in the Connectors tab before
+    chatting with a network that needs MCP auth.
+    """
+    # Imported here to avoid pulling the (heavy) websocket utils at module import.
+    from nsflow.backend.utils.agentutils.ns_websocket_utils import NsWebsocketUtils
+
+    name = network_name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="network_name is required.")
+    # Network parse + token-store read are synchronous; offload off the loop.
+    missing = await asyncio.to_thread(NsWebsocketUtils.missing_mcp_connections, name)
+    # missing is None when the network HOCON is not locally readable (e.g. a
+    # remote network); we can't determine requirements, so report none missing
+    # rather than blocking the user.
+    return JSONResponse(content={"network": name, "missing": missing or []})

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -20,11 +20,12 @@ import logging
 import os
 import tempfile
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import WebSocket, WebSocketDisconnect
 from neuro_san.client.agent_session_factory import AgentSessionFactory
+from neuro_san.internals.run_context.utils.external_agent_parsing import ExternalAgentParsing
 
 from nsflow.backend.utils.agentutils.agent_log_processor import AgentLogProcessor
 from nsflow.backend.utils.agentutils.agent_network_utils import AgentNetworkUtils
@@ -480,8 +481,14 @@ class NsWebsocketUtils:
         return urlunsplit((scheme, netloc, path, parts.query, ""))
 
     def get_network_mcp_urls(self):
+        """Instance convenience for this connection's network. See
+        :meth:`collect_network_mcp_urls`."""
+        return self.collect_network_mcp_urls(self.agent_name)
+
+    @classmethod
+    def collect_network_mcp_urls(cls, agent_name: str):
         """
-        Collect the MCP server URLs this network expects auth headers for.
+        Collect the MCP server URLs a network expects auth headers for.
 
         Two signals are combined:
 
@@ -505,41 +512,71 @@ class NsWebsocketUtils:
                  connections.
         """
         try:
-            agent_network = AgentNetworkUtils().get_agent_network(self.agent_name)
+            agent_network = AgentNetworkUtils().get_agent_network(agent_name)
             if agent_network is None:
                 return None
             config = agent_network.get_config()
         except Exception as e:  # noqa: BLE001 - invalid/remote/unreadable network
-            logging.info("MCP auth: network '%s' not readable locally: %s", self.agent_name, e)
+            logging.info("MCP auth: network '%s' not readable locally: %s", agent_name, e)
             return None
 
         urls: set = set()
 
         # 1) Schema-declared URLs (the explicit auth contract).
-        self._collect_schema_http_header_urls(config, urls)
+        cls._collect_schema_http_header_urls(config, urls)
 
-        # 2) URLs the tools reference, combined with the above.
-        def _walk(node):
-            if isinstance(node, dict):
-                # Dictionary-reference MCP tool: {"url": "https://.../mcp", ...}.
-                url = node.get("url", None)
-                if isinstance(url, str) and url:
-                    urls.add(url)
-                for value in node.values():
-                    _walk(value)
-            elif isinstance(node, list):
-                for item in node:
-                    _walk(item)
-            elif isinstance(node, str):
-                # String-reference MCP tool: "tools": ["https://.../mcp"].
-                # Bare http(s) references are MCP server URLs (agent-name refs are
-                # not URLs). Safe even if a stray URL appears elsewhere, since the
-                # caller only injects for URLs that match a connected server.
-                if node.startswith(("http://", "https://")):
-                    urls.add(node)
-
-        _walk(config.get("tools", []))
+        # 2) URLs the tools actually reference, combined with the above.
+        cls._collect_tool_ref_urls(config.get("tools"), urls)
         return urls
+
+    @classmethod
+    def _collect_tool_ref_urls(cls, tools: Any, urls: set) -> None:
+        """
+        Add MCP server URLs referenced through a node's ``tools`` list.
+
+        Each entry in a ``tools`` list is either an agent-name string, an MCP
+        server URL string, or a dict MCP tool ``{"url": ...}`` that may itself
+        carry a nested ``tools`` list. We follow only the ``tools`` chain - never
+        sibling fields such as ``function`` or ``sly_data_schema`` (handled by
+        :meth:`_collect_schema_http_header_urls`) - so a schema's ``required``
+        entries or example URLs in descriptions are not mistaken for tool refs.
+
+        ``ExternalAgentParsing.is_mcp_tool`` is neuro-san's own classifier; it
+        distinguishes an MCP server URI from a neuro-san external-agent URL (both
+        are ``http(s)``), which a bare scheme check cannot.
+        """
+        if not isinstance(tools, list):
+            return
+        for entry in tools:
+            if isinstance(entry, str):
+                if ExternalAgentParsing.is_mcp_tool(entry):
+                    urls.add(entry)
+            elif isinstance(entry, dict):
+                url = entry.get("url")
+                if isinstance(url, str) and ExternalAgentParsing.is_mcp_tool(url):
+                    urls.add(url)
+                # A node or MCP tool entry can nest its own "tools" list.
+                cls._collect_tool_ref_urls(entry.get("tools"), urls)
+
+    @classmethod
+    def missing_mcp_connections(cls, agent_name: str) -> Optional[List[str]]:
+        """
+        MCP URLs the network requires (schema + tool refs) that have no usable
+        stored connection yet - i.e. the servers the user still needs to connect
+        in the Connectors tab before this network can authenticate.
+
+        Matching is normalized (trailing slash / host case / default port).
+
+        :return: A sorted list of unconnected required URLs (possibly empty), or
+                 None if the network is not locally readable (we can't determine
+                 requirements, so the caller should not block on it).
+        """
+        required = cls.collect_network_mcp_urls(agent_name)
+        if required is None:
+            return None
+        connections = FileTokenStorage.list_connections()
+        connected = {cls._normalize_mcp_url(conn["server_url"]) for conn in connections}
+        return sorted(url for url in required if cls._normalize_mcp_url(url) not in connected)
 
     @staticmethod
     def _collect_schema_http_header_urls(config: Any, urls: set) -> None:
@@ -550,6 +587,11 @@ class NsWebsocketUtils:
         - each key there is an MCP URL the network advertises it needs an
         ``http_headers`` entry for. Every level is type-guarded so a partial or
         unconventional schema is simply skipped rather than raising.
+
+        A URL key must be quoted in HOCON (it contains ``:`` and ``/``), and
+        neuro-san's restorer preserves those surrounding quotes in the parsed
+        key (e.g. ``'"https://api.githubcopilot.com/mcp"'``), so each key is
+        unquoted before the ``http(s)`` check.
         """
         tools = config.get("tools") if isinstance(config, dict) else None
         if not isinstance(tools, list):
@@ -565,7 +607,10 @@ class NsWebsocketUtils:
             if not isinstance(header_props, dict):
                 continue
             for url in header_props:
-                if isinstance(url, str) and url.startswith(("http://", "https://")):
+                if not isinstance(url, str):
+                    continue
+                url = url.strip().strip('"').strip("'").strip()
+                if url.startswith(("http://", "https://")):
                     urls.add(url)
 
     @classmethod

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -25,7 +25,6 @@ from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import WebSocket, WebSocketDisconnect
 from neuro_san.client.agent_session_factory import AgentSessionFactory
-from neuro_san.internals.run_context.utils.external_agent_parsing import ExternalAgentParsing
 
 from nsflow.backend.utils.agentutils.agent_log_processor import AgentLogProcessor
 from nsflow.backend.utils.agentutils.agent_network_utils import AgentNetworkUtils
@@ -258,11 +257,12 @@ class NsWebsocketUtils:
         Merge OAuth Bearer tokens for connected MCP servers into sly_data's
         ``http_headers`` so the agent network can authenticate to them.
 
-        Only servers this network actually references are injected (so a token is
-        never broadcast to an unrelated network). If the network's HOCON cannot be
-        read locally (e.g. it lives on a remote neuro-san server), we fall back to
-        injecting every connected server. Any header the user already supplied for
-        a given URL is left untouched.
+        Only servers this network declares it needs auth for (in its
+        ``sly_data_schema``) are injected, so a token is never broadcast to an
+        unrelated network or to an MCP server that needs no auth. If the network's
+        HOCON cannot be read locally (e.g. it lives on a remote neuro-san server),
+        we fall back to injecting every connected server. Any header the user
+        already supplied for a given URL is left untouched.
 
         :param sly_data: The sly_data dict to enrich in place.
         """
@@ -279,11 +279,11 @@ class NsWebsocketUtils:
             referenced = await asyncio.to_thread(self.get_network_mcp_urls)
             # Build (header_key, token_url) pairs. URLs are matched on a normalized
             # form so cosmetic differences (trailing slash, host case, default
-            # port) between the stored connection URL and the network's tool URL
-            # don't block injection. But each original string is kept for its real
-            # job: header_key is the URL the network references (what neuro-san's
-            # MCP adapter looks the header up by), and token_url is the stored
-            # connection URL (the key the token store is keyed on).
+            # port) between the stored connection URL and the network's declared
+            # URL don't block injection. But each original string is kept for its
+            # real job: header_key is the URL the network declares in its schema
+            # (what neuro-san's MCP adapter looks the header up by), and token_url
+            # is the stored connection URL (the key the token store is keyed on).
             if referenced is None:
                 # HOCON not locally readable: inject every connection, keyed by
                 # its own URL (we have no network-side form to match against).
@@ -490,26 +490,25 @@ class NsWebsocketUtils:
         """
         Collect the MCP server URLs a network expects auth headers for.
 
-        Two signals are combined:
-
-        1. The network's declared ``sly_data_schema`` - the MCP URLs listed under
-           ``tools[].function.sly_data_schema.properties.http_headers.properties``.
-           This is the explicit contract: a network that requires authenticated
-           MCP access advertises exactly which URLs need ``http_headers`` (see
-           neuro-san ``mcp_github.hocon``). We check this first.
-        2. The MCP URLs the tools actually reference (a dict tool's ``url`` or a
-           bare ``http(s)`` string in a ``tools`` list), so networks that don't
-           spell out a schema are still covered.
+        These come solely from the network's declared ``sly_data_schema`` - the
+        MCP URLs listed under
+        ``tools[].function.sly_data_schema.properties.http_headers.properties``.
+        This is the explicit contract: a network that requires authenticated MCP
+        access advertises exactly which URLs need ``http_headers`` (see neuro-san
+        ``mcp_github.hocon``). We deliberately do NOT also harvest every MCP URL
+        the tools reference, because a network may call MCP servers that need no
+        auth at all - those must not be flagged as a missing connection nor have
+        a token injected for them.
 
         Loads the network through ``AgentNetworkUtils.get_agent_network`` - the
         same restore path the rest of the app uses - so the config is plain and
         fully resolved (commondefs/defaults applied), and missing/remote networks
         raise.
 
-        :return: The union of URLs from both signals, or None if the network is
-                 not readable locally (invalid name, or a network on a remote
-                 neuro-san server), signalling the caller to fall back to all
-                 connections.
+        :return: The set of schema-declared URLs (possibly empty), or None if the
+                 network is not readable locally (invalid name, or a network on a
+                 remote neuro-san server), signalling the caller to fall back to
+                 all connections.
         """
         try:
             agent_network = AgentNetworkUtils().get_agent_network(agent_name)
@@ -520,50 +519,18 @@ class NsWebsocketUtils:
             logging.info("MCP auth: network '%s' not readable locally: %s", agent_name, e)
             return None
 
+        # Schema-declared URLs are the explicit auth contract.
         urls: set = set()
-
-        # 1) Schema-declared URLs (the explicit auth contract).
         cls._collect_schema_http_header_urls(config, urls)
-
-        # 2) URLs the tools actually reference, combined with the above.
-        cls._collect_tool_ref_urls(config.get("tools"), urls)
         return urls
-
-    @classmethod
-    def _collect_tool_ref_urls(cls, tools: Any, urls: set) -> None:
-        """
-        Add MCP server URLs referenced through a node's ``tools`` list.
-
-        Each entry in a ``tools`` list is either an agent-name string, an MCP
-        server URL string, or a dict MCP tool ``{"url": ...}`` that may itself
-        carry a nested ``tools`` list. We follow only the ``tools`` chain - never
-        sibling fields such as ``function`` or ``sly_data_schema`` (handled by
-        :meth:`_collect_schema_http_header_urls`) - so a schema's ``required``
-        entries or example URLs in descriptions are not mistaken for tool refs.
-
-        ``ExternalAgentParsing.is_mcp_tool`` is neuro-san's own classifier; it
-        distinguishes an MCP server URI from a neuro-san external-agent URL (both
-        are ``http(s)``), which a bare scheme check cannot.
-        """
-        if not isinstance(tools, list):
-            return
-        for entry in tools:
-            if isinstance(entry, str):
-                if ExternalAgentParsing.is_mcp_tool(entry):
-                    urls.add(entry)
-            elif isinstance(entry, dict):
-                url = entry.get("url")
-                if isinstance(url, str) and ExternalAgentParsing.is_mcp_tool(url):
-                    urls.add(url)
-                # A node or MCP tool entry can nest its own "tools" list.
-                cls._collect_tool_ref_urls(entry.get("tools"), urls)
 
     @classmethod
     def missing_mcp_connections(cls, agent_name: str) -> Optional[List[str]]:
         """
-        MCP URLs the network requires (schema + tool refs) that have no usable
-        stored connection yet - i.e. the servers the user still needs to connect
-        in the Connectors tab before this network can authenticate.
+        MCP URLs the network declares it needs auth for (in its ``sly_data_schema``)
+        that have no usable stored connection yet - i.e. the servers the user
+        still needs to connect in the Connectors tab before this network can
+        authenticate.
 
         Matching is normalized (trailing slash / host case / default port).
 

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -481,17 +481,26 @@ class NsWebsocketUtils:
 
     def get_network_mcp_urls(self):
         """
-        Collect the MCP server URLs referenced by this network's tools.
+        Collect the MCP server URLs this network expects auth headers for.
+
+        Two signals are combined:
+
+        1. The network's declared ``sly_data_schema`` - the MCP URLs listed under
+           ``tools[].function.sly_data_schema.properties.http_headers.properties``.
+           This is the explicit contract: a network that requires authenticated
+           MCP access advertises exactly which URLs need ``http_headers`` (see
+           neuro-san ``mcp_github.hocon``). We check this first.
+        2. The MCP URLs the tools actually reference (a dict tool's ``url`` or a
+           bare ``http(s)`` string in a ``tools`` list), so networks that don't
+           spell out a schema are still covered.
 
         Loads the network through ``AgentNetworkUtils.get_agent_network`` - the
-        same restore path the rest of the app uses - rather than parsing the
-        HOCON directly. That returns a plain, fully-resolved config dict (its
-        commondefs/defaults filter chain has run, so a ``url`` defined via a
-        commondef is already substituted) and transparently handles missing or
-        remote networks by raising.
+        same restore path the rest of the app uses - so the config is plain and
+        fully resolved (commondefs/defaults applied), and missing/remote networks
+        raise.
 
-        :return: A set of URLs, or None if the network is not readable locally
-                 (e.g. an invalid name or a network that lives on a remote
+        :return: The union of URLs from both signals, or None if the network is
+                 not readable locally (invalid name, or a network on a remote
                  neuro-san server), signalling the caller to fall back to all
                  connections.
         """
@@ -506,6 +515,10 @@ class NsWebsocketUtils:
 
         urls: set = set()
 
+        # 1) Schema-declared URLs (the explicit auth contract).
+        self._collect_schema_http_header_urls(config, urls)
+
+        # 2) URLs the tools reference, combined with the above.
         def _walk(node):
             if isinstance(node, dict):
                 # Dictionary-reference MCP tool: {"url": "https://.../mcp", ...}.
@@ -527,6 +540,33 @@ class NsWebsocketUtils:
 
         _walk(config.get("tools", []))
         return urls
+
+    @staticmethod
+    def _collect_schema_http_header_urls(config: Any, urls: set) -> None:
+        """
+        Add MCP URLs declared in any tool's ``sly_data_schema`` to ``urls``.
+
+        Reads ``tools[].function.sly_data_schema.properties.http_headers.properties``
+        - each key there is an MCP URL the network advertises it needs an
+        ``http_headers`` entry for. Every level is type-guarded so a partial or
+        unconventional schema is simply skipped rather than raising.
+        """
+        tools = config.get("tools") if isinstance(config, dict) else None
+        if not isinstance(tools, list):
+            return
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function")
+            schema = function.get("sly_data_schema") if isinstance(function, dict) else None
+            props = schema.get("properties") if isinstance(schema, dict) else None
+            http_headers = props.get("http_headers") if isinstance(props, dict) else None
+            header_props = http_headers.get("properties") if isinstance(http_headers, dict) else None
+            if not isinstance(header_props, dict):
+                continue
+            for url in header_props:
+                if isinstance(url, str) and url.startswith(("http://", "https://")):
+                    urls.add(url)
 
     @classmethod
     def get_latest_sly_data(cls, network_name: str, session_id: str = None) -> dict:

--- a/nsflow/frontend/src/components/mcp/McpAuthGate.tsx
+++ b/nsflow/frontend/src/components/mcp/McpAuthGate.tsx
@@ -1,0 +1,95 @@
+/*
+Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useApiPort } from '../../context/ApiPortContext';
+import { useChatContext } from '../../context/ChatContext';
+import { McpAuthRequiredDialog } from './McpAuthRequiredDialog';
+
+export interface McpAuthGateProps {
+  /**
+   * Called when the user acknowledges the dialog, to return them to a clean
+   * home view. The host should clear the selected/active network and the
+   * `?network=` URL param. If omitted, the gate falls back to a full reload of
+   * `/home` (which also resets that state, at the cost of reloading the app).
+   */
+  onGoHome?: () => void;
+}
+
+/**
+ * Renders nothing until a selected network requires MCP servers the user hasn't
+ * connected. When the active network changes, it asks the backend which required
+ * MCP URLs are unconnected; if any, it shows a dialog telling the user to connect
+ * them in the Connectors tab. Acknowledging returns to the nsflow home.
+ */
+const McpAuthGate: React.FC<McpAuthGateProps> = ({ onGoHome }) => {
+  const { apiUrl, isReady } = useApiPort();
+  const { activeNetwork } = useChatContext();
+
+  const [open, setOpen] = useState(false);
+  const [missing, setMissing] = useState<string[]>([]);
+  const [gatedNetwork, setGatedNetwork] = useState('');
+  // Avoid re-prompting for a network the user already acknowledged this session.
+  const acknowledgedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!activeNetwork || !isReady || !apiUrl) return;
+    if (acknowledgedRef.current.has(activeNetwork)) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${apiUrl}/api/v1/mcp/oauth/required/${encodeURIComponent(activeNetwork)}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        // Ignore a response for a network the user already moved away from.
+        if (cancelled || data?.network !== activeNetwork) return;
+        const missingUrls: string[] = Array.isArray(data?.missing) ? data.missing : [];
+        if (missingUrls.length > 0) {
+          setMissing(missingUrls);
+          setGatedNetwork(activeNetwork);
+          setOpen(true);
+        }
+      } catch (err) {
+        // Never block the user on a check failure.
+        console.error('Failed to check MCP auth requirements:', err);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [activeNetwork, isReady, apiUrl]);
+
+  const handleOk = () => {
+    // Remember so re-selecting this network (after connecting) doesn't loop.
+    if (gatedNetwork) acknowledgedRef.current.add(gatedNetwork);
+    setOpen(false);
+    // Return to the nsflow home (no network selected) where the Connectors tab
+    // is available so the user can authenticate the required server(s). Prefer a
+    // soft in-app reset (no full reload) so the proxied WebSocket isn't torn down.
+    if (onGoHome) {
+      onGoHome();
+    } else {
+      window.location.href = '/home';
+    }
+  };
+
+  if (!open) return null;
+  return (
+    <McpAuthRequiredDialog open={open} networkName={gatedNetwork} missing={missing} onOk={handleOk} />
+  );
+};
+
+export default McpAuthGate;

--- a/nsflow/frontend/src/components/mcp/McpAuthGate.tsx
+++ b/nsflow/frontend/src/components/mcp/McpAuthGate.tsx
@@ -19,23 +19,13 @@ import { useApiPort } from '../../context/ApiPortContext';
 import { useChatContext } from '../../context/ChatContext';
 import { McpAuthRequiredDialog } from './McpAuthRequiredDialog';
 
-export interface McpAuthGateProps {
-  /**
-   * Called when the user acknowledges the dialog, to return them to a clean
-   * home view. The host should clear the selected/active network and the
-   * `?network=` URL param. If omitted, the gate falls back to a full reload of
-   * `/home` (which also resets that state, at the cost of reloading the app).
-   */
-  onGoHome?: () => void;
-}
-
 /**
  * Renders nothing until a selected network requires MCP servers the user hasn't
  * connected. When the active network changes, it asks the backend which required
  * MCP URLs are unconnected; if any, it shows a dialog telling the user to connect
  * them in the Connectors tab. Acknowledging returns to the nsflow home.
  */
-const McpAuthGate: React.FC<McpAuthGateProps> = ({ onGoHome }) => {
+const McpAuthGate: React.FC = () => {
   const { apiUrl, isReady } = useApiPort();
   const { activeNetwork } = useChatContext();
 
@@ -77,13 +67,10 @@ const McpAuthGate: React.FC<McpAuthGateProps> = ({ onGoHome }) => {
     if (gatedNetwork) acknowledgedRef.current.add(gatedNetwork);
     setOpen(false);
     // Return to the nsflow home (no network selected) where the Connectors tab
-    // is available so the user can authenticate the required server(s). Prefer a
-    // soft in-app reset (no full reload) so the proxied WebSocket isn't torn down.
-    if (onGoHome) {
-      onGoHome();
-    } else {
-      window.location.href = '/home';
-    }
+    // is available so the user can authenticate the required server(s). A full
+    // navigation cleanly resets all network-dependent views and the acknowledged
+    // set, so re-selecting a still-unconnected network prompts again.
+    window.location.href = '/home';
   };
 
   if (!open) return null;

--- a/nsflow/frontend/src/components/mcp/McpAuthRequiredDialog.tsx
+++ b/nsflow/frontend/src/components/mcp/McpAuthRequiredDialog.tsx
@@ -1,0 +1,72 @@
+/*
+Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import {
+  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography, alpha,
+} from '@mui/material';
+import { useTheme } from '../../context/ThemeContext';
+
+export interface McpAuthRequiredDialogProps {
+  open: boolean;
+  networkName: string;
+  /** MCP server URLs this network needs but that aren't connected yet. */
+  missing: string[];
+  onOk: () => void;
+}
+
+/**
+ * Shown when a selected network requires authenticated MCP servers the user has
+ * not connected. Directs the user to the Connectors tab; OK returns them home.
+ */
+export const McpAuthRequiredDialog: React.FC<McpAuthRequiredDialogProps> = ({
+  open, networkName, missing, onOk,
+}) => {
+  const { theme } = useTheme();
+
+  return (
+    <Dialog open={open} onClose={onOk} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ color: theme.palette.text.primary, backgroundColor: theme.palette.background.paper }}>
+        Authentication required
+      </DialogTitle>
+      <DialogContent sx={{ backgroundColor: theme.palette.background.paper, color: theme.palette.text.primary }}>
+        <Typography variant="body2" sx={{ mb: 2, color: theme.palette.text.secondary }}>
+          {networkName ? <>The agent network <b>{networkName}</b> needs access to MCP server(s) you
+            haven't connected yet:</> : 'This agent network needs access to MCP server(s) you haven\'t connected yet:'}
+        </Typography>
+        <Box
+          sx={{
+            mb: 2, p: 1, borderRadius: 1, fontFamily: 'monospace', fontSize: '0.8rem',
+            wordBreak: 'break-all', backgroundColor: alpha(theme.palette.primary.main, 0.08),
+            border: `1px solid ${theme.palette.divider}`, color: theme.palette.text.primary,
+          }}
+        >
+          {missing.map((url) => (
+            <div key={url}>{url}</div>
+          ))}
+        </Box>
+        <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>
+          Please connect them in the <b>Connectors</b> tab first, then select this network again.
+        </Typography>
+      </DialogContent>
+      <DialogActions sx={{ backgroundColor: theme.palette.background.paper }}>
+        <Button onClick={onOk} sx={{ color: theme.palette.primary.main }}>OK</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default McpAuthRequiredDialog;

--- a/nsflow/frontend/src/pages/Home/Home.tsx
+++ b/nsflow/frontend/src/pages/Home/Home.tsx
@@ -64,18 +64,6 @@ const HomeContent: React.FC = () => {
     }
   }, [selectedNetwork]);
 
-  // Soft reset to a clean home view (no network selected) without reloading the
-  // app, so the proxied WebSocket isn't torn down. Used by the MCP auth gate.
-  const handleGoHome = () => {
-    setSelectedNetwork("");
-    setActiveNetwork("");
-    const currentUrl = new URL(window.location.href);
-    if (currentUrl.searchParams.has("network")) {
-      currentUrl.searchParams.delete("network");
-      window.history.replaceState({}, "", currentUrl.toString());
-    }
-  };
-
   return (
     <ReactFlowProvider>
       <ApiPortProvider>
@@ -83,7 +71,7 @@ const HomeContent: React.FC = () => {
           {/* NeuroSanProvider is used to manage the host and port for the NeuroSan server */}
           <div className="h-screen w-screen bg-gray-900 flex flex-col">
             {/* Prompts to connect required MCP servers before chatting; no layout footprint. */}
-            <McpAuthGate onGoHome={handleGoHome} />
+            <McpAuthGate />
             <div className="h-14">
               <Header selectedNetwork={selectedNetwork} isEditorPage={false}/>
             </div>

--- a/nsflow/frontend/src/pages/Home/Home.tsx
+++ b/nsflow/frontend/src/pages/Home/Home.tsx
@@ -22,6 +22,7 @@ import AgentFlow from "../../components/AgentFlow";
 import Sidebar from "../../components/Sidebar";
 // import ChatPanel from "./components/ChatPanel";
 import TabbedChatPanel from "../../components/TabbedChatPanel";
+import McpAuthGate from "../../components/mcp/McpAuthGate";
 import LogsPanel from "../../components/LogsPanel";
 import InfoPanel from "../../components/InfoPanel";
 import Header from "../../components/Header";
@@ -63,12 +64,26 @@ const HomeContent: React.FC = () => {
     }
   }, [selectedNetwork]);
 
+  // Soft reset to a clean home view (no network selected) without reloading the
+  // app, so the proxied WebSocket isn't torn down. Used by the MCP auth gate.
+  const handleGoHome = () => {
+    setSelectedNetwork("");
+    setActiveNetwork("");
+    const currentUrl = new URL(window.location.href);
+    if (currentUrl.searchParams.has("network")) {
+      currentUrl.searchParams.delete("network");
+      window.history.replaceState({}, "", currentUrl.toString());
+    }
+  };
+
   return (
     <ReactFlowProvider>
       <ApiPortProvider>
         <NeuroSanProvider>
           {/* NeuroSanProvider is used to manage the host and port for the NeuroSan server */}
           <div className="h-screen w-screen bg-gray-900 flex flex-col">
+            {/* Prompts to connect required MCP servers before chatting; no layout footprint. */}
+            <McpAuthGate onGoHome={handleGoHome} />
             <div className="h-14">
               <Header selectedNetwork={selectedNetwork} isEditorPage={false}/>
             </div>

--- a/tests/nsflow/test_mcp_oauth_endpoints.py
+++ b/tests/nsflow/test_mcp_oauth_endpoints.py
@@ -256,6 +256,29 @@ def test_delete_connection_blank_server_url(monkeypatch):
     remove.assert_not_awaited()
 
 
+def test_required_reports_missing(monkeypatch):
+    """/required surfaces the unconnected MCP URLs a network needs."""
+    import nsflow.backend.utils.agentutils.ns_websocket_utils as nw
+    monkeypatch.setattr(
+        nw.NsWebsocketUtils, "missing_mcp_connections",
+        MagicMock(return_value=["https://api.githubcopilot.com/mcp"]),
+    )
+    response = client.get("/api/v1/mcp/oauth/required/my_net")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["network"] == "my_net"
+    assert body["missing"] == ["https://api.githubcopilot.com/mcp"]
+
+
+def test_required_none_reports_empty(monkeypatch):
+    """A non-locally-readable network (None) reports nothing missing, not an error."""
+    import nsflow.backend.utils.agentutils.ns_websocket_utils as nw
+    monkeypatch.setattr(nw.NsWebsocketUtils, "missing_mcp_connections", MagicMock(return_value=None))
+    response = client.get("/api/v1/mcp/oauth/required/remote_net")
+    assert response.status_code == 200
+    assert response.json()["missing"] == []
+
+
 def test_redirect_uri(monkeypatch):
     """The redirect URI endpoint returns the manager's computed callback URL."""
     uri = "http://127.0.0.1:8005/api/v1/mcp/oauth/callback"

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -174,10 +174,71 @@ def test_get_urls_tolerates_partial_schema(monkeypatch):
     assert _utils().get_network_mcp_urls() == set()
 
 
+def test_get_urls_schema_key_with_preserved_hocon_quotes(monkeypatch):
+    # neuro-san's HOCON restorer preserves the surrounding quotes a URL key must
+    # carry, so the parsed key is '"https://.../mcp"'. It must still be collected.
+    config = {"tools": [_schema_tool('"https://api.githubcopilot.com/mcp"')]}
+    _patch_network(monkeypatch, config=config)
+    assert _utils().get_network_mcp_urls() == {"https://api.githubcopilot.com/mcp"}
+
+
+def test_get_urls_ignores_schema_required_array(monkeypatch):
+    # Tool-ref discovery follows only the `tools` chain - it must NOT harvest URLs
+    # from sibling schema fields such as `required` (a JSON-schema constraint, not
+    # a tool reference). Only the property key is the declared URL here.
+    tool = _schema_tool("https://declared.example.com/mcp")
+    tool["function"]["sly_data_schema"]["properties"]["http_headers"]["required"] = [
+        "https://only-in-required.example.com/mcp",
+    ]
+    _patch_network(monkeypatch, config={"tools": [tool]})
+    assert _utils().get_network_mcp_urls() == {"https://declared.example.com/mcp"}
+
+
+def test_get_urls_ignores_external_agent_url(monkeypatch):
+    # An http(s) tool ref that is a neuro-san external-agent URL (no "mcp" label)
+    # is not an MCP server and must not be collected.
+    config = {"tools": [{"name": "front", "tools": ["http://localhost:8080/api/v1/agent"]}]}
+    _patch_network(monkeypatch, config=config)
+    assert _utils().get_network_mcp_urls() == set()
+
+
 def test_get_urls_remote_or_missing_network_returns_none(monkeypatch):
     # get_agent_network raising (invalid/remote/unreadable) -> None (caller fallback).
     _patch_network(monkeypatch, raise_exc=FileNotFoundError("not local"))
     assert _utils().get_network_mcp_urls() is None
+
+
+# --------------------------- missing_mcp_connections --------------------------- #
+
+def _patch_connections(monkeypatch, urls):
+    monkeypatch.setattr(
+        nw.FileTokenStorage, "list_connections",
+        MagicMock(return_value=[{"server_url": u} for u in urls]),
+    )
+
+
+def test_missing_mcp_connections_reports_unconnected(monkeypatch):
+    # github required via schema + a connected tool url; only github is missing.
+    config = {"tools": [
+        _schema_tool("https://api.githubcopilot.com/mcp"),
+        {"name": "x", "url": "https://connected.example.com/mcp"},
+    ]}
+    _patch_network(monkeypatch, config=config)
+    _patch_connections(monkeypatch, ["https://connected.example.com/mcp"])
+    assert nw.NsWebsocketUtils.missing_mcp_connections("net") == ["https://api.githubcopilot.com/mcp"]
+
+
+def test_missing_mcp_connections_matches_normalized(monkeypatch):
+    # A connection stored with a trailing slash still satisfies the requirement.
+    config = {"tools": [_schema_tool("https://api.githubcopilot.com/mcp")]}
+    _patch_network(monkeypatch, config=config)
+    _patch_connections(monkeypatch, ["https://api.githubcopilot.com/mcp/"])
+    assert nw.NsWebsocketUtils.missing_mcp_connections("net") == []
+
+
+def test_missing_mcp_connections_none_when_network_unreadable(monkeypatch):
+    _patch_network(monkeypatch, raise_exc=FileNotFoundError("remote"))
+    assert nw.NsWebsocketUtils.missing_mcp_connections("net") is None
 
 
 def test_get_urls_network_none_returns_none(monkeypatch):

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -97,35 +97,16 @@ def _patch_network(monkeypatch, *, config=None, raise_exc=None, network_none=Fal
     monkeypatch.setattr(nw, "AgentNetworkUtils", fake_anu)
 
 
-def test_get_urls_dict_reference_tool(monkeypatch):
-    config = {"tools": [{"name": "front", "url": "https://api.example.com/mcp"}]}
-    _patch_network(monkeypatch, config=config)
-    assert _utils().get_network_mcp_urls() == {"https://api.example.com/mcp"}
-
-
-def test_get_urls_string_reference_tool(monkeypatch):
-    # A bare http(s) string in a tools list is an MCP server reference.
-    config = {"tools": [{"name": "front", "tools": ["https://api.example.com/mcp", "helper"]}]}
-    _patch_network(monkeypatch, config=config)
-    assert _utils().get_network_mcp_urls() == {"https://api.example.com/mcp"}
-
-
-def test_get_urls_ignores_agent_name_refs(monkeypatch):
-    # Non-URL tool references (agent names) are not collected.
-    config = {"tools": [{"name": "front", "tools": ["helper_a", "helper_b"]}]}
-    _patch_network(monkeypatch, config=config)
-    assert _utils().get_network_mcp_urls() == set()
-
-
-def test_get_urls_multiple(monkeypatch):
+def test_get_urls_ignores_tool_refs_without_schema(monkeypatch):
+    # MCP servers a network merely references (dict `url` or a bare string in a
+    # `tools` list) but does NOT declare in its sly_data_schema need no auth, so
+    # they are not collected - only the schema is the auth contract.
     config = {"tools": [
-        {"name": "a", "url": "https://one.example.com/mcp"},
-        {"name": "b", "tools": ["https://two.example.com/mcp"]},
+        {"name": "a", "url": "https://no-auth.example.com/mcp"},
+        {"name": "b", "tools": ["https://also-no-auth.example.com/mcp", "helper"]},
     ]}
     _patch_network(monkeypatch, config=config)
-    assert _utils().get_network_mcp_urls() == {
-        "https://one.example.com/mcp", "https://two.example.com/mcp",
-    }
+    assert _utils().get_network_mcp_urls() == set()
 
 
 def _schema_tool(url):
@@ -153,14 +134,13 @@ def test_get_urls_from_sly_data_schema(monkeypatch):
     assert _utils().get_network_mcp_urls() == {"https://api.githubcopilot.com/mcp"}
 
 
-def test_get_urls_unions_schema_and_tool_refs(monkeypatch):
-    # Schema-declared URL + a separate tool url-reference are combined.
+def test_get_urls_only_from_schema_not_tool_refs(monkeypatch):
+    # Only the schema-declared URL is collected; a separate MCP url merely
+    # referenced by a tool (and absent from the schema) is not.
     schema = _schema_tool("https://api.githubcopilot.com/mcp")
     config = {"tools": [schema, {"name": "getter", "url": "https://other.example.com/mcp"}]}
     _patch_network(monkeypatch, config=config)
-    assert _utils().get_network_mcp_urls() == {
-        "https://api.githubcopilot.com/mcp", "https://other.example.com/mcp",
-    }
+    assert _utils().get_network_mcp_urls() == {"https://api.githubcopilot.com/mcp"}
 
 
 def test_get_urls_tolerates_partial_schema(monkeypatch):
@@ -183,23 +163,14 @@ def test_get_urls_schema_key_with_preserved_hocon_quotes(monkeypatch):
 
 
 def test_get_urls_ignores_schema_required_array(monkeypatch):
-    # Tool-ref discovery follows only the `tools` chain - it must NOT harvest URLs
-    # from sibling schema fields such as `required` (a JSON-schema constraint, not
-    # a tool reference). Only the property key is the declared URL here.
+    # Discovery collects the http_headers property keys, NOT URLs that only
+    # appear in a sibling JSON-schema `required` array.
     tool = _schema_tool("https://declared.example.com/mcp")
     tool["function"]["sly_data_schema"]["properties"]["http_headers"]["required"] = [
         "https://only-in-required.example.com/mcp",
     ]
     _patch_network(monkeypatch, config={"tools": [tool]})
     assert _utils().get_network_mcp_urls() == {"https://declared.example.com/mcp"}
-
-
-def test_get_urls_ignores_external_agent_url(monkeypatch):
-    # An http(s) tool ref that is a neuro-san external-agent URL (no "mcp" label)
-    # is not an MCP server and must not be collected.
-    config = {"tools": [{"name": "front", "tools": ["http://localhost:8080/api/v1/agent"]}]}
-    _patch_network(monkeypatch, config=config)
-    assert _utils().get_network_mcp_urls() == set()
 
 
 def test_get_urls_remote_or_missing_network_returns_none(monkeypatch):

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -128,6 +128,52 @@ def test_get_urls_multiple(monkeypatch):
     }
 
 
+def _schema_tool(url):
+    """A front-man tool declaring an http_headers sly_data_schema for `url`."""
+    return {
+        "name": "front",
+        "function": {
+            "sly_data_schema": {
+                "type": "object",
+                "properties": {
+                    "http_headers": {
+                        "type": "object",
+                        "properties": {url: {"type": "object"}},
+                    }
+                },
+            }
+        },
+    }
+
+
+def test_get_urls_from_sly_data_schema(monkeypatch):
+    # The schema's http_headers properties keys are collected as MCP URLs.
+    config = {"tools": [_schema_tool("https://api.githubcopilot.com/mcp")]}
+    _patch_network(monkeypatch, config=config)
+    assert _utils().get_network_mcp_urls() == {"https://api.githubcopilot.com/mcp"}
+
+
+def test_get_urls_unions_schema_and_tool_refs(monkeypatch):
+    # Schema-declared URL + a separate tool url-reference are combined.
+    schema = _schema_tool("https://api.githubcopilot.com/mcp")
+    config = {"tools": [schema, {"name": "getter", "url": "https://other.example.com/mcp"}]}
+    _patch_network(monkeypatch, config=config)
+    assert _utils().get_network_mcp_urls() == {
+        "https://api.githubcopilot.com/mcp", "https://other.example.com/mcp",
+    }
+
+
+def test_get_urls_tolerates_partial_schema(monkeypatch):
+    # A malformed/partial sly_data_schema is skipped, not raised on.
+    config = {"tools": [
+        {"name": "a", "function": {"sly_data_schema": "not-a-dict"}},
+        {"name": "b", "function": {"sly_data_schema": {"properties": {"http_headers": 5}}}},
+        {"name": "c", "function": {}},
+    ]}
+    _patch_network(monkeypatch, config=config)
+    assert _utils().get_network_mcp_urls() == set()
+
+
 def test_get_urls_remote_or_missing_network_returns_none(monkeypatch):
     # get_agent_network raising (invalid/remote/unreadable) -> None (caller fallback).
     _patch_network(monkeypatch, raise_exc=FileNotFoundError("not local"))

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -189,12 +189,10 @@ def _patch_connections(monkeypatch, urls):
 
 
 def test_missing_mcp_connections_reports_unconnected(monkeypatch):
-    # github required via schema + a connected tool url; only github is missing.
-    config = {"tools": [
-        _schema_tool("https://api.githubcopilot.com/mcp"),
-        {"name": "x", "url": "https://connected.example.com/mcp"},
-    ]}
-    _patch_network(monkeypatch, config=config)
+    # One required MCP URL is connected and one is not; only the unconnected one is reported.
+    tool = _schema_tool("https://api.githubcopilot.com/mcp")
+    tool["function"]["sly_data_schema"]["properties"]["http_headers"]["properties"]["https://connected.example.com/mcp"] = {"type": "object"}
+    _patch_network(monkeypatch, config={"tools": [tool]})
     _patch_connections(monkeypatch, ["https://connected.example.com/mcp"])
     assert nw.NsWebsocketUtils.missing_mcp_connections("net") == ["https://api.githubcopilot.com/mcp"]
 


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Agent networks that call authenticated MCP tools declare which servers they
need via `sly_data.http_headers[<mcp_url>]`. This PR (1) discovers those
required MCP URLs from a network's `sly_data_schema`, and (2) prompts the user
to connect any that aren't yet authenticated in the Connectors tab before
chatting — then returns them to the home view.

Supersedes #213 (its commit is included here).

## Changes

**MCP URL discovery** (`ns_websocket_utils.py`)
- `collect_network_mcp_urls` returns the MCP URLs a network declares it needs
  auth for, taken solely from
  `tools[].function.sly_data_schema.properties.http_headers.properties` — the
  explicit auth contract (see neuro-san `mcp_github.hocon`).
- It deliberately does NOT harvest every MCP URL the tools reference: a network
  may call MCP servers that need no auth, and those must not be flagged as a
  missing connection nor have a token injected for them.
- Unquote schema header keys: a URL key must be quoted in HOCON, and neuro-san's
  restorer preserves those quotes in the parsed key (`'"https://.../mcp"'`), so
  without unquoting the schema signal never matched.

**Auth-required gate**
- New `GET /api/v1/mcp/oauth/required/{network}` endpoint, backed by
  `missing_mcp_connections()`, returning the required-but-unconnected MCP URLs.
- New `McpAuthGate` + `McpAuthRequiredDialog` components, wired into `Home`.
  When a selected network needs unconnected MCP servers, a dialog directs the
  user to the Connectors tab.
- Acknowledging the dialog navigates to `/home`, which cleanly resets all
  network-dependent views and the per-session acknowledged-set, so re-selecting
  a still-unconnected network prompts again.

## Testing
- Added/updated tests: schema-only discovery (ignores tool refs that lack a
  schema entry; collects only schema keys), quoted schema keys, `required`-array
  ignored, partial-schema tolerance, and the `/required` endpoint.
- All MCP backend tests pass (`test_ns_websocket_mcp.py`,
  `test_mcp_oauth_endpoints.py`); frontend `tsc` clean.

## Notes
- Tokens remain backend-only; the gate only reports *which* URLs are missing,
  never any credential.
- A network that needs auth but doesn't declare it in `sly_data_schema` won't be
  auto-detected — the schema is the single source of truth.

Fixes #212 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
