### PR TITLE
Fix MCP reconnect: force the 401 challenge and re-register DCR clients

### DIFF
--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -60,10 +60,10 @@ disconnect — that deletes the stored credentials.
 
 A connection whose token expired and could not be silently renewed (e.g. the
 provider revoked the grant) shows a **Reconnect required** chip instead, with a
-reconnect button that re-runs the sign-in — no credentials to re-enter, the
-stored client registration is reused. Until reconnected it behaves like a
-disconnected server: nothing is injected, and selecting a network that needs it
-prompts you.
+reconnect button that re-runs the sign-in — no credentials to re-enter:
+pre-registered credentials are reused, and DCR servers register a fresh client
+automatically. Until reconnected it behaves like a disconnected server: nothing
+is injected, and selecting a network that needs it prompts you.
 
 ### Pre-registered servers (Client ID/Secret)
 

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -69,6 +69,7 @@ except ImportError:  # pragma: no cover - exercised only on older/newer SDK layo
 from nsflow.backend.utils.mcp.mcp_refresh_provider import ReauthRequiredError
 from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
 from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
+from nsflow.backend.utils.mcp.mcp_token_storage import ReauthFlowTokenStorage
 from nsflow.backend.utils.mcp.mcp_token_storage import _stored_expiry
 
 logger = logging.getLogger(__name__)
@@ -310,7 +311,10 @@ class MCPOAuthManager:
         auth_method = "client_secret_post" if client_secret else "none"
 
         if client_id:
-            # Pre-seed the dynamic-registration result so the SDK skips DCR.
+            # Pre-seed the user-supplied credentials so the SDK skips DCR.
+            # manual=True lets a later reconnect reuse them (the user shouldn't
+            # re-enter credentials), unlike DCR-issued registrations which are
+            # re-registered on reconnect.
             await FileTokenStorage(server_url).set_client_info(
                 OAuthClientInformationFull(
                     client_id=client_id,
@@ -321,7 +325,8 @@ class MCPOAuthManager:
                     response_types=["code"],
                     token_endpoint_auth_method=auth_method,
                     scope=scope,
-                )
+                ),
+                manual=True,
             )
 
         flow = PendingFlow(flow_id=uuid.uuid4().hex, server_url=server_url, created_at=time.time())
@@ -394,7 +399,11 @@ class MCPOAuthManager:
             provider = OAuthClientProvider(
                 server_url=flow.server_url,
                 client_metadata=self._build_client_metadata(scope, auth_method, redirect_uri),
-                storage=FileTokenStorage(flow.server_url),
+                # ReauthFlowTokenStorage hides any stored (dead) tokens: on a
+                # reconnect the stock provider would otherwise present the old
+                # Bearer token, a tolerant server answers 200, and the flow
+                # aborts with "no 401 challenge was returned".
+                storage=ReauthFlowTokenStorage(FileTokenStorage(flow.server_url)),
                 redirect_handler=self._make_redirect_handler(flow),
                 callback_handler=self._make_callback_handler(flow),
             )

--- a/nsflow/backend/utils/mcp/mcp_token_storage.py
+++ b/nsflow/backend/utils/mcp/mcp_token_storage.py
@@ -200,14 +200,22 @@ class FileTokenStorage:
             logger.warning("Ignoring unparsable stored MCP tokens for %s: %s", self.server_url, exc)
             return None
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
-        """Persist OAuth tokens for this server to the token store."""
+    async def set_tokens(self, tokens: OAuthToken, preserve_refresh_token: bool = True) -> None:
+        """
+        Persist OAuth tokens for this server to the token store.
+
+        ``preserve_refresh_token`` keeps the stored refresh token when the new
+        payload omits one (RFC 6749 section 6 refresh-response semantics; the
+        SDK calls this with a single argument). Interactive (re)auth flows pass
+        False: their write is a fresh grant - possibly for a freshly registered
+        client - so the old refresh token must not outlive it.
+        """
         # asyncio.Lock serializes coroutines in-process; the blocking
         # read-modify-write (and the cross-process fcntl lock) runs in a thread.
         async with self._lock:
-            await asyncio.to_thread(self._sync_set_tokens, tokens)
+            await asyncio.to_thread(self._sync_set_tokens, tokens, preserve_refresh_token)
 
-    def _sync_set_tokens(self, tokens: OAuthToken) -> None:
+    def _sync_set_tokens(self, tokens: OAuthToken, preserve_refresh_token: bool = True) -> None:
         with _interprocess_lock(self._lock_path):
             blob = self._load_file()
             entry = blob.get(self.server_url)
@@ -217,7 +225,7 @@ class FileTokenStorage:
                 entry = {}
                 blob[self.server_url] = entry
             new_tokens = tokens.model_dump(mode="json")
-            if "refresh_token" not in new_tokens or new_tokens["refresh_token"] is None:
+            if preserve_refresh_token and ("refresh_token" not in new_tokens or new_tokens["refresh_token"] is None):
                 # RFC 6749 section 6: a refresh response MAY omit the refresh
                 # token, meaning "keep using the existing one" (Salesforce and
                 # Google do this; You.com rotates instead). Overwriting with
@@ -563,19 +571,37 @@ class ReauthFlowTokenStorage:
         return None
 
     async def set_tokens(self, tokens: OAuthToken) -> None:
-        """Persist the newly exchanged tokens to the real store."""
-        await self._inner.set_tokens(tokens)
+        """
+        Persist the newly exchanged tokens to the real store.
+
+        ``preserve_refresh_token=False``: the RFC 6749 keep-the-old-refresh-token
+        rule applies to *refresh* responses, not to this fresh grant. The stored
+        refresh token is the one whose refresh just definitively failed - and
+        after a DCR re-registration it belongs to the abandoned client - so
+        grafting it onto these tokens would only set up an ``invalid_grant`` at
+        the first silent refresh.
+        """
+        await self._inner.set_tokens(tokens, preserve_refresh_token=False)
 
     async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
         """Reuse a user-supplied registration; hide a DCR-issued one (re-register)."""
         entry = await asyncio.to_thread(self._inner.get_metadata)
         manual = entry.get("client_info_manual")
         if manual is None:
-            # Legacy entry written before the flag existed: DCR responses carry
-            # the RFC 7591 client_id_issued_at metadata, while our manual
-            # pre-seed never set it - use that to classify.
+            # Legacy entry written before the flag existed. Classify by RFC 7591
+            # registration-response metadata our manual pre-seed never writes:
+            # client_id_issued_at, or client_secret_expires_at (required whenever
+            # DCR issues a secret; 0 is meaningful - "never expires" - hence the
+            # presence checks, not truthiness). Both fields are OPTIONAL for a
+            # DCR server to send, so a legacy DCR entry carrying neither still
+            # classifies as manual and reuses the old client; if that provider
+            # no longer honors it, recovery is disconnect + reconnect. Accepted
+            # residual: only pre-flag stores, and only providers that both omit
+            # the metadata and reject their own old clients.
             raw = entry.get("client_info")
-            manual = isinstance(raw, dict) and not raw.get("client_id_issued_at")
+            manual = isinstance(raw, dict) and all(
+                raw.get(field) is None for field in ("client_id_issued_at", "client_secret_expires_at")
+            )
         if not manual:
             return None
         return await self._inner.get_client_info()

--- a/nsflow/backend/utils/mcp/mcp_token_storage.py
+++ b/nsflow/backend/utils/mcp/mcp_token_storage.py
@@ -252,12 +252,22 @@ class FileTokenStorage:
             logger.warning("Ignoring unparsable stored MCP client_info for %s: %s", self.server_url, exc)
             return None
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
-        """Persist OAuth client info for this server to the token store."""
-        async with self._lock:
-            await asyncio.to_thread(self._sync_set_client_info, client_info)
+    async def set_client_info(self, client_info: OAuthClientInformationFull, manual: bool = False) -> None:
+        """
+        Persist OAuth client info for this server to the token store.
 
-    def _sync_set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        ``manual=True`` records that the credentials were supplied by the user
+        (a pre-registered server without DCR); the default False means a
+        DCR-issued registration (the SDK calls this with one argument). The
+        distinction decides whether a later reconnect may reuse the
+        registration (manual: yes - the user shouldn't re-enter credentials)
+        or must register a fresh client (DCR: reuse can wedge the flow, see
+        ReauthFlowTokenStorage.get_client_info).
+        """
+        async with self._lock:
+            await asyncio.to_thread(self._sync_set_client_info, client_info, manual)
+
+    def _sync_set_client_info(self, client_info: OAuthClientInformationFull, manual: bool = False) -> None:
         with _interprocess_lock(self._lock_path):
             blob = self._load_file()
             entry = blob.get(self.server_url)
@@ -265,6 +275,7 @@ class FileTokenStorage:
                 entry = {}
                 blob[self.server_url] = entry
             entry["client_info"] = client_info.model_dump(mode="json")
+            entry["client_info_manual"] = bool(manual)
             self._write_file(blob)
 
     async def set_token_endpoint(self, token_endpoint: str) -> None:
@@ -519,3 +530,56 @@ class FileTokenStorage:
         except OSError:
             # Best effort (e.g. on Windows); not fatal.
             pass
+
+
+class ReauthFlowTokenStorage:
+    """
+    ``TokenStorage`` view used while a (re)authorization flow is running.
+
+    Reads of stored tokens return None so the flow's probe request goes out
+    unauthenticated and the server's 401 challenge starts a fresh
+    authorization. A flow only ever runs when the stored tokens are unusable -
+    expired beyond refresh, or marked ``needs_reauth`` (``/start``
+    short-circuits with ``already_connected`` otherwise) - and presenting such
+    a token can draw a ``200`` from tolerant servers (e.g. You.com accepts
+    stale tokens), in which case no 401 ever fires and the flow aborts with
+    "no 401 challenge was returned".
+
+    Client-info reads pass through only for *user-supplied* registrations
+    (pre-registered servers without DCR - the user shouldn't have to re-enter
+    credentials). A DCR-issued registration is hidden so the SDK registers a
+    fresh client: DCR is free, and providers may no longer honor the old
+    dynamic client (You.com's consent page still accepts it, but its
+    post-approval step hangs and never redirects back). ALL writes pass
+    through, so the completed token exchange persists normally - which also
+    clears any ``needs_reauth`` marker.
+    """
+
+    def __init__(self, inner: FileTokenStorage):
+        self._inner = inner
+
+    async def get_tokens(self) -> Optional[OAuthToken]:
+        """Hide stored (unusable) tokens so the probe triggers the 401 challenge."""
+        return None
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        """Persist the newly exchanged tokens to the real store."""
+        await self._inner.set_tokens(tokens)
+
+    async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
+        """Reuse a user-supplied registration; hide a DCR-issued one (re-register)."""
+        entry = await asyncio.to_thread(self._inner.get_metadata)
+        manual = entry.get("client_info_manual")
+        if manual is None:
+            # Legacy entry written before the flag existed: DCR responses carry
+            # the RFC 7591 client_id_issued_at metadata, while our manual
+            # pre-seed never set it - use that to classify.
+            raw = entry.get("client_info")
+            manual = isinstance(raw, dict) and not raw.get("client_id_issued_at")
+        if not manual:
+            return None
+        return await self._inner.get_client_info()
+
+    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        """Persist a (re)registration to the real store (DCR-issued: not manual)."""
+        await self._inner.set_client_info(client_info)

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -382,20 +382,50 @@ def test_reconnect_hides_dcr_client_info_but_reuses_manual(tmp_path):
     assert asyncio.run(wrapped.get_client_info()).client_id == "client-1"
 
 
-def test_reconnect_classifies_legacy_client_info_by_issued_at(tmp_path):
+def test_reconnect_classifies_legacy_client_info_by_registration_metadata(tmp_path):
     """
-    Entries written before the manual flag existed are classified by the
-    RFC 7591 ``client_id_issued_at`` metadata: DCR responses carry it, our
-    manual pre-seed never did.
+    Entries written before the manual flag existed are classified by RFC 7591
+    registration-response metadata - ``client_id_issued_at`` or
+    ``client_secret_expires_at`` - which DCR responses may carry and our manual
+    pre-seed never wrote. Presence counts, not truthiness: 0 is a meaningful
+    DCR value for both fields ("never expires").
     """
-    _seed_store(tmp_path)  # no flag, no client_id_issued_at -> manual, reused
+    _seed_store(tmp_path)  # no flag, no registration metadata -> manual, reused
     wrapped = ReauthFlowTokenStorage(FileTokenStorage(SERVER_URL, storage_dir=tmp_path))
+
+    def _set_client_info_field(field, value):
+        blob = json.loads((tmp_path / "tokens.json").read_text(encoding="utf-8"))
+        blob[SERVER_URL]["client_info"][field] = value
+        (tmp_path / "tokens.json").write_text(json.dumps(blob), encoding="utf-8")
+
     assert asyncio.run(wrapped.get_client_info()).client_id == "client-1"
 
-    blob = json.loads((tmp_path / "tokens.json").read_text(encoding="utf-8"))
-    blob[SERVER_URL]["client_info"]["client_id_issued_at"] = 1784333961  # DCR fingerprint
-    (tmp_path / "tokens.json").write_text(json.dumps(blob), encoding="utf-8")
+    _set_client_info_field("client_id_issued_at", 1784333961)  # DCR fingerprint
     assert asyncio.run(wrapped.get_client_info()) is None
+
+    _set_client_info_field("client_id_issued_at", None)  # ambiguous again...
+    _set_client_info_field("client_secret_expires_at", 0)  # ...but DCR issued a secret
+    assert asyncio.run(wrapped.get_client_info()) is None
+
+
+def test_reconnect_exchange_does_not_graft_old_refresh_token(tmp_path):
+    """
+    A (re)connect flow's token write is a fresh grant - possibly for a freshly
+    registered DCR client - so an exchange response that omits the refresh
+    token must NOT inherit the stored one (its refresh just definitively
+    failed, and it may belong to the abandoned client). The RFC 6749
+    keep-if-omitted rule still applies to writes through the plain storage
+    (refresh-grant responses).
+    """
+    _seed_store(tmp_path, needs_reauth=True)  # stored refresh_token "refresh-1"
+    inner = FileTokenStorage(SERVER_URL, storage_dir=tmp_path)
+
+    asyncio.run(ReauthFlowTokenStorage(inner).set_tokens(OAuthToken(access_token="new-token", expires_in=3600)))
+    assert _read_store(tmp_path)["tokens"].get("refresh_token") is None
+
+    _seed_store(tmp_path)  # re-seed: a refresh-grant write still preserves it
+    asyncio.run(inner.set_tokens(OAuthToken(access_token="new-token-2", expires_in=3600)))
+    assert _read_store(tmp_path)["tokens"]["refresh_token"] == "refresh-1"
 
 
 def test_set_client_info_records_manual_flag(tmp_path):

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -32,12 +32,14 @@ import time
 import httpx
 import pytest
 from mcp.client.auth.exceptions import OAuthTokenError
+from mcp.shared.auth import OAuthClientInformationFull
 from mcp.shared.auth import OAuthClientMetadata
 from mcp.shared.auth import OAuthToken
 
 import nsflow.backend.utils.mcp.mcp_oauth_manager as om
 from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
 from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
+from nsflow.backend.utils.mcp.mcp_token_storage import ReauthFlowTokenStorage
 
 SERVER_URL = "https://mcp.example.com/mcp"
 TOKEN_ENDPOINT = "https://auth.example.com/oauth/token"
@@ -321,6 +323,91 @@ def test_concurrent_get_fresh_token_refreshes_once(tmp_path, monkeypatch):
 
     assert asyncio.run(both()) == ["Bearer fresh-token", "Bearer fresh-token"]
     assert len(calls) == 1  # the second caller reused the first one's result
+
+
+def test_reconnect_flow_probes_unauthenticated(tmp_path, monkeypatch):
+    """
+    Regression: a (re)connect flow over an entry with stored tokens must NOT
+    present the old Bearer token in its probe. Tolerant servers (You.com)
+    answer 200 to a stale token, so no 401 challenge would ever start the
+    authorization and the flow would abort with "no 401 challenge was
+    returned" - the exact failure seen when reconnecting a marked connection.
+    """
+    monkeypatch.setenv("NSFLOW_MCP_STORAGE_DIR", str(tmp_path))
+    _seed_store(tmp_path, needs_reauth=True)
+    captured = {}
+
+    def _capture_probe(**kwargs):
+        captured["auth"] = kwargs.get("auth")
+        raise RuntimeError("stop probe")
+
+    monkeypatch.setattr(om, "streamablehttp_client", _capture_probe)
+    flow = om.PendingFlow(flow_id="f2", server_url=SERVER_URL, created_at=0.0)
+
+    asyncio.run(om.mcp_oauth_manager._run_oauth_flow(flow, None))  # pylint: disable=protected-access  # exercising a private method under test
+
+    storage = captured["auth"].context.storage
+    # The flow's storage view hides the stored (dead) tokens so the probe goes
+    # out unauthenticated and draws the 401 challenge...
+    assert asyncio.run(storage.get_tokens()) is None
+    # ...but reuses the stored user-supplied credentials (no re-entering them;
+    # the seeded entry has no client_id_issued_at, so it classifies as manual)...
+    assert asyncio.run(storage.get_client_info()).client_id == "client-1"
+    # ...and writes pass through to disk, clearing the marker on success.
+    asyncio.run(storage.set_tokens(OAuthToken(access_token="new-token", expires_in=3600, refresh_token="r3")))
+    entry = _read_store(tmp_path)
+    assert entry["tokens"]["access_token"] == "new-token"
+    assert "needs_reauth" not in entry
+
+
+def test_reconnect_hides_dcr_client_info_but_reuses_manual(tmp_path):
+    """
+    A DCR-issued registration is hidden from a (re)connect flow so the SDK
+    registers a fresh client - providers may no longer honor the old dynamic
+    client (You.com renders consent for it, then hangs after approval and never
+    redirects back). User-supplied credentials are reused: the user must not
+    have to re-enter them, and the server has no DCR to fall back on.
+    """
+    _seed_store(tmp_path)
+    wrapped = ReauthFlowTokenStorage(FileTokenStorage(SERVER_URL, storage_dir=tmp_path))
+
+    def _set_flag(manual):
+        blob = json.loads((tmp_path / "tokens.json").read_text(encoding="utf-8"))
+        blob[SERVER_URL]["client_info_manual"] = manual
+        (tmp_path / "tokens.json").write_text(json.dumps(blob), encoding="utf-8")
+
+    _set_flag(False)  # DCR-issued -> hidden, forcing a fresh registration
+    assert asyncio.run(wrapped.get_client_info()) is None
+    _set_flag(True)  # user-supplied -> reused
+    assert asyncio.run(wrapped.get_client_info()).client_id == "client-1"
+
+
+def test_reconnect_classifies_legacy_client_info_by_issued_at(tmp_path):
+    """
+    Entries written before the manual flag existed are classified by the
+    RFC 7591 ``client_id_issued_at`` metadata: DCR responses carry it, our
+    manual pre-seed never did.
+    """
+    _seed_store(tmp_path)  # no flag, no client_id_issued_at -> manual, reused
+    wrapped = ReauthFlowTokenStorage(FileTokenStorage(SERVER_URL, storage_dir=tmp_path))
+    assert asyncio.run(wrapped.get_client_info()).client_id == "client-1"
+
+    blob = json.loads((tmp_path / "tokens.json").read_text(encoding="utf-8"))
+    blob[SERVER_URL]["client_info"]["client_id_issued_at"] = 1784333961  # DCR fingerprint
+    (tmp_path / "tokens.json").write_text(json.dumps(blob), encoding="utf-8")
+    assert asyncio.run(wrapped.get_client_info()) is None
+
+
+def test_set_client_info_records_manual_flag(tmp_path):
+    """set_client_info persists whether the registration was user-supplied."""
+    storage = FileTokenStorage(SERVER_URL, storage_dir=tmp_path)
+    info = OAuthClientInformationFull(client_id="cid", redirect_uris=None)
+
+    asyncio.run(storage.set_client_info(info))  # the SDK's DCR write path
+    assert _read_store(tmp_path)["client_info_manual"] is False
+
+    asyncio.run(storage.set_client_info(info, manual=True))  # the /start pre-seed path
+    assert _read_store(tmp_path)["client_info_manual"] is True
 
 
 def test_cleanup_failed_preseed_keeps_token_bearing_entry(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #243

## What

Reconnecting an expired MCP connection failed in two ways: the flow presented the old (dead) Bearer token, so tolerant servers (You.com) answered `200` and the 401 challenge that starts authorization never fired ("no 401 challenge was returned"); and when the flow did start, it reused the stored DCR-issued client registration, which some providers no longer honor — You.com accepts the consent but hangs post-approval and the callback never arrives.

## How

- **`ReauthFlowTokenStorage`** (new, in `mcp_token_storage.py`): a `TokenStorage` view handed to the SDK's `OAuthClientProvider` during (re)connect flows only.
  - `get_tokens()` returns `None` → the probe goes out unauthenticated → the 401 challenge always fires. Safe because a flow only ever runs over unusable tokens (`/start` short-circuits with `already_connected` otherwise).
  - `get_client_info()` hides DCR-issued registrations → the SDK registers a fresh client. **User-supplied credentials pass through** — pre-registered servers (GitHub, Salesforce, …) never require re-typing the Client ID/Secret.
  - All writes pass through, so the completed exchange persists normally and clears the `needs_reauth` marker.
- **`client_info_manual` flag**: `set_client_info(..., manual=...)` records whether a registration was user-supplied (the `/start` pre-seed) or DCR-issued (the SDK's single-arg call). Entries written before the flag are classified by RFC 7591 registration-response metadata (`client_id_issued_at` / `client_secret_expires_at`, presence-checked — `0` is a meaningful DCR value).
- **No refresh-token grafting on fresh grants**: `set_tokens` gains `preserve_refresh_token` (default `True`, SDK-compatible). Reconnect writes pass `False` so an exchange response that omits `refresh_token` doesn't inherit the stored one — that token's refresh just definitively failed, and after a DCR re-registration it belongs to the abandoned client (guaranteed `invalid_grant` at the first silent refresh). RFC 6749 §6 keep-if-omitted still applies to refresh-grant responses.

## Testing

- 114/114 tests pass; ruff clean; pylint 10.00/10 (source + tests).
- New tests: unauthenticated reconnect probe over a marked entry (regression for the 401 suppression), DCR-hidden vs manual-reused classification (flag, legacy fingerprint incl. `client_secret_expires_at: 0`), manual-flag persistence for both write paths, no-graft on reconnect writes vs preservation on plain writes.
- Verified live against You.com: reconnect of a marked connection now completes end-to-end (fresh DCR registration, tokens stored, marker cleared).

