### PR TITLE
Fix Editor path blocking Cruse Launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ draft_states/
 mcp/
 skills/
 middleware/
+config/
 
 # The unanchored "mcp/" rule above matches any directory named "mcp" at any
 # depth. Re-include the MCP OAuth source directories, which are real source code.

--- a/nsflow/backend/api/v1/app_configs.py
+++ b/nsflow/backend/api/v1/app_configs.py
@@ -48,6 +48,14 @@ def get_runtime_config():
             "VITE_WS_PROTOCOL": os.getenv("VITE_WS_PROTOCOL", "ws"),
             "VITE_USE_SPEECH": os.getenv("VITE_USE_SPEECH", True),
             "NSFLOW_WAND_NAME": os.getenv("NSFLOW_WAND_NAME", "agent_network_designer"),
+            # Subdirectory under registries/ where the Agent Network Designer persists
+            # generated networks. Mirrors neuro-san-studio's AGENT_NETWORK_DESIGNER_SUBDIRECTORY
+            # so the Editor can build the served agent path (e.g. "generated/<name>") for launch.
+            "AGENT_NETWORK_DESIGNER_SUBDIRECTORY": os.getenv("AGENT_NETWORK_DESIGNER_SUBDIRECTORY", "generated"),
+            # Seconds the neuro-san server takes to reload its registries. The Editor uses this
+            # to delay enabling the launch button after generation finishes, so the freshly
+            # generated network has time to register and become discoverable via /api/v1/list.
+            "AGENT_MANIFEST_UPDATE_PERIOD_SECONDS": os.getenv("AGENT_MANIFEST_UPDATE_PERIOD_SECONDS", "2"),
             "NSFLOW_CRUSE_WIDGET_AGENT_NAME": os.getenv("NSFLOW_CRUSE_WIDGET_AGENT_NAME", "experimental/cruse_widget_agent"),
             "NSFLOW_CRUSE_THEME_AGENT_NAME": os.getenv("NSFLOW_CRUSE_THEME_AGENT_NAME", "experimental/cruse_theme_agent"),
             # NEW: feature flags (booleans)

--- a/nsflow/frontend/src/components/EditorAgentFlow.tsx
+++ b/nsflow/frontend/src/components/EditorAgentFlow.tsx
@@ -33,7 +33,7 @@ import {
   Home as HomeIcon
 } from "@mui/icons-material";
 import { useChatContext } from "../context/ChatContext";
-import { getFeatureFlags } from "../utils/config";
+import { getFeatureFlags, toServedNetworkPath, getManifestUpdatePeriodMs } from "../utils/config";
 import {extractProgressPayload } from "../utils/progressHelper";
 
 export const nodeTypes = Object.freeze({
@@ -88,8 +88,35 @@ const EditorAgentFlow = ({
   const launchAnchorRef = useRef<HTMLDivElement>(null);
 
   // We'll read the latest agent_network_definition from logs in view-mode
-  const { getLastProgressMessage, getLastSlyDataMessage, targetNetwork, 
-    progressTick, slyDataTick, lastProgressAt, lastSlyDataAt } = useChatContext();
+  const { getLastProgressMessage, getLastSlyDataMessage, targetNetwork,
+    progressTick, slyDataTick, lastProgressAt, lastSlyDataAt, waitingForAgent } = useChatContext();
+
+  // The launch button becomes visible as soon as the designer reports a network name,
+  // but a freshly-generated network isn't actually finished/registered until the agent
+  // completes its turn. Disable launch while we're still waiting on the agent so users
+  // can't launch a half-built network. `waitingForAgent` is true from message-send until
+  // the final agent chat message arrives (or the chat socket closes); it's the same
+  // signal the "Load Existing" dropdown already gates on. It is never true for loaded
+  // existing networks, so those stay launchable immediately.
+  //
+  // Even after the agent finishes, the neuro-san server needs a couple of seconds to
+  // reload its registries before the new network is discoverable via /api/v1/list. We
+  // hold the button disabled for one manifest-reload period after generation completes
+  // (the `waitingForAgent` true->false transition) so launching can't race that refresh.
+  const [registryReloadPending, setRegistryReloadPending] = useState(false);
+  const prevWaitingRef = useRef(waitingForAgent);
+  useEffect(() => {
+    const wasWaiting = prevWaitingRef.current;
+    prevWaitingRef.current = waitingForAgent;
+    // A generation cycle just finished: start the registry-reload grace period.
+    if (wasWaiting && !waitingForAgent) {
+      setRegistryReloadPending(true);
+      const timer = setTimeout(() => setRegistryReloadPending(false), getManifestUpdatePeriodMs());
+      return () => clearTimeout(timer);
+    }
+  }, [waitingForAgent]);
+
+  const launchDisabled = waitingForAgent || registryReloadPending;
 
   // latest definition for view-mode
   const getViewDefinition = useCallback(() => {
@@ -394,7 +421,11 @@ const EditorAgentFlow = ({
   const handleLaunchCruse = useCallback(() => {
     const agentNetworkName = getLatestAgentNetworkName();
     if (agentNetworkName) {
-      const cruseUrl = `${window.location.origin}/cruse?network=${encodeURIComponent(agentNetworkName)}`;
+      // The designer reports the raw name (e.g. "foo"); neuro-san serves generated
+      // networks under the configured subdirectory (e.g. "generated/foo"), which is
+      // what Cruse matches against /api/v1/list. Map to the served path before launch.
+      const servedName = toServedNetworkPath(agentNetworkName);
+      const cruseUrl = `${window.location.origin}/cruse?network=${encodeURIComponent(servedName)}`;
       window.open(cruseUrl, '_blank');
     }
   }, [getLatestAgentNetworkName]);
@@ -403,7 +434,8 @@ const EditorAgentFlow = ({
   const handleLaunchHome = useCallback(() => {
     const agentNetworkName = getLatestAgentNetworkName();
     if (agentNetworkName) {
-      const homeUrl = `${window.location.origin}/home?network=${encodeURIComponent(agentNetworkName)}`;
+      const servedName = toServedNetworkPath(agentNetworkName);
+      const homeUrl = `${window.location.origin}/home?network=${encodeURIComponent(servedName)}`;
       window.open(homeUrl, '_blank');
     }
     setLaunchMenuOpen(false);
@@ -741,39 +773,48 @@ const EditorAgentFlow = ({
                 }}
               >
                 {/* Main Launch Button - Cruse */}
-                <Tooltip title={`Launch ${lastSeenNameRef.current} in Cruse`}>
-                  <Button
-                    onClick={handleLaunchCruse}
-                    startIcon={<LaunchIcon />}
-                    sx={{
-                      minWidth: 100,
-                      px: 2.5,
-                      textTransform: 'none',
-                      borderTopLeftRadius: '28px',
-                      borderBottomLeftRadius: '28px',
-                      backgroundColor: theme.palette.primary.main,
-                    }}
-                  >
-                    Launch
-                  </Button>
+                <Tooltip title={launchDisabled
+                  ? "Waiting for the agent network to finish generating..."
+                  : `Launch ${selectedNetwork || lastSeenNameRef.current} in Cruse`}>
+                  {/* span wrapper so the tooltip still shows while the button is disabled */}
+                  <span>
+                    <Button
+                      onClick={handleLaunchCruse}
+                      disabled={launchDisabled}
+                      startIcon={<LaunchIcon />}
+                      sx={{
+                        minWidth: 100,
+                        px: 2.5,
+                        textTransform: 'none',
+                        borderTopLeftRadius: '28px',
+                        borderBottomLeftRadius: '28px',
+                        backgroundColor: theme.palette.primary.main,
+                      }}
+                    >
+                      Launch
+                    </Button>
+                  </span>
                 </Tooltip>
 
                 {/* Dropdown Arrow */}
                 <Tooltip title="More launch options">
-                  <Button
-                    size="small"
-                    onClick={handleToggleLaunchMenu}
-                    sx={{
-                      px: 0.5,
-                      minWidth: 32,
-                      borderTopRightRadius: '28px',
-                      borderBottomRightRadius: '28px',
-                      borderLeft: `1px solid ${alpha(theme.palette.common.white, 0.3)}`,
-                      backgroundColor: theme.palette.primary.main,
-                    }}
-                  >
-                    <ArrowDropDownIcon />
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      onClick={handleToggleLaunchMenu}
+                      disabled={launchDisabled}
+                      sx={{
+                        px: 0.5,
+                        minWidth: 32,
+                        borderTopRightRadius: '28px',
+                        borderBottomRightRadius: '28px',
+                        borderLeft: `1px solid ${alpha(theme.palette.common.white, 0.3)}`,
+                        backgroundColor: theme.palette.primary.main,
+                      }}
+                    >
+                      <ArrowDropDownIcon />
+                    </Button>
+                  </span>
                 </Tooltip>
               </ButtonGroup>
 
@@ -831,29 +872,35 @@ const EditorAgentFlow = ({
             </>
           ) : (
             // Cruse disabled: Show simple Launch to Home button
-            <Tooltip title={`Launch ${lastSeenNameRef.current} in Home`}>
-              <Button
-                variant="contained"
-                color="primary"
-                startIcon={<LaunchIcon />}
-                onClick={handleLaunchHome}
-                sx={{
-                  height: 56,
-                  minWidth: 100,
-                  px: 2.5,
-                  textTransform: 'none',
-                  borderRadius: '28px',
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
-                  backgroundColor: theme.palette.primary.main,
-                  '&:hover': {
-                    backgroundColor: theme.palette.primary.dark,
-                    transform: 'scale(1.02)',
-                    transition: 'all 0.2s ease-in-out'
-                  }
-                }}
-              >
-                Launch
-              </Button>
+            <Tooltip title={launchDisabled
+              ? "Waiting for the agent network to finish generating..."
+              : `Launch ${selectedNetwork || lastSeenNameRef.current} in Home`}>
+              {/* span wrapper so the tooltip still shows while the button is disabled */}
+              <span>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  startIcon={<LaunchIcon />}
+                  onClick={handleLaunchHome}
+                  disabled={launchDisabled}
+                  sx={{
+                    height: 56,
+                    minWidth: 100,
+                    px: 2.5,
+                    textTransform: 'none',
+                    borderRadius: '28px',
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+                    backgroundColor: theme.palette.primary.main,
+                    '&:hover': {
+                      backgroundColor: theme.palette.primary.dark,
+                      transform: 'scale(1.02)',
+                      transition: 'all 0.2s ease-in-out'
+                    }
+                  }}
+                >
+                  Launch
+                </Button>
+              </span>
             </Tooltip>
           )}
         </Box>

--- a/nsflow/frontend/src/components/EditorSidebar.tsx
+++ b/nsflow/frontend/src/components/EditorSidebar.tsx
@@ -23,7 +23,7 @@ import { useApiPort } from "../context/ApiPortContext";
 import { useChatContext } from "../context/ChatContext";
 import { useChatControls } from "../hooks/useChatControls";
 import { useNeuroSan } from "../context/NeuroSanContext";
-import { getFeatureFlags } from "../utils/config";
+import { getFeatureFlags, toServedNetworkPath } from "../utils/config";
 import {extractProgressPayload } from "../utils/progressHelper";
 
 
@@ -296,7 +296,13 @@ const EditorSidebar = ({
       ];
       designPlaceholderRef.current = placeholders[Math.floor(Math.random() * placeholders.length)];
     }
-    const nameFromPayload = payload.agent_network_name || lastSeenNameRef.current || designPlaceholderRef.current!;
+    // For a real generated-network name, show the path it is actually served under
+    // (e.g. "generated/foo") so the sidebar, the "Editing:" card, and the launch URL all
+    // agree and match /api/v1/list. The placeholder and the last-seen fallback are left
+    // untouched (the placeholder must never be prefixed).
+    const nameFromPayload = payload.agent_network_name
+      ? toServedNetworkPath(payload.agent_network_name)
+      : (lastSeenNameRef.current || designPlaceholderRef.current!);
 
     // Ensure dropdown has exactly one option (view-only)
     const singleOption: NetworkOption = {

--- a/nsflow/frontend/src/utils/config.ts
+++ b/nsflow/frontend/src/utils/config.ts
@@ -26,6 +26,10 @@ type AppRuntimeConfig = {
   NSFLOW_WAND_NAME: string;
   NSFLOW_CRUSE_WIDGET_AGENT_NAME: string;
   NSFLOW_CRUSE_THEME_AGENT_NAME: string;
+  // Subdirectory prefix under which AND-generated networks are served (e.g. "generated").
+  AGENT_NETWORK_DESIGNER_SUBDIRECTORY?: string;
+  // Seconds the neuro-san server takes to reload its registries (string from backend).
+  AGENT_MANIFEST_UPDATE_PERIOD_SECONDS?: string;
   // NEW flags (booleans from backend)
   NSFLOW_PLUGIN_CRUSE: boolean;
   NSFLOW_PLUGIN_WAND: boolean;
@@ -80,6 +84,51 @@ export function getWandName() {
   return {
     wandName: c.NSFLOW_WAND_NAME,
   };
+}
+
+// Subdirectory prefix under which the Agent Network Designer's generated networks
+// are served by neuro-san. Defaults to "generated" when the backend doesn't supply it.
+export function getGeneratedSubdir(): string {
+  try {
+    const raw = getAppConfig().AGENT_NETWORK_DESIGNER_SUBDIRECTORY;
+    const trimmed = (raw ?? "").trim().replace(/^\/+|\/+$/g, "");
+    return trimmed || "generated";
+  } catch {
+    // Config not loaded yet; fall back to the default prefix.
+    return "generated";
+  }
+}
+
+// How long (in milliseconds) the neuro-san server needs to reload its registries before a
+// freshly generated network shows up in /api/v1/list. The Editor uses this to delay enabling
+// the launch button after generation finishes. Defaults to 2000ms when unset or unparseable.
+export function getManifestUpdatePeriodMs(): number {
+  try {
+    const raw = getAppConfig().AGENT_MANIFEST_UPDATE_PERIOD_SECONDS;
+    const seconds = Number((raw ?? "").trim());
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  } catch {
+    // Config not loaded yet; fall through to default.
+  }
+  return 2000;
+}
+
+// Map an Agent Network Designer (AND) generated network's raw name to the path it is
+// actually *served* under by neuro-san (e.g. "foo" -> "generated/foo"), so launching it
+// matches what /api/v1/list returns.
+//
+// IMPORTANT: only call this with a name that came from the AND design payload; it is
+// generated-by-construction. Do NOT use the presence/absence of "/" to decide whether a
+// network is "generated": regular networks can live in the registries root with no "/",
+// and some served names legitimately contain "/". The only guard here is idempotency:
+// a name already starting with "<subdir>/" is returned unchanged so it can't be
+// double-prefixed (e.g. "generated/generated/foo").
+export function toServedNetworkPath(rawName: string): string {
+  const name = (rawName ?? "").trim();
+  if (!name) return name;
+  const subdir = getGeneratedSubdir();
+  if (name.startsWith(`${subdir}/`)) return name;
+  return `${subdir}/${name}`;
 }
 
 export function getCruseAgentNames() {


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description
- Resolve the bare name to its served path (<subdir>/<name>) when building the launch URL, and use that same path for the Editor sidebar and the "Editing:" card. The subdirectory comes from `AGENT_NETWORK_DESIGNER_SUBDIRECTORY` (defaults to `generated`).
- Scope is by code path, not name shape: only names from the designer payload are prefixed, with an idempotency guard so already-served names aren't double-prefixed. Regular and root-level networks are untouched.
- Gate the launch button: disabled while the agent is still generating, then held for one `AGENT_MANIFEST_UPDATE_PERIOD_SECONDS` (default 2) so the server has time to register the network before launch. Loaded existing networks stay launchable immediately.

Fixes #201, #211

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
