### PR TITLE
Bump build-common to 1.0.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # cognizant-ai-lab/build-common 1.0.7 -- setup-python-env
+      # cognizant-ai-lab/build-common 1.0.8 -- setup-python-env
       - name: Set up Python and install build tools
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@30321843331e00848309b34e08b839e1f6490ba2
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -33,10 +33,10 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
-      # cognizant-ai-lab/build-common 1.0.7 -- slack-notify
+      # cognizant-ai-lab/build-common 1.0.8 -- slack-notify
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@30321843331e00848309b34e08b839e1f6490ba2
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ permissions:
 jobs:
   test:
     if: github.repository == 'cognizant-ai-lab/nsflow'
-    # 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    # 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.12'
       # No lint or test steps in original workflow


### PR DESCRIPTION
## Description

Bumps all `cognizant-ai-lab/build-common` references from 1.0.7 (`3ead7f6`) to 1.0.8 (`3032184`). Updates SHA pins and version comments in `tests.yml` and `publish.yml`.

## Type of Change

- [x] Dependency upgrade

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt`

Link to Devin session: https://app.devin.ai/sessions/aad527cb16b14184a12c5ff5c362cccf
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/nsflow/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->