### PR TITLE
Derive MCP OAuth redirect URI from the browser's Host; add MCP OAuth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,12 @@ sudo apt install ffmpeg
 ### Enabling Visual Question Answering (VQA) http endpoints
 
 Follow these [instructions](./docs/VQA_README.md)
+
+---
+
+### Connecting OAuth-protected MCP servers
+
+Connect MCP servers that require OAuth (e.g. You.com, Linear, GitHub, Salesforce)
+from the **Connectors** tab — nsflow runs the OAuth flow, stores the tokens
+locally, and injects them into agent networks automatically. See these
+[instructions](./docs/MCP_OAUTH.md).

--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -1,0 +1,177 @@
+# MCP OAuth Connectors
+
+nsflow can connect to **OAuth-protected MCP (Model Context Protocol) servers** so
+that agent networks calling those servers are authenticated automatically — you
+never have to paste a bearer token into the SlyData editor.
+
+You connect a server once from the **Connectors** tab (a standard OAuth sign-in,
+like Claude Desktop / the Claude console). nsflow stores the resulting tokens
+locally and injects a fresh `Authorization` header into `sly_data.http_headers`
+for any MCP URL the selected network references.
+
+---
+
+## How it works
+
+- **OAuth runs on the backend.** nsflow performs the OAuth 2.1 authorization-code
+  flow with **PKCE**, using **Dynamic Client Registration (DCR)** when the server
+  supports it. The backend owns the loopback redirect URI and the token refresh
+  logic; the frontend only opens the sign-in popup and lists/disconnects
+  connections. Tokens are **never** returned to the UI.
+- **Tokens are persisted locally** (including the refresh token) so connections
+  survive a backend restart and can be refreshed without re-authenticating.
+- **At chat time**, the backend reads the selected network's `sly_data_schema`,
+  finds the MCP URLs it declares `http_headers` for, and — for each one you've
+  connected — injects `sly_data.http_headers[<url>] = {"Authorization": "Bearer …"}`.
+  Only URLs the network actually uses are injected. **User-supplied `http_headers`
+  always win** over injected ones.
+- **Secrets stay backend-only.** Credential headers (`Authorization`, etc.) are
+  redacted at every point where `sly_data` could be logged or streamed back to
+  the UI. Do not put secrets in `sly_data` yourself.
+
+Relevant code: [`mcp_oauth_manager.py`](../nsflow/backend/utils/mcp/mcp_oauth_manager.py),
+[`mcp_oauth_endpoints.py`](../nsflow/backend/api/v1/mcp_oauth_endpoints.py),
+[`mcp_token_storage.py`](../nsflow/backend/utils/mcp/mcp_token_storage.py),
+[`ns_websocket_utils.py`](../nsflow/backend/utils/agentutils/ns_websocket_utils.py),
+[`McpConnectorsPanel.tsx`](../nsflow/frontend/src/components/mcp/McpConnectorsPanel.tsx).
+
+---
+
+## Using the Connectors tab
+
+Open the **Connectors** tab. You'll see:
+
+- **Quick Connect** — curated servers that support DCR. One click, nothing to
+  enter: a popup opens, you approve, done. (You.com, Linear, Notion, Sentry,
+  Atlassian, Stripe, PayPal, Intercom, Zapier, Postman.)
+- **Client ID/Secret** — curated servers that do **not** support DCR, so you must
+  register an OAuth app at the provider and paste its Client ID (and Secret, if
+  it's a confidential client). (GitHub, Asana, Slack.)
+- **Add server** — connect any OAuth-protected MCP server by URL. Supply a Client
+  ID/Secret only if the server has no DCR.
+
+The catalog of curated servers lives in
+[`knownMcpServers.ts`](../nsflow/frontend/src/components/mcp/knownMcpServers.ts),
+which also documents servers deliberately excluded and why.
+
+Connected servers appear in the list with a **Connected** chip (and an
+**Auto-refresh** chip when a refresh token was issued). Click the trash icon to
+disconnect — that deletes the stored credentials.
+
+### Pre-registered servers (Client ID/Secret)
+
+For servers without DCR (GitHub, Salesforce, …) you register an OAuth app once at
+the provider, then paste its credentials into nsflow:
+
+1. In the provider's developer console, create an OAuth app / client.
+2. Set its **callback / redirect URI** to **exactly** the value nsflow shows in
+   the connect dialog (see [Redirect URI](#the-redirect--callback-uri) below).
+3. Enable the **authorization-code** flow and **PKCE**; request the scopes the MCP
+   server needs.
+4. Paste the resulting **Client ID** (and **Secret**, if any) into the dialog and
+   click **Connect**. A popup opens for you to approve.
+
+---
+
+## The redirect / callback URI
+
+The provider redirects back to nsflow's callback route after you approve:
+
+```
+http://<host>:<port>/api/v1/mcp/oauth/callback
+```
+
+Because nsflow runs locally, this is a **loopback** redirect (RFC 8252) — the
+backend itself serves `/callback`, receives the authorization code, exchanges it
+for tokens, and closes the popup.
+
+### localhost vs 127.0.0.1 (handled automatically)
+
+Providers match the redirect URI **character-for-character**, and they disagree on
+the loopback host: some (e.g. **Salesforce**) reject the bare IP and require
+`localhost`; others prefer `127.0.0.1`.
+
+nsflow resolves this automatically: **the callback host follows whichever loopback
+name you browse nsflow on.** Open nsflow at `http://localhost:4173` and it uses
+`localhost`; open it at `http://127.0.0.1:4173` and it uses `127.0.0.1`. The
+connect dialog (and `GET /api/v1/mcp/oauth/redirect_uri`) always show the exact
+value that will be sent — **register that string**, and open nsflow the same way
+you registered.
+
+> Only loopback hosts are trusted from the request; a non-loopback `Host` header
+> is ignored (it falls back to the configured default) so it can't steer the
+> redirect to an external origin.
+
+### Overriding the callback URL (proxied / remote / HTTPS deployments)
+
+If nsflow runs behind a reverse proxy, on a remote host, or must present a fixed
+HTTPS callback, set the full base URL explicitly — it is used verbatim and wins
+over the automatic behavior:
+
+```bash
+export NSFLOW_PUBLIC_BASE_URL=https://nsflow.example.com
+# -> https://nsflow.example.com/api/v1/mcp/oauth/callback
+```
+
+To force a specific loopback form regardless of how you browse:
+
+```bash
+export NSFLOW_PUBLIC_BASE_URL=http://localhost:4173
+```
+
+If the callback must be reached on a different port than the backend binds (e.g.
+a proxy), set `NSFLOW_OAUTH_REDIRECT_PORT` — it must still resolve to wherever
+`/callback` is served.
+
+---
+
+## Environment variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `NSFLOW_MCP_STORAGE_DIR` | Directory holding `tokens.json` (the credential store) | `~/.nsflow/mcp_oauth` |
+| `NSFLOW_PUBLIC_BASE_URL` | Full base URL override for the callback (proxied / remote / HTTPS). Used verbatim; highest priority. | *(derived from the browse host / loopback)* |
+| `NSFLOW_OAUTH_REDIRECT_PORT` | Port for the callback URL when it differs from the backend port | `NSFLOW_PORT` |
+| `NSFLOW_HOST` / `NSFLOW_PORT` | Backend bind host / port | `127.0.0.1` / `4173` (`8005` in dev) |
+
+---
+
+## Token storage & security
+
+- Credentials are stored in a single JSON file, `tokens.json`, under
+  `NSFLOW_MCP_STORAGE_DIR` (default `~/.nsflow/mcp_oauth`), written `0600` with a
+  cross-process lock. It contains the access token, refresh token, and the
+  registered client info per server URL.
+- Tokens are **never** sent to the frontend and are **redacted** anywhere
+  `sly_data` might be logged or streamed.
+- Disconnecting a server from the Connectors tab removes its entry from the file.
+- nsflow keeps the access token fresh using the stored refresh token where the
+  server supports it. If a connection can no longer be refreshed, just
+  **reconnect** it from the tab.
+
+---
+
+## Troubleshooting
+
+**`redirect_uri_mismatch` / "redirect_uri must match configuration"** — the URI
+nsflow sent isn't a byte-for-byte match with the one registered on the provider.
+Usually `localhost` vs `127.0.0.1`, a port difference, or a trailing slash. Check
+the exact value at `GET /api/v1/mcp/oauth/redirect_uri` (or the connect dialog)
+and make the registered callback identical. Remember the callback follows the host
+you browse nsflow on — open it the same way you registered (or register both
+loopback forms if the provider allows multiple callback URLs).
+
+**`unsupported_response_type` / "response type not supported"** — typically a
+malformed authorize URL (e.g. a provider whose `authorization_endpoint` already
+carries a query, producing a double `?`). nsflow normalizes these, so on current
+builds this should not occur; if it does, capture the backend log line for the
+authorize request and file it.
+
+**Popup blocked** — allow popups for the nsflow origin and retry. nsflow also
+polls the flow status as a fallback, so completion is still detected if the
+popup can't message back.
+
+**A network prompts you to connect before chatting** — if a network's
+`sly_data_schema` declares `http_headers` for an MCP URL you haven't connected,
+nsflow surfaces a gate directing you to the Connectors tab. Connect the server,
+then retry.

--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -119,9 +119,12 @@ To force a specific loopback form regardless of how you browse:
 export NSFLOW_PUBLIC_BASE_URL=http://localhost:4173
 ```
 
-If the callback must be reached on a different port than the backend binds (e.g.
-a proxy), set `NSFLOW_OAUTH_REDIRECT_PORT` — it must still resolve to wherever
-`/callback` is served.
+> **`NSFLOW_OAUTH_REDIRECT_PORT` (legacy — rarely needed).** Overrides only the
+> *port* of the advertised callback. It predates the browse-host behavior above,
+> which already picks up a port-mapped setup (Docker `-p`, SSH tunnel) from the
+> address you browse on; and `NSFLOW_PUBLIC_BASE_URL` covers everything else.
+> Prefer those. If set, it must still resolve to wherever `/callback` is served —
+> the env vars change only the advertised URL, never where the backend listens.
 
 ---
 
@@ -131,7 +134,7 @@ a proxy), set `NSFLOW_OAUTH_REDIRECT_PORT` — it must still resolve to wherever
 | --- | --- | --- |
 | `NSFLOW_MCP_STORAGE_DIR` | Directory holding `tokens.json` (the credential store) | `~/.nsflow/mcp_oauth` |
 | `NSFLOW_PUBLIC_BASE_URL` | Full base URL override for the callback (proxied / remote / HTTPS). Used verbatim; highest priority. | *(derived from the browse host / loopback)* |
-| `NSFLOW_OAUTH_REDIRECT_PORT` | Port for the callback URL when it differs from the backend port | `NSFLOW_PORT` |
+| `NSFLOW_OAUTH_REDIRECT_PORT` | Legacy: port-only override for the advertised callback. Rarely needed — the browse host already carries the right port, and `NSFLOW_PUBLIC_BASE_URL` covers the rest. | `NSFLOW_PORT` |
 | `NSFLOW_HOST` / `NSFLOW_PORT` | Backend bind host / port | `127.0.0.1` / `4173` (`8005` in dev) |
 
 ---

--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -77,7 +77,7 @@ the provider, then paste its credentials into nsflow:
 
 The provider redirects back to nsflow's callback route after you approve:
 
-```
+```text
 http://<host>:<port>/api/v1/mcp/oauth/callback
 ```
 
@@ -130,12 +130,16 @@ export NSFLOW_PUBLIC_BASE_URL=http://localhost:4173
 
 ## Environment variables
 
-| Variable | Purpose | Default |
-| --- | --- | --- |
-| `NSFLOW_MCP_STORAGE_DIR` | Directory holding `tokens.json` (the credential store) | `~/.nsflow/mcp_oauth` |
-| `NSFLOW_PUBLIC_BASE_URL` | Full base URL override for the callback (proxied / remote / HTTPS). Used verbatim; highest priority. | *(derived from the browse host / loopback)* |
-| `NSFLOW_OAUTH_REDIRECT_PORT` | Legacy: port-only override for the advertised callback. Rarely needed — the browse host already carries the right port, and `NSFLOW_PUBLIC_BASE_URL` covers the rest. | `NSFLOW_PORT` |
-| `NSFLOW_HOST` / `NSFLOW_PORT` | Backend bind host / port | `127.0.0.1` / `4173` (`8005` in dev) |
+- **`NSFLOW_MCP_STORAGE_DIR`** — directory holding `tokens.json` (the credential
+  store). Default: `~/.nsflow/mcp_oauth`.
+- **`NSFLOW_PUBLIC_BASE_URL`** — full base URL override for the callback
+  (proxied / remote / HTTPS deployments). Used verbatim; highest priority.
+  Default: derived from the browse host / loopback.
+- **`NSFLOW_OAUTH_REDIRECT_PORT`** — legacy port-only override for the advertised
+  callback. Rarely needed: the browse host already carries the right port, and
+  `NSFLOW_PUBLIC_BASE_URL` covers the rest. Default: `NSFLOW_PORT`.
+- **`NSFLOW_HOST` / `NSFLOW_PORT`** — backend bind host / port. Default:
+  `127.0.0.1` / `4173` (`8005` in dev).
 
 ---
 

--- a/nsflow/backend/api/v1/mcp_oauth_endpoints.py
+++ b/nsflow/backend/api/v1/mcp_oauth_endpoints.py
@@ -31,6 +31,7 @@ from typing import Optional
 from fastapi import APIRouter
 from fastapi import HTTPException
 from fastapi import Query
+from fastapi import Request
 from fastapi.responses import HTMLResponse
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -98,7 +99,7 @@ def _callback_html(status: str, server_url: str, message: str = "") -> str:
 
 
 @router.post("/start")
-async def start_oauth_flow(body: StartFlowRequest):
+async def start_oauth_flow(body: StartFlowRequest, request: Request):
     """
     Begin an OAuth flow for an MCP server.
 
@@ -112,13 +113,19 @@ async def start_oauth_flow(body: StartFlowRequest):
     if await asyncio.to_thread(FileTokenStorage.has_connection, server_url):
         return JSONResponse(content={"already_connected": True, "server_url": server_url})
 
-    logger.info("Starting MCP OAuth flow for %s", server_url)
+    # Derive the redirect_uri from the host the browser used to reach nsflow, so
+    # it follows localhost vs 127.0.0.1 automatically and matches the value shown
+    # in the connect dialog (see compute_redirect_uri / GET /redirect_uri).
+    redirect_uri = mcp_oauth_manager.compute_redirect_uri(request.headers.get("host"))
+
+    logger.info("Starting MCP OAuth flow for %s (redirect_uri=%s)", server_url, redirect_uri)
     try:
         flow = await mcp_oauth_manager.start_flow(
             server_url,
             scope=body.scope,
             client_id=(body.client_id or "").strip() or None,
             client_secret=(body.client_secret or "").strip() or None,
+            redirect_uri=redirect_uri,
         )
     except TimeoutError as exc:
         logger.warning("MCP OAuth flow for %s timed out building the authorization URL.", server_url)
@@ -222,13 +229,19 @@ async def oauth_status(flow_id: str):
 
 
 @router.get("/redirect_uri")
-async def get_redirect_uri():
+async def get_redirect_uri(request: Request):
     """
     Return the OAuth callback URL nsflow uses. Users must register this exact
     value as the redirect/callback URI of any manually-created OAuth app (for
-    servers without dynamic client registration, e.g. GitHub).
+    servers without dynamic client registration, e.g. GitHub, Salesforce).
+
+    Derived from the request host so it reflects the loopback name the user is
+    actually browsing on (localhost vs 127.0.0.1) - the same value /start sends,
+    so what the dialog tells them to register is exactly what gets used.
     """
-    return JSONResponse(content={"redirect_uri": mcp_oauth_manager.compute_redirect_uri()})
+    return JSONResponse(
+        content={"redirect_uri": mcp_oauth_manager.compute_redirect_uri(request.headers.get("host"))}
+    )
 
 
 @router.get("/connections")

--- a/nsflow/backend/api/v1/mcp_oauth_endpoints.py
+++ b/nsflow/backend/api/v1/mcp_oauth_endpoints.py
@@ -239,9 +239,7 @@ async def get_redirect_uri(request: Request):
     actually browsing on (localhost vs 127.0.0.1) - the same value /start sends,
     so what the dialog tells them to register is exactly what gets used.
     """
-    return JSONResponse(
-        content={"redirect_uri": mcp_oauth_manager.compute_redirect_uri(request.headers.get("host"))}
-    )
+    return JSONResponse(content={"redirect_uri": mcp_oauth_manager.compute_redirect_uri(request.headers.get("host"))})
 
 
 @router.get("/connections")

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -192,10 +192,13 @@ class MCPOAuthManager:
 
         The default port is ``NSFLOW_PORT`` because ``/callback`` is a route on
         the FastAPI backend, which binds ``NSFLOW_PORT`` (8005 in dev, 4173 when
-        that same process also serves the built frontend). The dedicated
-        ``NSFLOW_OAUTH_REDIRECT_PORT`` knob exists for topologies where the
-        browser must reach the callback on a different port (e.g. a reverse
-        proxy) - it must still resolve to wherever ``/callback`` is served.
+        that same process also serves the built frontend). ``NSFLOW_OAUTH_REDIRECT_PORT``
+        is a legacy port-only override, kept for backward compatibility: it
+        predates the request-host derivation (which already picks up a
+        port-mapped setup from the browse address), and ``NSFLOW_PUBLIC_BASE_URL``
+        expresses everything it can. Prefer those. Either way, these env vars
+        change only the ADVERTISED URL - the value must still resolve to
+        wherever ``/callback`` is actually served.
         """
         override = os.getenv("NSFLOW_PUBLIC_BASE_URL")
         if override:

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -165,7 +165,7 @@ class MCPOAuthManager:
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    def compute_redirect_uri() -> str:
+    def compute_redirect_uri(request_host: Optional[str] = None) -> str:
         """
         Build the loopback redirect URI that the MCP server redirects back to.
 
@@ -177,7 +177,17 @@ class MCPOAuthManager:
         Resolution order:
           1. ``NSFLOW_PUBLIC_BASE_URL`` - full base URL override (proxied/HTTPS
              deployments); used verbatim.
-          2. Otherwise ``http://<host>:<port>/...`` where ``port`` is
+          2. ``request_host`` (the ``Host`` header of the originating request),
+             but ONLY when it is a loopback host - so the redirect_uri follows
+             whichever loopback name the user actually browses nsflow on
+             (``localhost`` vs ``127.0.0.1``) and matches the value the connect
+             dialog shows them to register. Some providers (e.g. Salesforce)
+             reject the bare IP and require ``localhost``; others prefer the IP.
+             Following the browse host makes both work with no configuration.
+             Non-loopback request hosts are ignored so a spoofed ``Host`` header
+             can't steer the redirect to an external origin - proxied/remote
+             deployments use ``NSFLOW_PUBLIC_BASE_URL`` instead.
+          3. Otherwise ``http://<host>:<port>/...`` where ``port`` is
              ``NSFLOW_OAUTH_REDIRECT_PORT`` if set, else ``NSFLOW_PORT``.
 
         The default port is ``NSFLOW_PORT`` because ``/callback`` is a route on
@@ -191,6 +201,13 @@ class MCPOAuthManager:
         if override:
             return f"{override.rstrip('/')}/api/v1/mcp/oauth/callback"
 
+        if request_host:
+            # Host header is "<host>" or "<host>:<port>"; trust only loopback so
+            # the redirect follows the browse host (localhost vs 127.0.0.1).
+            hostname = request_host.rsplit(":", 1)[0].strip().lower().strip("[]")
+            if hostname in ("localhost", "127.0.0.1", "::1"):
+                return f"http://{request_host.strip()}/api/v1/mcp/oauth/callback"
+
         host = os.getenv("NSFLOW_HOST", "127.0.0.1")
         if host in ("0.0.0.0", "::", "", "localhost"):
             host = "127.0.0.1"
@@ -201,10 +218,11 @@ class MCPOAuthManager:
         return f"http://{host}:{port}/api/v1/mcp/oauth/callback"
 
     def _build_client_metadata(
-        self, scope: Optional[str] = None, auth_method: str = "none"
+        self, scope: Optional[str] = None, auth_method: str = "none",
+        redirect_uri: Optional[str] = None,
     ) -> OAuthClientMetadata:
         return OAuthClientMetadata(
-            redirect_uris=[self.compute_redirect_uri()],
+            redirect_uris=[redirect_uri or self.compute_redirect_uri()],
             client_name="nsflow",
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
@@ -224,6 +242,7 @@ class MCPOAuthManager:
         scope: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
+        redirect_uri: Optional[str] = None,
     ) -> PendingFlow:
         """
         Kick off an OAuth flow for ``server_url`` and wait until the
@@ -238,6 +257,12 @@ class MCPOAuthManager:
         """
         self._sweep_expired()
 
+        # Resolve the redirect_uri once so pre-seeded client_info, DCR, and the
+        # authorization request all send the same value (the provider matches it
+        # exactly). Defaults to the configured/loopback value when the caller
+        # (the /start endpoint) didn't derive one from the request host.
+        redirect_uri = redirect_uri or self.compute_redirect_uri()
+
         # Public (PKCE) unless a secret was provided.
         auth_method = "client_secret_post" if client_secret else "none"
 
@@ -247,7 +272,7 @@ class MCPOAuthManager:
                 OAuthClientInformationFull(
                     client_id=client_id,
                     client_secret=client_secret or None,
-                    redirect_uris=[self.compute_redirect_uri()],
+                    redirect_uris=[redirect_uri],
                     client_name="nsflow",
                     grant_types=["authorization_code", "refresh_token"],
                     response_types=["code"],
@@ -260,7 +285,7 @@ class MCPOAuthManager:
         flow.preseeded_client_info = bool(client_id)
         flow.code_future = asyncio.get_running_loop().create_future()
         self._by_flow_id[flow.flow_id] = flow
-        flow.task = asyncio.create_task(self._run_oauth_flow(flow, scope, auth_method))
+        flow.task = asyncio.create_task(self._run_oauth_flow(flow, scope, auth_method, redirect_uri))
 
         # Wait for redirect_handler to capture the URL, or the task to fail.
         try:
@@ -310,12 +335,15 @@ class MCPOAuthManager:
         if flow.state:
             self._by_state.pop(flow.state, None)
 
-    async def _run_oauth_flow(self, flow: PendingFlow, scope: Optional[str], auth_method: str = "none") -> None:
+    async def _run_oauth_flow(
+        self, flow: PendingFlow, scope: Optional[str], auth_method: str = "none",
+        redirect_uri: Optional[str] = None,
+    ) -> None:
         """Background task: drive the SDK auth flow to completion."""
         try:
             provider = OAuthClientProvider(
                 server_url=flow.server_url,
-                client_metadata=self._build_client_metadata(scope, auth_method),
+                client_metadata=self._build_client_metadata(scope, auth_method, redirect_uri),
                 storage=FileTokenStorage(flow.server_url),
                 redirect_handler=self._make_redirect_handler(flow),
                 callback_handler=self._make_callback_handler(flow),

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -239,9 +239,10 @@ class MCPOAuthManager:
     # Starting / completing a flow
     # ------------------------------------------------------------------ #
 
-    async def start_flow(
+    async def start_flow(  # pylint: disable=too-many-arguments  # independent optional OAuth knobs, keyword-only
         self,
         server_url: str,
+        *,
         scope: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -40,7 +40,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Tuple
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse, urlsplit
 
 import httpx
 from mcp import ClientSession
@@ -205,11 +205,26 @@ class MCPOAuthManager:
             return f"{override.rstrip('/')}/api/v1/mcp/oauth/callback"
 
         if request_host:
-            # Host header is "<host>" or "<host>:<port>"; trust only loopback so
-            # the redirect follows the browse host (localhost vs 127.0.0.1).
-            hostname = request_host.rsplit(":", 1)[0].strip().lower().strip("[]")
-            if hostname in ("localhost", "127.0.0.1", "::1"):
-                return f"http://{request_host.strip()}/api/v1/mcp/oauth/callback"
+            # The Host header is client-controllable, so parse it strictly and
+            # rebuild the authority rather than interpolating the raw value:
+            # a header like "localhost:4173@evil.com" would pass a naive host
+            # check yet resolve to evil.com as the real authority (userinfo@host),
+            # leaking the OAuth code off-origin. Trust only a bare loopback host
+            # with an optional numeric port and nothing else (no userinfo, path,
+            # query, or fragment).
+            try:
+                parsed = urlsplit(f"//{request_host.strip()}", scheme="http")
+                hostname = (parsed.hostname or "").lower()
+                port = parsed.port  # raises ValueError on a bad/out-of-range port
+                suspicious = bool(
+                    parsed.username or parsed.password or parsed.path or parsed.query or parsed.fragment
+                )
+            except ValueError:  # malformed Host (bad port, unbalanced IPv6, ...)
+                hostname, port, suspicious = "", None, True
+            if not suspicious and hostname in ("localhost", "127.0.0.1", "::1"):
+                host = f"[{hostname}]" if ":" in hostname else hostname
+                authority = f"{host}:{port}" if port is not None else host
+                return f"http://{authority}/api/v1/mcp/oauth/callback"
 
         host = os.getenv("NSFLOW_HOST", "127.0.0.1")
         if host in ("0.0.0.0", "::", "", "localhost"):

--- a/tests/nsflow/test_mcp_oauth_endpoints.py
+++ b/tests/nsflow/test_mcp_oauth_endpoints.py
@@ -326,45 +326,43 @@ def test_redirect_uri_follows_loopback_request_host(monkeypatch):
     """The redirect_uri follows the loopback host the browser used (localhost vs
     127.0.0.1), including its port - so it matches whatever the user registers."""
     monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
-    assert (
-        MCPOAuthManager.compute_redirect_uri("localhost:4173")
-        == "http://localhost:4173/api/v1/mcp/oauth/callback"
-    )
-    assert (
-        MCPOAuthManager.compute_redirect_uri("127.0.0.1:9999")
-        == "http://127.0.0.1:9999/api/v1/mcp/oauth/callback"
-    )
+    assert MCPOAuthManager.compute_redirect_uri("localhost:4173") == "http://localhost:4173/api/v1/mcp/oauth/callback"
+    assert MCPOAuthManager.compute_redirect_uri("127.0.0.1:9999") == "http://127.0.0.1:9999/api/v1/mcp/oauth/callback"
+
+
+def _pin_fallback_env(monkeypatch):
+    """Pin the env the fallback path reads so its output is deterministic
+    regardless of a dev/CI environment that exports NSFLOW_HOST/PORT."""
+    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("NSFLOW_OAUTH_REDIRECT_PORT", raising=False)
+    monkeypatch.setenv("NSFLOW_HOST", "127.0.0.1")
+    monkeypatch.setenv("NSFLOW_PORT", "4173")
+
+
+FALLBACK_URI = "http://127.0.0.1:4173/api/v1/mcp/oauth/callback"
 
 
 def test_redirect_uri_ignores_non_loopback_request_host(monkeypatch):
     """A non-loopback (potentially spoofed) Host header must NOT steer the
     redirect to an external origin; it falls back to the loopback default."""
-    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
-    result = MCPOAuthManager.compute_redirect_uri("evil.example.com")
-    assert "evil.example.com" not in result
-    assert result.startswith("http://127.0.0.1:")
-    assert result.endswith("/api/v1/mcp/oauth/callback")
+    _pin_fallback_env(monkeypatch)
+    assert MCPOAuthManager.compute_redirect_uri("evil.example.com") == FALLBACK_URI
 
 
 def test_redirect_uri_rejects_host_with_userinfo(monkeypatch):
     """A Host with embedded userinfo (e.g. "localhost:4173@evil.com") must not
     pass the loopback check by its prefix and resolve to an external authority;
     the real host is evil.com, so it is rejected and the default is used."""
-    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
-    result = MCPOAuthManager.compute_redirect_uri("localhost:4173@evil.com")
-    assert "evil.com" not in result
-    assert result.startswith("http://127.0.0.1:")
-    assert result.endswith("/api/v1/mcp/oauth/callback")
+    _pin_fallback_env(monkeypatch)
+    assert MCPOAuthManager.compute_redirect_uri("localhost:4173@evil.com") == FALLBACK_URI
 
 
 def test_redirect_uri_tolerates_malformed_host(monkeypatch):
     """A malformed Host (bad port / unbalanced IPv6) never raises and falls back
     to the loopback default rather than producing a broken URL."""
-    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
+    _pin_fallback_env(monkeypatch)
     for bad in ("localhost:notaport", "[::1", "localhost:99999"):
-        result = MCPOAuthManager.compute_redirect_uri(bad)
-        assert result.startswith("http://127.0.0.1:")
-        assert result.endswith("/api/v1/mcp/oauth/callback")
+        assert MCPOAuthManager.compute_redirect_uri(bad) == FALLBACK_URI
 
 
 def test_redirect_uri_override_beats_request_host(monkeypatch):

--- a/tests/nsflow/test_mcp_oauth_endpoints.py
+++ b/tests/nsflow/test_mcp_oauth_endpoints.py
@@ -346,6 +346,27 @@ def test_redirect_uri_ignores_non_loopback_request_host(monkeypatch):
     assert result.endswith("/api/v1/mcp/oauth/callback")
 
 
+def test_redirect_uri_rejects_host_with_userinfo(monkeypatch):
+    """A Host with embedded userinfo (e.g. "localhost:4173@evil.com") must not
+    pass the loopback check by its prefix and resolve to an external authority;
+    the real host is evil.com, so it is rejected and the default is used."""
+    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
+    result = MCPOAuthManager.compute_redirect_uri("localhost:4173@evil.com")
+    assert "evil.com" not in result
+    assert result.startswith("http://127.0.0.1:")
+    assert result.endswith("/api/v1/mcp/oauth/callback")
+
+
+def test_redirect_uri_tolerates_malformed_host(monkeypatch):
+    """A malformed Host (bad port / unbalanced IPv6) never raises and falls back
+    to the loopback default rather than producing a broken URL."""
+    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
+    for bad in ("localhost:notaport", "[::1", "localhost:99999"):
+        result = MCPOAuthManager.compute_redirect_uri(bad)
+        assert result.startswith("http://127.0.0.1:")
+        assert result.endswith("/api/v1/mcp/oauth/callback")
+
+
 def test_redirect_uri_override_beats_request_host(monkeypatch):
     """NSFLOW_PUBLIC_BASE_URL wins over the request host (proxied deployments)."""
     monkeypatch.setenv("NSFLOW_PUBLIC_BASE_URL", "https://nsflow.example.com")

--- a/tests/nsflow/test_mcp_oauth_endpoints.py
+++ b/tests/nsflow/test_mcp_oauth_endpoints.py
@@ -317,3 +317,48 @@ def test_normalize_auth_url_leaves_normal_url_untouched():
     """A normal authorization URL (single query separator) is returned as-is."""
     normal = "https://idp.example.com/authorize?response_type=code&client_id=abc&state=xyz"
     assert MCPOAuthManager._normalize_authorization_url(normal) == normal  # pylint: disable=protected-access  # exercising a private method under test
+
+
+# --------------------- compute_redirect_uri host handling --------------------- #
+
+
+def test_redirect_uri_follows_loopback_request_host(monkeypatch):
+    """The redirect_uri follows the loopback host the browser used (localhost vs
+    127.0.0.1), including its port - so it matches whatever the user registers."""
+    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
+    assert (
+        MCPOAuthManager.compute_redirect_uri("localhost:4173")
+        == "http://localhost:4173/api/v1/mcp/oauth/callback"
+    )
+    assert (
+        MCPOAuthManager.compute_redirect_uri("127.0.0.1:9999")
+        == "http://127.0.0.1:9999/api/v1/mcp/oauth/callback"
+    )
+
+
+def test_redirect_uri_ignores_non_loopback_request_host(monkeypatch):
+    """A non-loopback (potentially spoofed) Host header must NOT steer the
+    redirect to an external origin; it falls back to the loopback default."""
+    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
+    result = MCPOAuthManager.compute_redirect_uri("evil.example.com")
+    assert "evil.example.com" not in result
+    assert result.startswith("http://127.0.0.1:")
+    assert result.endswith("/api/v1/mcp/oauth/callback")
+
+
+def test_redirect_uri_override_beats_request_host(monkeypatch):
+    """NSFLOW_PUBLIC_BASE_URL wins over the request host (proxied deployments)."""
+    monkeypatch.setenv("NSFLOW_PUBLIC_BASE_URL", "https://nsflow.example.com")
+    assert (
+        MCPOAuthManager.compute_redirect_uri("localhost:4173")
+        == "https://nsflow.example.com/api/v1/mcp/oauth/callback"
+    )
+
+
+def test_redirect_uri_endpoint_reflects_host_header(monkeypatch):
+    """End to end: GET /redirect_uri echoes the loopback Host the client used, so
+    the connect dialog shows exactly what /start will send."""
+    monkeypatch.delenv("NSFLOW_PUBLIC_BASE_URL", raising=False)
+    response = client.get("/api/v1/mcp/oauth/redirect_uri", headers={"host": "localhost:4173"})
+    assert response.status_code == 200
+    assert response.json()["redirect_uri"] == "http://localhost:4173/api/v1/mcp/oauth/callback"


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

The MCP OAuth connector hardcoded its callback to
`http://127.0.0.1:<port>/api/v1/mcp/oauth/callback`. Providers match
`redirect_uri` character-for-character against the registered callback, and
some accept only the `localhost` form and reject the bare IP outright
(e.g. Salesforce External Client Apps) — so connecting to those servers always
failed with `redirect_uri_mismatch`, unless the user discovered the
undocumented `NSFLOW_PUBLIC_BASE_URL` workaround.

Fixes #233

## Changes

### Backend
- `compute_redirect_uri()` now accepts the originating request's `Host` header
  and uses it when — and only when — it is a loopback host (`localhost` /
  `127.0.0.1` / `::1`). The redirect URI follows whichever address the user
  browses nsflow on: open the UI at `http://localhost:4173` and the flow sends
  the `localhost` form; open it at `http://127.0.0.1:4173` and it sends the IP
  form. Non-loopback hosts are ignored (a spoofed `Host` header cannot steer
  the redirect off-origin), and `NSFLOW_PUBLIC_BASE_URL` still wins for
  proxied / remote / HTTPS deployments.
- The derived value is threaded through `POST /start` into the pre-seeded
  client_info, DCR metadata, and authorize request so all three always agree.
- `GET /redirect_uri` derives the same way, so the connect dialog always shows
  exactly the value the flow will send.
- `NSFLOW_OAUTH_REDIRECT_PORT` documented as a legacy override (the browse-host
  behavior already covers port-mapped setups; `NSFLOW_PUBLIC_BASE_URL` covers
  the rest).

### Docs
- New `docs/MCP_OAUTH.md`: Connectors tab usage (Quick Connect / Client
  ID-Secret / Add server), how the backend OAuth flow and `sly_data` token
  injection work, redirect URI behavior (localhost vs 127.0.0.1), environment
  variables, token storage & security, and troubleshooting
  (`redirect_uri_mismatch`, `unsupported_response_type`, blocked popups).
- README links to the new doc.

### Tests
- Loopback `Host` is honored (host and port); non-loopback is rejected and
  falls back to the default; `NSFLOW_PUBLIC_BASE_URL` beats the request host;
  `GET /redirect_uri` reflects the `Host` header end to end.

## Behavior notes
- One flow sends exactly one `redirect_uri`, so users must open nsflow at the
  address whose form is registered on the OAuth app (for Salesforce:
  `http://localhost:4173`). Registering both forms on providers that allow
  multiple callback URLs makes either address work.
- No frontend changes; the prebuilt bundle is untouched.

## Verification
- Connected to a Salesforce-hosted MCP server (External Client App with the
  `localhost` callback registered) by opening nsflow at
  `http://localhost:4173` — previously failed with `redirect_uri_mismatch`.
- Confirmed `curl -s http://localhost:4173/api/v1/mcp/oauth/redirect_uri` vs
  `http://127.0.0.1:4173/...` return the matching loopback forms.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
