### PR TITLE
Run tests in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,8 @@ jobs:
         set -e
         VIRTUAL_ENV=system make lint-check
       run-shellcheck: false
-      run-pytest: false
+      run-pytest: true
+      test-command-override: 'VIRTUAL_ENV=system PYTHONPATH=.:$PYTHONPATH make test'
       check-readme-pypi: true
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

Fixes #225

Enables the test suite in the GitHub workflow: `run-pytest: true` with a `test-command-override` that runs `make test`. Previously tests were disabled (`run-pytest: false`).

Stacked on #230 (which enables the linter and makes the version test install-state independent). Base will move to main after #230 merges.

## Impact

CI now runs the linter and the pytest suite. Tests pass green (verified locally with the package uninstalled, mirroring a fresh CI checkout).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate \`requirements.txt\` (tool-specific preferred; main only for core functionality)