### PR TITLE
keep stored refresh token when a refresh response does not rotate it

### DIFF
--- a/nsflow/backend/utils/mcp/mcp_token_storage.py
+++ b/nsflow/backend/utils/mcp/mcp_token_storage.py
@@ -216,7 +216,16 @@ class FileTokenStorage:
             if not isinstance(entry, dict):
                 entry = {}
                 blob[self.server_url] = entry
-            entry["tokens"] = tokens.model_dump(mode="json")
+            new_tokens = tokens.model_dump(mode="json")
+            if not new_tokens.get("refresh_token"):
+                # RFC 6749 section 6: a refresh response MAY omit the refresh
+                # token, meaning "keep using the existing one" (Salesforce and
+                # Google do this; You.com rotates instead). Overwriting with
+                # null would silently make the next refresh impossible.
+                old_tokens = entry.get("tokens")
+                if isinstance(old_tokens, dict) and old_tokens.get("refresh_token"):
+                    new_tokens["refresh_token"] = old_tokens["refresh_token"]
+            entry["tokens"] = new_tokens
             entry["obtained_at"] = int(time.time())
             if tokens.expires_in is not None:
                 entry["expires_at"] = entry["obtained_at"] + int(tokens.expires_in)

--- a/nsflow/backend/utils/mcp/mcp_token_storage.py
+++ b/nsflow/backend/utils/mcp/mcp_token_storage.py
@@ -217,14 +217,17 @@ class FileTokenStorage:
                 entry = {}
                 blob[self.server_url] = entry
             new_tokens = tokens.model_dump(mode="json")
-            if not new_tokens.get("refresh_token"):
+            if "refresh_token" not in new_tokens or new_tokens["refresh_token"] is None:
                 # RFC 6749 section 6: a refresh response MAY omit the refresh
                 # token, meaning "keep using the existing one" (Salesforce and
                 # Google do this; You.com rotates instead). Overwriting with
-                # null would silently make the next refresh impossible.
+                # null would silently make the next refresh impossible. Only an
+                # omitted/None field means "keep" - an explicit empty string is
+                # stored as sent (a server clearing the token), not preserved.
                 old_tokens = entry.get("tokens")
-                if isinstance(old_tokens, dict) and old_tokens.get("refresh_token"):
-                    new_tokens["refresh_token"] = old_tokens["refresh_token"]
+                old_refresh = old_tokens.get("refresh_token") if isinstance(old_tokens, dict) else None
+                if isinstance(old_refresh, str) and old_refresh:
+                    new_tokens["refresh_token"] = old_refresh
             entry["tokens"] = new_tokens
             entry["obtained_at"] = int(time.time())
             if tokens.expires_in is not None:

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -135,6 +135,39 @@ def test_proactive_refresh_fires_before_request(tmp_path):
     assert entry["token_endpoint"] == TOKEN_ENDPOINT  # set_tokens preserved it
 
 
+def test_refresh_without_rotation_keeps_stored_refresh_token(tmp_path):
+    """
+    Providers like Salesforce omit the refresh token from a refresh response,
+    meaning "keep using the existing one" (RFC 6749 section 6). The stored
+    refresh token must survive the overwrite, or the next refresh would find
+    null and force a reconnect.
+    """
+    _seed_store(tmp_path)
+    provider = _provider(tmp_path, token_expiry_time=time.time() - 10)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == TOKEN_ENDPOINT:
+            # No refresh_token in the response - the non-rotating style.
+            return httpx.Response(
+                200, json={"access_token": "fresh-token", "token_type": "Bearer", "expires_in": 3600}
+            )
+        return httpx.Response(200, json={})
+
+    response = _request_through(provider, handler)
+
+    assert response.status_code == 200
+    entry = _read_store(tmp_path)
+    assert entry["tokens"]["access_token"] == "fresh-token"
+    assert entry["tokens"]["refresh_token"] == "refresh-1"  # preserved, not nulled
+    assert entry["expires_at"] > time.time()
+
+    # A second refresh cycle must still be possible with the preserved token.
+    provider2 = _provider(tmp_path, token_expiry_time=time.time() - 10)
+    response2 = _request_through(provider2, handler)
+    assert response2.status_code == 200
+    assert _read_store(tmp_path)["tokens"]["refresh_token"] == "refresh-1"
+
+
 def test_valid_token_is_not_refreshed(tmp_path):
     """A token whose restored expiry is still in the future is used as-is."""
     future = time.time() + 3600

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -32,6 +32,7 @@ import time
 import httpx
 import pytest
 from mcp.shared.auth import OAuthClientMetadata
+from mcp.shared.auth import OAuthToken
 
 import nsflow.backend.utils.mcp.mcp_oauth_manager as om
 from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
@@ -244,6 +245,20 @@ def test_silent_refresh_wires_stored_expiry_and_endpoint(tmp_path, monkeypatch):
     assert captured["server_url"] == SERVER_URL
     assert captured["token_endpoint"] == TOKEN_ENDPOINT
     assert captured["token_expiry_time"] == expires_at - om.TOKEN_REFRESH_MARGIN_SECONDS
+
+
+def test_set_tokens_stores_explicit_empty_refresh_token(tmp_path):
+    """
+    Only an omitted/None refresh_token means "keep using the existing one"
+    (RFC 6749 section 6). An explicit empty string is a server clearing the
+    token and must be stored as sent, not swapped for the previous value.
+    """
+    _seed_store(tmp_path, token_endpoint=None)
+    storage = FileTokenStorage(SERVER_URL, storage_dir=tmp_path)
+
+    asyncio.run(storage.set_tokens(OAuthToken(access_token="fresh-token", refresh_token="")))
+
+    assert _read_store(tmp_path)["tokens"]["refresh_token"] == ""
 
 
 def test_set_token_endpoint_persists_and_merges(tmp_path):


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

RFC 6749 section 6 allows the token endpoint to omit the refresh token from a refresh response, meaning "keep using the existing one" (Salesforce and Google do this; You.com rotates). _sync_set_tokens replaced the entry's tokens wholesale, nulling the stored refresh_token after the first silent refresh and forcing a reconnect at the next expiry. Preserve the existing refresh token when the incoming token set has none; rotating providers and connections without refresh tokens are unaffected.

Fixes #239 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
