### PR TITLE
Add automatic MCP token refresh via a refresh-only OAuth provider

### DIFF
--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -147,14 +147,16 @@ export NSFLOW_PUBLIC_BASE_URL=http://localhost:4173
 
 - Credentials are stored in a single JSON file, `tokens.json`, under
   `NSFLOW_MCP_STORAGE_DIR` (default `~/.nsflow/mcp_oauth`), written `0600` with a
-  cross-process lock. It contains the access token, refresh token, and the
-  registered client info per server URL.
+  cross-process lock. It contains the access token, refresh token, registered
+  client info, and discovered token endpoint per server URL.
 - Tokens are **never** sent to the frontend and are **redacted** anywhere
   `sly_data` might be logged or streamed.
 - Disconnecting a server from the Connectors tab removes its entry from the file.
 - nsflow keeps the access token fresh using the stored refresh token where the
-  server supports it. If a connection can no longer be refreshed, just
-  **reconnect** it from the tab.
+  server supports it: at chat time, a token near expiry is exchanged silently
+  (a standard OAuth refresh grant on the backend) before being injected. If a
+  connection can no longer be refreshed (e.g. the grant was revoked), nsflow
+  injects nothing and you just **reconnect** it from the tab.
 
 ---
 

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -38,15 +38,22 @@ import logging
 import os
 import time
 import uuid
-from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple
-from urllib.parse import parse_qs, urlparse, urlsplit
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 import httpx
 from mcp import ClientSession
 from mcp.client.auth import OAuthClientProvider
 from mcp.client.streamable_http import streamablehttp_client
-from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+from mcp.shared.auth import OAuthClientInformationFull
+from mcp.shared.auth import OAuthClientMetadata
+from mcp.shared.auth import OAuthToken
 
 # create_mcp_http_client currently lives in the private mcp.shared._httpx_utils
 # (that is where the SDK's own client modules import it from as of mcp 1.27.x).
@@ -58,7 +65,10 @@ try:
 except ImportError:  # pragma: no cover - exercised only on older/newer SDK layouts
     from mcp.shared._httpx_utils import create_mcp_http_client
 
-from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage, _stored_expiry
+from nsflow.backend.utils.mcp.mcp_refresh_provider import ReauthRequiredError
+from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
+from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
+from nsflow.backend.utils.mcp.mcp_token_storage import _stored_expiry
 
 logger = logging.getLogger(__name__)
 
@@ -85,9 +95,7 @@ async def _force_json_accept_on_oauth_requests(request: httpx.Request) -> None:
         request.headers["Accept"] = "application/json"
 
 
-def _mcp_http_client_factory(
-    headers=None, timeout=None, auth=None, **kwargs
-) -> httpx.AsyncClient:
+def _mcp_http_client_factory(headers=None, timeout=None, auth=None, **kwargs) -> httpx.AsyncClient:
     """
     MCP http client factory that adds the OAuth Accept-JSON request hook.
 
@@ -101,10 +109,6 @@ def _mcp_http_client_factory(
     client = create_mcp_http_client(headers=headers, timeout=timeout, auth=auth, **kwargs)
     client.event_hooks.setdefault("request", []).append(_force_json_accept_on_oauth_requests)
     return client
-
-
-class ReauthRequiredError(Exception):
-    """Raised internally when a silent refresh would require user interaction."""
 
 
 @dataclass
@@ -216,9 +220,7 @@ class MCPOAuthManager:
                 parsed = urlsplit(f"//{request_host.strip()}", scheme="http")
                 hostname = (parsed.hostname or "").lower()
                 port = parsed.port  # raises ValueError on a bad/out-of-range port
-                suspicious = bool(
-                    parsed.username or parsed.password or parsed.path or parsed.query or parsed.fragment
-                )
+                suspicious = bool(parsed.username or parsed.password or parsed.path or parsed.query or parsed.fragment)
             except ValueError:  # malformed Host (bad port, unbalanced IPv6, ...)
                 hostname, port, suspicious = "", None, True
             if not suspicious and hostname in ("localhost", "127.0.0.1", "::1"):
@@ -236,7 +238,9 @@ class MCPOAuthManager:
         return f"http://{host}:{port}/api/v1/mcp/oauth/callback"
 
     def _build_client_metadata(
-        self, scope: Optional[str] = None, auth_method: str = "none",
+        self,
+        scope: Optional[str] = None,
+        auth_method: str = "none",
         redirect_uri: Optional[str] = None,
     ) -> OAuthClientMetadata:
         return OAuthClientMetadata(
@@ -342,9 +346,7 @@ class MCPOAuthManager:
             logger.info("Could not clean up stale client_info for %s: %s", flow.server_url, exc)
             return
         if removed:
-            logger.info(
-                "Removed stale pre-seeded client_info for %s after a failed OAuth flow.", flow.server_url
-            )
+            logger.info("Removed stale pre-seeded client_info for %s after a failed OAuth flow.", flow.server_url)
 
     def _discard_flow(self, flow: PendingFlow) -> None:
         """Cancel a flow's background task and remove it from both registries."""
@@ -355,10 +357,14 @@ class MCPOAuthManager:
             self._by_state.pop(flow.state, None)
 
     async def _run_oauth_flow(
-        self, flow: PendingFlow, scope: Optional[str], auth_method: str = "none",
+        self,
+        flow: PendingFlow,
+        scope: Optional[str],
+        auth_method: str = "none",
         redirect_uri: Optional[str] = None,
     ) -> None:
         """Background task: drive the SDK auth flow to completion."""
+        provider: Optional[OAuthClientProvider] = None
         try:
             provider = OAuthClientProvider(
                 server_url=flow.server_url,
@@ -380,6 +386,7 @@ class MCPOAuthManager:
             # Reached here without the provider needing to authorize.
             if await asyncio.to_thread(FileTokenStorage.has_connection, flow.server_url):
                 flow.status = "completed"
+                await self._persist_token_endpoint(provider, flow.server_url)
             else:
                 flow.status = "error"
                 flow.error = (
@@ -395,17 +402,36 @@ class MCPOAuthManager:
             # later handshake step failed - the goal is to acquire credentials.
             if await asyncio.to_thread(FileTokenStorage.has_connection, flow.server_url):
                 flow.status = "completed"
+                await self._persist_token_endpoint(provider, flow.server_url)
             else:
                 flow.status = "error"
                 flow.error = self._describe_exception(exc)
-                logger.warning(
-                    "MCP OAuth flow for %s failed: %s", flow.server_url, flow.error, exc_info=True
-                )
+                logger.warning("MCP OAuth flow for %s failed: %s", flow.server_url, flow.error, exc_info=True)
                 await self._cleanup_failed_preseed(flow)
         finally:
             # Make sure a /start caller is never left blocked.
             if not flow.url_event.is_set():
                 flow.url_event.set()
+
+    @staticmethod
+    async def _persist_token_endpoint(provider: Optional[OAuthClientProvider], server_url: str) -> None:
+        """
+        Record the token endpoint the flow discovered alongside the stored tokens.
+
+        A later silent refresh runs with a fresh provider that has no discovery
+        state; without the stored endpoint the SDK falls back to guessing
+        ``<authorization-base>/token``, which is wrong whenever the authorization
+        server lives on a different host than the MCP server (e.g. Salesforce's
+        login.salesforce.com vs api.salesforce.com). Best effort: a miss only
+        means the refresh must fall back to discovery via the 401 path.
+        """
+        try:
+            metadata = provider.context.oauth_metadata if provider else None
+            token_endpoint = str(metadata.token_endpoint) if metadata and metadata.token_endpoint else None
+            if token_endpoint:
+                await FileTokenStorage(server_url).set_token_endpoint(token_endpoint)
+        except Exception as exc:  # noqa: BLE001 - metadata capture must never fail the flow
+            logger.info("Could not persist the token endpoint for %s: %s", server_url, exc)
 
     @staticmethod
     def _describe_exception(exc: BaseException) -> str:
@@ -586,9 +612,7 @@ class MCPOAuthManager:
 
         # Drop a token that is actually expired (refresh failed / unavailable).
         if expires_at is not None and time.time() >= expires_at:
-            logger.warning(
-                "MCP token for %s is expired and could not be refreshed; reconnect required.", server_url
-            )
+            logger.warning("MCP token for %s is expired and could not be refreshed; reconnect required.", server_url)
             return None
 
         raw = meta.get("tokens")
@@ -597,9 +621,7 @@ class MCPOAuthManager:
         try:
             tokens = OAuthToken.model_validate(raw)
         except Exception as exc:  # noqa: BLE001 - tolerate a corrupted/hand-edited store
-            logger.warning(
-                "MCP token for %s is unparsable; reconnect required: %s", server_url, exc
-            )
+            logger.warning("MCP token for %s is unparsable; reconnect required: %s", server_url, exc)
             return None
         if not tokens.access_token:
             return None
@@ -610,29 +632,37 @@ class MCPOAuthManager:
 
     async def _silent_refresh(self, server_url: str) -> None:
         """
-        Probe the server through the provider so the SDK refreshes the access
-        token using the stored refresh token. If full re-authentication would be
-        required, abort quietly (the stale token is left in place; the user can
-        reconnect from the Connectors tab).
+        Exchange the stored refresh token for a fresh access token, headlessly.
+
+        Probes the server through ``SilentRefreshOAuthProvider``, which restores
+        our persisted expiry so the SDK's proactive refresh grant fires *before*
+        the probe request (a server that answers a stale token with ``200``
+        instead of ``401`` would otherwise never trigger a refresh), and answers
+        a ``401`` with the refresh grant rather than interactive re-auth. On any
+        failure (no refresh token, revoked grant, ...) it aborts quietly, leaving
+        the stale token in place; get_fresh_token then refuses to inject it and
+        the user can reconnect from the Connectors tab.
         """
+        storage = FileTokenStorage(server_url)
+        meta = await asyncio.to_thread(storage.get_metadata)
+        expires_at = _stored_expiry(meta)
+        token_endpoint = meta.get("token_endpoint")
 
-        async def _no_reauth(_authorization_url: str) -> None:
-            raise ReauthRequiredError("re-authentication required")
-
-        async def _no_callback() -> Tuple[str, Optional[str]]:
-            raise ReauthRequiredError("re-authentication required")
-
-        provider = OAuthClientProvider(
+        provider = SilentRefreshOAuthProvider(
             server_url=server_url,
             client_metadata=self._build_client_metadata(),
-            storage=FileTokenStorage(server_url),
-            redirect_handler=_no_reauth,
-            callback_handler=_no_callback,
+            storage=storage,
+            # Report the expiry with the refresh margin already applied, so a
+            # token get_fresh_token deems stale is equally invalid to the SDK's
+            # is_token_valid() and the proactive refresh fires.
+            token_expiry_time=(expires_at - TOKEN_REFRESH_MARGIN_SECONDS) if expires_at is not None else None,
+            token_endpoint=token_endpoint if isinstance(token_endpoint, str) else None,
         )
         try:
-            # Touch the MCP server through the provider; with a valid refresh
-            # token the SDK refreshes silently (no redirect). If full re-auth is
-            # required, _no_reauth raises and we bail out, leaving the stale token.
+            # Touch the MCP server through the provider; the refresh grant runs
+            # inside its auth flow before/with this request. If re-auth would be
+            # required instead, the provider raises and we bail out, leaving the
+            # stale token.
             async with streamablehttp_client(
                 url=server_url, auth=provider, httpx_client_factory=_mcp_http_client_factory
             ) as (read, write, _get_id):

--- a/nsflow/backend/utils/mcp/mcp_refresh_provider.py
+++ b/nsflow/backend/utils/mcp/mcp_refresh_provider.py
@@ -164,7 +164,7 @@ class SilentRefreshOAuthProvider(OAuthClientProvider):
             token_url = str(self.context.oauth_metadata.token_endpoint)
         else:
             auth_base_url = self.context.get_authorization_base_url(self.context.server_url)
-            token_url = urljoin(auth_base_url, "/token")
+            token_url = urljoin(auth_base_url.rstrip("/") + "/", "token")
 
         refresh_data = {
             "grant_type": "refresh_token",

--- a/nsflow/backend/utils/mcp/mcp_refresh_provider.py
+++ b/nsflow/backend/utils/mcp/mcp_refresh_provider.py
@@ -150,8 +150,9 @@ class SilentRefreshOAuthProvider(OAuthClientProvider):
         """
         Build the refresh-grant request (RFC 6749 section 6).
 
-        Identical to the base implementation except that the token endpoint
-        captured at connect time wins over the discovered/guessed one.
+        Same as the base implementation except that the token endpoint captured
+        at connect time wins over the discovered/guessed one, and the fallback
+        guess joins onto the base URL instead of replacing its path.
         """
         if not self.context.current_tokens or not self.context.current_tokens.refresh_token:
             raise OAuthTokenError("No refresh token available")
@@ -163,6 +164,13 @@ class SilentRefreshOAuthProvider(OAuthClientProvider):
         elif self.context.oauth_metadata and self.context.oauth_metadata.token_endpoint:
             token_url = str(self.context.oauth_metadata.token_endpoint)
         else:
+            # Last-resort guess (the SDK's own legacy default) for connections
+            # made before the token endpoint was persisted. auth_base_url is
+            # scheme://netloc by construction (get_authorization_base_url strips
+            # the path), so this matches the SDK's urljoin(base, "/token") for
+            # every reachable input - but the trailing-slash join also preserves
+            # a path prefix should that helper ever start returning one. If the
+            # guess is wrong, the reactive 401 path discovers the real endpoint.
             auth_base_url = self.context.get_authorization_base_url(self.context.server_url)
             token_url = urljoin(auth_base_url.rstrip("/") + "/", "token")
 

--- a/nsflow/backend/utils/mcp/mcp_refresh_provider.py
+++ b/nsflow/backend/utils/mcp/mcp_refresh_provider.py
@@ -1,0 +1,182 @@
+# Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Refresh-only OAuth provider used for silent (headless) MCP token refreshes.
+
+The MCP SDK's ``OAuthClientProvider`` cannot refresh a token it loaded from
+storage: ``_initialize()`` restores the tokens but not their expiry, so
+``is_token_valid()`` reports any stored token as valid and the proactive
+refresh in ``async_auth_flow`` never fires; and when the server then answers
+``401``, the SDK starts the full *interactive* authorization-code flow (browser
+redirect) rather than a refresh grant. See
+https://github.com/modelcontextprotocol/python-sdk/issues/1250.
+
+``SilentRefreshOAuthProvider`` makes the stored refresh token actually usable
+without user interaction:
+
+* ``_initialize`` additionally restores the token expiry we persist ourselves
+  (``expires_at`` in the token store), so the SDK's own proactive refresh grant
+  fires *before* the request goes out - required for servers that answer a
+  stale token with ``200`` rather than ``401``.
+* ``_perform_authorization`` (the interactive browser step) is replaced with
+  the refresh grant, so the reactive ``401`` path also refreshes instead of
+  trying to open a browser.
+* ``_refresh_token`` prefers the token endpoint captured at connect time: at
+  refresh time no discovery has run yet, and the SDK's fallback guess of
+  ``<authorization-base>/token`` is wrong whenever the authorization server
+  lives on a different host than the MCP server (e.g. Salesforce).
+
+Adapted from neuro-san's ``RefreshTokenOauthProvider``
+(https://github.com/cognizant-ai-lab/neuro-san/pull/683), reworked for nsflow's
+authorization-code connections: ``client_info`` comes from the token store
+(persisted at connect time by DCR or manual pre-registration) instead of
+constructor arguments, and tokens/credentials never transit ``sly_data``.
+
+WARNING - FRAGILITY: this overrides *private* methods of the SDK's OAuth
+implementation (``_initialize``, ``_perform_authorization``,
+``_refresh_token``), which may change without notice; the SDK version is what
+these overrides were written against. Upstream work toward a proper extension
+point is tracked in modelcontextprotocol/python-sdk issues #1250/#1318/#2121
+and PRs #1743/#1784 - migrate to it if it lands.
+"""
+
+import logging
+from typing import Optional
+from typing import Tuple
+from urllib.parse import urljoin
+
+import httpx
+from mcp.client.auth import OAuthClientProvider
+from mcp.client.auth import TokenStorage
+from mcp.client.auth.exceptions import OAuthTokenError
+from mcp.shared.auth import OAuthClientMetadata
+
+logger = logging.getLogger(__name__)
+
+
+class ReauthRequiredError(Exception):
+    """Raised internally when a silent refresh would require user interaction."""
+
+
+async def _refuse_redirect(_authorization_url: str) -> None:
+    """``redirect_handler`` for headless refreshes: interactive re-auth is impossible."""
+    raise ReauthRequiredError("re-authentication required")
+
+
+async def _refuse_callback() -> Tuple[str, Optional[str]]:
+    """``callback_handler`` for headless refreshes: interactive re-auth is impossible."""
+    raise ReauthRequiredError("re-authentication required")
+
+
+class SilentRefreshOAuthProvider(OAuthClientProvider):
+    """
+    ``OAuthClientProvider`` variant that only ever performs the refresh grant.
+
+    Drive it exactly like the base class (it is an ``httpx.Auth``): any request
+    sent through it refreshes the stored token first when it is stale, and
+    answers a ``401`` with a refresh grant. It never opens a browser - if
+    interactive re-authentication would be required, it raises instead, leaving
+    the stored (stale) token untouched for the caller to handle.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments  # base-class args + independent optional knobs, keyword-only
+        self,
+        server_url: str,
+        client_metadata: OAuthClientMetadata,
+        storage: TokenStorage,
+        *,
+        token_expiry_time: Optional[float] = None,
+        token_endpoint: Optional[str] = None,
+    ):
+        """
+        :param token_expiry_time: wall-clock expiry (epoch seconds) of the stored
+            access token, restored into the SDK context at initialization. Pass
+            the persisted ``expires_at`` (minus any refresh margin) so
+            ``is_token_valid()`` is honest about staleness.
+        :param token_endpoint: the authorization server's token endpoint as
+            discovered at connect time. Without it, a proactive refresh falls
+            back to the SDK's guessed endpoint and may only succeed via the
+            reactive ``401``-then-discovery path.
+        """
+        super().__init__(
+            server_url=server_url,
+            client_metadata=client_metadata,
+            storage=storage,
+            redirect_handler=_refuse_redirect,
+            callback_handler=_refuse_callback,
+        )
+        self._stored_token_expiry_time = token_expiry_time
+        self.token_endpoint = token_endpoint
+
+    async def _initialize(self) -> None:
+        """Load stored tokens/client info, then restore the token expiry."""
+        await super()._initialize()
+        # The SDK loads tokens from storage without their expiry, so
+        # is_token_valid() would treat an arbitrarily stale token as valid and
+        # the proactive refresh in async_auth_flow could never fire. Restoring
+        # the wall-clock expiry we persist ourselves makes the refresh grant
+        # run before the request is sent.
+        if self._stored_token_expiry_time is not None:
+            self.context.token_expiry_time = self._stored_token_expiry_time
+
+    async def _perform_authorization(self) -> httpx.Request:
+        """
+        Exchange the refresh token instead of starting interactive authorization.
+
+        The base implementation opens the provider's authorize page and waits
+        for a browser callback - impossible headlessly. By the time the ``401``
+        path calls this, discovery has populated ``oauth_metadata``, so the
+        refresh grant reaches the real token endpoint even when none was stored.
+        If no refresh token is available (or it was just rejected and cleared),
+        ``_refresh_token`` raises and the surrounding request fails, leaving the
+        stored token untouched.
+        """
+        return await self._refresh_token()
+
+    async def _refresh_token(self) -> httpx.Request:
+        """
+        Build the refresh-grant request (RFC 6749 section 6).
+
+        Identical to the base implementation except that the token endpoint
+        captured at connect time wins over the discovered/guessed one.
+        """
+        if not self.context.current_tokens or not self.context.current_tokens.refresh_token:
+            raise OAuthTokenError("No refresh token available")
+        if not self.context.client_info or not self.context.client_info.client_id:
+            raise OAuthTokenError("No client info available")
+
+        if self.token_endpoint:
+            token_url = self.token_endpoint
+        elif self.context.oauth_metadata and self.context.oauth_metadata.token_endpoint:
+            token_url = str(self.context.oauth_metadata.token_endpoint)
+        else:
+            auth_base_url = self.context.get_authorization_base_url(self.context.server_url)
+            token_url = urljoin(auth_base_url, "/token")
+
+        refresh_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": self.context.current_tokens.refresh_token,
+            "client_id": self.context.client_info.client_id,
+        }
+        if self.context.should_include_resource_param(self.context.protocol_version):
+            refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
+
+        # prepare_token_auth applies the client's token_endpoint_auth_method
+        # (client_secret_post adds the secret to the form, client_secret_basic
+        # to the Authorization header).
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        refresh_data, headers = self.context.prepare_token_auth(refresh_data, headers)
+        return httpx.Request("POST", token_url, data=refresh_data, headers=headers)

--- a/nsflow/backend/utils/mcp/mcp_token_storage.py
+++ b/nsflow/backend/utils/mcp/mcp_token_storage.py
@@ -34,9 +34,13 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
-from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from mcp.shared.auth import OAuthClientInformationFull
+from mcp.shared.auth import OAuthToken
 
 try:
     import fcntl  # POSIX only
@@ -157,13 +161,15 @@ class FileTokenStorage:
                 "tokens": { ...OAuthToken.model_dump()... },
                 "client_info": { ...OAuthClientInformationFull.model_dump()... },
                 "obtained_at": 1733659200,
-                "expires_at": 1733662800
+                "expires_at": 1733662800,
+                "token_endpoint": "https://auth.example.com/oauth/token"
             }
         }
 
     ``expires_at`` is computed and stored by us because ``OAuthToken`` only
     carries the relative ``expires_in`` and loses the wall-clock anchor across
-    restarts.
+    restarts. ``token_endpoint`` is captured at connect time so silent refreshes
+    can send the refresh grant directly, without re-running discovery.
     """
 
     # Serializes read-modify-write within this process (across coroutines). A
@@ -243,6 +249,28 @@ class FileTokenStorage:
                 entry = {}
                 blob[self.server_url] = entry
             entry["client_info"] = client_info.model_dump(mode="json")
+            self._write_file(blob)
+
+    async def set_token_endpoint(self, token_endpoint: str) -> None:
+        """
+        Persist the authorization server's token endpoint for this server.
+
+        Captured once at connect time (from the SDK's completed discovery) so a
+        later silent refresh can POST the refresh grant straight to it instead
+        of re-running discovery or falling back to the SDK's guessed endpoint.
+        Not part of the ``TokenStorage`` protocol.
+        """
+        async with self._lock:
+            await asyncio.to_thread(self._sync_set_token_endpoint, token_endpoint)
+
+    def _sync_set_token_endpoint(self, token_endpoint: str) -> None:
+        with _interprocess_lock(self._lock_path):
+            blob = self._load_file()
+            entry = blob.get(self.server_url)
+            if not isinstance(entry, dict):
+                entry = {}
+                blob[self.server_url] = entry
+            entry["token_endpoint"] = token_endpoint
             self._write_file(blob)
 
     # ------------------------------------------------------------------ #
@@ -351,7 +379,7 @@ class FileTokenStorage:
         return cls._entry_is_usable(entry)
 
     def get_metadata(self) -> Dict[str, Any]:
-        """Return this server's stored entry (tokens, client_info, obtained_at, expires_at)."""
+        """Return this server's stored entry (tokens, client_info, obtained_at, expires_at, token_endpoint)."""
         return self._read_entry(self.server_url)
 
     # ------------------------------------------------------------------ #

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -1,0 +1,226 @@
+# Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for the silent (headless) MCP token refresh.
+
+These drive ``SilentRefreshOAuthProvider`` through real httpx auth flows against
+an ``httpx.MockTransport``, with tokens persisted in a temp-dir FileTokenStorage
+- no network and no live MCP session. They pin the behavior the stock SDK
+provider gets wrong for stored tokens: the refresh grant must fire proactively
+(before the request) using the token endpoint captured at connect time, and a
+failed refresh must leave the stored token untouched rather than falling into
+interactive re-authentication.
+"""
+
+import asyncio
+import json
+import time
+
+import httpx
+import pytest
+from mcp.shared.auth import OAuthClientMetadata
+
+import nsflow.backend.utils.mcp.mcp_oauth_manager as om
+from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
+from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
+
+SERVER_URL = "https://mcp.example.com/mcp"
+TOKEN_ENDPOINT = "https://auth.example.com/oauth/token"
+
+
+def _seed_store(tmp_path, *, refresh_token="refresh-1", expires_at=None, token_endpoint=TOKEN_ENDPOINT):
+    """Write a tokens.json entry the way a completed connect flow would have."""
+    tokens = {"access_token": "stale-token", "token_type": "Bearer"}
+    if refresh_token:
+        tokens["refresh_token"] = refresh_token
+    entry = {
+        "tokens": tokens,
+        "client_info": {
+            "client_id": "client-1",
+            "redirect_uris": ["http://localhost:4173/api/v1/mcp/oauth/callback"],
+            "token_endpoint_auth_method": "none",
+        },
+        "obtained_at": int(time.time()) - 7200,
+        "expires_at": expires_at if expires_at is not None else int(time.time()) - 3600,
+    }
+    if token_endpoint:
+        entry["token_endpoint"] = token_endpoint
+    (tmp_path / "tokens.json").write_text(json.dumps({SERVER_URL: entry}), encoding="utf-8")
+
+
+def _read_store(tmp_path):
+    return json.loads((tmp_path / "tokens.json").read_text(encoding="utf-8"))[SERVER_URL]
+
+
+def _client_metadata():
+    return OAuthClientMetadata(
+        redirect_uris=None,
+        grant_types=["authorization_code", "refresh_token"],
+        token_endpoint_auth_method="none",
+    )
+
+
+def _provider(tmp_path, *, token_expiry_time, token_endpoint=TOKEN_ENDPOINT):
+    return SilentRefreshOAuthProvider(
+        server_url=SERVER_URL,
+        client_metadata=_client_metadata(),
+        storage=FileTokenStorage(SERVER_URL, storage_dir=tmp_path),
+        token_expiry_time=token_expiry_time,
+        token_endpoint=token_endpoint,
+    )
+
+
+def _request_through(provider, handler):
+    """Send one GET to the server through the provider's auth flow via a mock transport."""
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await client.get(SERVER_URL, auth=provider)
+
+    return asyncio.run(run())
+
+
+def test_proactive_refresh_fires_before_request(tmp_path):
+    """
+    A stale stored token is refreshed via the stored token endpoint BEFORE the
+    server request, and the new tokens (with a fresh expires_at) are persisted.
+    The server never needs to answer 401 - the case the stock provider misses.
+    """
+    _seed_store(tmp_path)
+    provider = _provider(tmp_path, token_expiry_time=time.time() - 10)
+
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        if str(request.url) == TOKEN_ENDPOINT:
+            body = dict(pair.split("=", 1) for pair in request.content.decode().split("&"))
+            assert body["grant_type"] == "refresh_token"
+            assert body["refresh_token"] == "refresh-1"
+            assert body["client_id"] == "client-1"
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "fresh-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "refresh_token": "refresh-2",
+                },
+            )
+        # The actual server request must already carry the refreshed token.
+        assert request.headers["Authorization"] == "Bearer fresh-token"
+        return httpx.Response(200, json={})
+
+    response = _request_through(provider, handler)
+
+    assert response.status_code == 200
+    assert calls[0] == TOKEN_ENDPOINT  # refresh grant went out first, proactively
+    entry = _read_store(tmp_path)
+    assert entry["tokens"]["access_token"] == "fresh-token"
+    assert entry["tokens"]["refresh_token"] == "refresh-2"
+    assert entry["expires_at"] > time.time()  # wall-clock expiry re-anchored
+    assert entry["token_endpoint"] == TOKEN_ENDPOINT  # set_tokens preserved it
+
+
+def test_valid_token_is_not_refreshed(tmp_path):
+    """A token whose restored expiry is still in the future is used as-is."""
+    future = time.time() + 3600
+    _seed_store(tmp_path, expires_at=int(future))
+    provider = _provider(tmp_path, token_expiry_time=future)
+
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        assert request.headers["Authorization"] == "Bearer stale-token"
+        return httpx.Response(200, json={})
+
+    response = _request_through(provider, handler)
+
+    assert response.status_code == 200
+    assert calls == [SERVER_URL]  # no refresh-grant request was made
+
+
+def test_failed_refresh_never_goes_interactive_and_keeps_stored_token(tmp_path):
+    """
+    When the refresh grant is rejected (e.g. invalid_grant after revocation) and
+    the server 401s, the provider must raise instead of opening a browser - and
+    the stored (stale) tokens must survive so the UI can prompt a reconnect.
+    """
+    _seed_store(tmp_path)
+    provider = _provider(tmp_path, token_expiry_time=time.time() - 10)
+
+    authorize_hits = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == TOKEN_ENDPOINT:
+            return httpx.Response(400, json={"error": "invalid_grant"})
+        if "authorize" in str(request.url):
+            authorize_hits.append(str(request.url))  # pragma: no cover - must not happen
+        if str(request.url) == SERVER_URL:
+            return httpx.Response(401)
+        # Discovery lookups (.well-known/...) find nothing.
+        return httpx.Response(404)
+
+    with pytest.raises(Exception):
+        _request_through(provider, handler)
+
+    assert not authorize_hits  # interactive authorization was never attempted
+    entry = _read_store(tmp_path)
+    assert entry["tokens"]["access_token"] == "stale-token"  # store untouched
+    assert entry["tokens"]["refresh_token"] == "refresh-1"
+
+
+def test_silent_refresh_wires_stored_expiry_and_endpoint(tmp_path, monkeypatch):
+    """
+    get_fresh_token's silent refresh hands the provider the persisted expiry
+    (minus the refresh margin) and the token endpoint captured at connect time.
+    """
+    monkeypatch.setenv("NSFLOW_MCP_STORAGE_DIR", str(tmp_path))
+    expires_at = int(time.time()) - 3600
+    _seed_store(tmp_path, expires_at=expires_at)
+
+    captured = {}
+
+    class _CaptureProvider:  # pylint: disable=too-few-public-methods  # minimal test stand-in
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    def _no_probe(**_kwargs):
+        raise RuntimeError("probe stopped by test")
+
+    monkeypatch.setattr(om, "SilentRefreshOAuthProvider", _CaptureProvider)
+    monkeypatch.setattr(om, "streamablehttp_client", _no_probe)
+
+    # Still expired after the (stopped) refresh -> nothing injectable.
+    assert asyncio.run(om.mcp_oauth_manager.get_fresh_token(SERVER_URL)) is None
+
+    assert captured["server_url"] == SERVER_URL
+    assert captured["token_endpoint"] == TOKEN_ENDPOINT
+    assert captured["token_expiry_time"] == expires_at - om.TOKEN_REFRESH_MARGIN_SECONDS
+
+
+def test_set_token_endpoint_persists_and_merges(tmp_path):
+    """set_token_endpoint adds to an existing entry without clobbering tokens."""
+    _seed_store(tmp_path, token_endpoint=None)
+    storage = FileTokenStorage(SERVER_URL, storage_dir=tmp_path)
+
+    asyncio.run(storage.set_token_endpoint(TOKEN_ENDPOINT))
+
+    entry = _read_store(tmp_path)
+    assert entry["token_endpoint"] == TOKEN_ENDPOINT
+    assert entry["tokens"]["access_token"] == "stale-token"
+    assert storage.get_metadata()["token_endpoint"] == TOKEN_ENDPOINT


### PR DESCRIPTION


<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

The MCP SDK cannot refresh tokens loaded from storage: the expiry is never restored, so its proactive refresh never fires, and a 401 starts the full interactive flow. Adapt neuro-san's RefreshTokenOauthProvider (cognizant-ai-lab/neuro-san#683) into SilentRefreshOAuthProvider: restore the persisted expires_at so the SDK's own refresh grant runs before the probe request, answer 401 with a refresh grant instead of a browser redirect, and use the token endpoint captured at connect time instead of the SDK's guessed one.

Fixes #237 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
