### PR TITLE
Fix editor 500 from inconsistent OperationStore._read_jsonl naming

### DIFF
--- a/nsflow/backend/api/v1/editor_endpoints.py
+++ b/nsflow/backend/api/v1/editor_endpoints.py
@@ -794,8 +794,8 @@ async def undo_operation(design_id: str):
         success = operation_store.undo()
 
         # Get updated undo/redo status
-        history = operation_store.read_jsonl(operation_store.hist_file)
-        redo_stack = operation_store.read_jsonl(operation_store.redo_file)
+        history = operation_store._read_jsonl(operation_store.hist_file)
+        redo_stack = operation_store._read_jsonl(operation_store.redo_file)
 
         return UndoRedoResponse(
             success=success,
@@ -822,8 +822,8 @@ async def redo_operation(design_id: str):
         success = operation_store.redo()
 
         # Get updated undo/redo status
-        history = operation_store.read_jsonl(operation_store.hist_file)
-        redo_stack = operation_store.read_jsonl(operation_store.redo_file)
+        history = operation_store._read_jsonl(operation_store.hist_file)
+        redo_stack = operation_store._read_jsonl(operation_store.redo_file)
 
         return UndoRedoResponse(
             success=success,

--- a/nsflow/backend/utils/editor/ops_store.py
+++ b/nsflow/backend/utils/editor/ops_store.py
@@ -675,7 +675,7 @@ class OperationStore:
                 f.write(json.dumps(r, ensure_ascii=False) + "\n")
 
     @staticmethod
-    def read_jsonl(path: str) -> List[Dict[str, Any]]:
+    def _read_jsonl(path: str) -> List[Dict[str, Any]]:
         if not os.path.exists(path):
             return []
         out = []

--- a/tests/nsflow/test_ops_store.py
+++ b/tests/nsflow/test_ops_store.py
@@ -1,0 +1,60 @@
+# Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import os
+import shutil
+import tempfile
+import unittest
+
+from nsflow.backend.utils.editor import ops_store
+from nsflow.backend.utils.editor.ops_store import OperationStore
+
+
+class _FakeManager:
+    """Minimal SimpleStateManager stand-in: OperationStore only needs get_state()."""
+
+    def get_state(self):
+        return {"network_name": "net", "agents": {}}
+
+
+class TestOperationStore(unittest.TestCase):
+    def setUp(self):
+        """Redirect the draft-state root to a temp dir so tests never touch the package."""
+        self.tmp_dir = tempfile.mkdtemp()
+        self._orig_root = ops_store.ROOT_DIR
+        ops_store.ROOT_DIR = self.tmp_dir
+
+    def tearDown(self):
+        ops_store.ROOT_DIR = self._orig_root
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_undo_on_empty_history_returns_false(self):
+        """Regression: undo() reads history via _read_jsonl before the empty check,
+        so a naming mismatch there raised AttributeError instead of returning False."""
+        store = OperationStore("design-1", _FakeManager())
+        self.assertFalse(store.undo())
+
+    def test_read_jsonl_round_trip(self):
+        """_read_jsonl returns [] for a missing file and reads back appended rows."""
+        path = os.path.join(self.tmp_dir, "history.jsonl")
+        self.assertEqual(OperationStore._read_jsonl(path), [])
+
+        OperationStore._append_jsonl(path, {"a": 1})
+        OperationStore._append_jsonl(path, {"b": 2})
+        self.assertEqual(OperationStore._read_jsonl(path), [{"a": 1}, {"b": 2}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

`OperationStore` defines its JSONL reader as `read_jsonl` (no leading underscore), but most call sites — and all of the sibling helpers (`_append_jsonl`, `_write_jsonl`, `_read_json`, `_write_json`) — use the private `_` convention. Ten call sites invoke `self._read_jsonl(...)` / `OperationStore._read_jsonl(...)`, which does not exist, so they raise:

```
AttributeError: 'OperationStore' object has no attribute '_read_jsonl'
```

Two of these calls are unguarded in `SimpleStateRegistry.list_all_networks()` (the `can_undo`/`can_redo` fields for active editing sessions). As soon as a network is loaded for editing, `GET /api/v1/andeditor/networks` and `GET /api/v1/andeditor/state/networks` return **500**, and the editor UI is stuck on "Awaiting Agent design…". `save_draft`, `get_draft_info`, `undo`, and `redo` are affected too.

This aligns the naming on the private form: renames the definition to `_read_jsonl` and updates the four remaining public callers in `editor_endpoints.py`. Net effect: all 12 call sites now resolve to the one defined method.

## Impact

Restores the in-browser network editor and draft/undo/redo endpoints. No behavior change beyond fixing the crash; the method body is untouched.

## Screenshots / Logs / Examples (optional)

Before (loading any network for editing, then listing):
```
GET /api/v1/andeditor/networks
-> 500 {"detail":"Error listing networks"}
   AttributeError: 'OperationStore' object has no attribute '_read_jsonl'
```

After:
```python
>>> OperationStore._read_jsonl("/tmp/missing.jsonl")
[]
```
`grep -rE "[^_]read_jsonl" nsflow` returns no remaining callers; both changed files `py_compile` cleanly.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt`
