### PR TITLE
support auth-optional MCP servers via a synthetic 401 challenge

### DIFF
--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -42,11 +42,12 @@ Relevant code: [`mcp_oauth_manager.py`](../nsflow/backend/utils/mcp/mcp_oauth_ma
 Open the **Connectors** tab. You'll see:
 
 - **Quick Connect** — curated servers that support DCR. One click, nothing to
-  enter: a popup opens, you approve, done. (You.com, Linear, Notion, Sentry,
-  Atlassian, Stripe, PayPal, Intercom, Zapier, Postman.)
+  enter: a popup opens, you approve, done. (Atlassian, Hugging Face, Intercom,
+  Linear, Notion, PayPal, Postman, Sentry, Stripe, You.com, Zapier.)
 - **Client ID/Secret** — curated servers that do **not** support DCR, so you must
   register an OAuth app at the provider and paste its Client ID (and Secret, if
-  it's a confidential client). (GitHub, Asana, Slack.)
+  it's a confidential client). (Asana, GitHub, Gmail, Google Calendar, Google
+  Drive, Google Maps, Salesforce, Slack.)
 - **Add server** — connect any OAuth-protected MCP server by URL. Supply a Client
   ID/Secret only if the server has no DCR.
 
@@ -79,6 +80,34 @@ the provider, then paste its credentials into nsflow:
    click **Connect**. A popup opens for you to approve.
 
 ---
+
+### Auth-optional servers (no 401 challenge)
+
+Some MCP servers (e.g. **Google Maps**, **Hugging Face**) answer an
+unauthenticated request with `200` and only require a token when you actually
+call a tool. The standard OAuth flow can't start from that: the SDK begins
+authorization only when the server returns a `401` challenge, which never comes.
+
+nsflow handles these automatically. When the connect probe succeeds without
+authenticating, the backend looks for the server's **protected-resource
+metadata** (RFC 9728, at `/.well-known/oauth-protected-resource`). If it's
+published — the signal that the server does support OAuth — nsflow retries the
+probe with a **synthetic 401 challenge** pointing at that metadata, and the
+normal flow (metadata fetch, client registration or your pre-registered
+credentials, authorization, token exchange) runs from there unchanged. Scopes
+come from the metadata, so you don't set them.
+
+If a server serves anonymous requests and publishes **no** such metadata, it
+either needs no auth (nothing to connect) or uses a scheme nsflow can't
+bootstrap (e.g. API keys); the connect attempt reports that instead of the
+generic "no 401 challenge" error.
+
+> **Google (Maps, and Drive/Gmail/Calendar):** Google has no DCR, so register an
+> OAuth client in the Google Cloud Console (Client ID/Secret), enable the
+> relevant API, and add its scope to the consent screen. nsflow appends
+> `access_type=offline` and `prompt=consent` to the authorization request so
+> Google returns a **refresh token** (it omits one otherwise), which is what
+> keeps the connection alive without re-authorizing.
 
 ## The redirect / callback URI
 

--- a/nsflow/backend/api/v1/mcp_oauth_endpoints.py
+++ b/nsflow/backend/api/v1/mcp_oauth_endpoints.py
@@ -26,6 +26,7 @@ import asyncio
 import html
 import json
 import logging
+from typing import Dict
 from typing import Optional
 
 from fastapi import APIRouter
@@ -53,6 +54,10 @@ class StartFlowRequest(BaseModel):
     # registration (e.g. GitHub). client_secret makes it a confidential client.
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
+    # Optional provider-specific query params appended to the authorization URL
+    # (e.g. Google needs access_type=offline & prompt=consent to issue a
+    # refresh token). Supplied by the connector catalog or the user.
+    extra_authorize_params: Optional[Dict[str, str]] = None
 
 
 def _callback_html(status: str, server_url: str, message: str = "") -> str:
@@ -126,6 +131,7 @@ async def start_oauth_flow(body: StartFlowRequest, request: Request):
             client_id=(body.client_id or "").strip() or None,
             client_secret=(body.client_secret or "").strip() or None,
             redirect_uri=redirect_uri,
+            extra_authorize_params=body.extra_authorize_params or None,
         )
     except TimeoutError as exc:
         logger.warning("MCP OAuth flow for %s timed out building the authorization URL.", server_url)

--- a/nsflow/backend/utils/mcp/mcp_http.py
+++ b/nsflow/backend/utils/mcp/mcp_http.py
@@ -190,7 +190,14 @@ async def _discover_protected_resource_metadata(server_url: str) -> Optional[str
             data = response.json()
         except ValueError:
             return None
-        return url if isinstance(data, dict) and data.get("authorization_servers") else None
+        if not isinstance(data, dict):
+            return None
+        # RFC 9728: authorization_servers is a non-empty JSON array of issuer
+        # URLs. Require exactly that - a truthy string/object here would be a
+        # malformed document, and treating it as OAuth-capable would wrongly
+        # send the flow down the synthetic-401 path into a confusing failure.
+        servers = data.get("authorization_servers")
+        return url if isinstance(servers, list) and servers else None
 
     async with _mcp_http_client_factory() as client:
         # Probe the well-known forms concurrently (worst case one timeout, not

--- a/nsflow/backend/utils/mcp/mcp_http.py
+++ b/nsflow/backend/utils/mcp/mcp_http.py
@@ -1,0 +1,200 @@
+# Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+httpx-level helpers for the MCP OAuth flow.
+
+Split out of ``mcp_oauth_manager`` so that module stays focused on flow
+orchestration: this one owns how the underlying httpx client is built and, for
+auth-optional servers, how a synthetic ``401`` challenge is injected so the
+SDK's 401-driven OAuth flow can start. Depends only on httpx and the MCP SDK
+(never on ``mcp_oauth_manager``), so it is import-cycle-free.
+"""
+
+import asyncio
+from typing import Optional
+from urllib.parse import urlsplit
+
+import httpx
+
+# create_mcp_http_client currently lives in the private mcp.shared._httpx_utils
+# (that is where the SDK's own client modules import it from as of mcp 1.27.x).
+# Prefer a public path if a future SDK promotes it (underscore -> public is a
+# common deprecation path), and fall back to the private module for current and
+# older versions.
+try:
+    from mcp.shared.httpx_utils import create_mcp_http_client  # type: ignore
+except ImportError:  # pragma: no cover - exercised only on older/newer SDK layouts
+    from mcp.shared._httpx_utils import create_mcp_http_client
+
+# RFC 9728 well-known URL builder. The SDK uses this to locate a server's
+# protected-resource metadata after a 401 challenge; we reuse it to probe for
+# that metadata on servers that never send the challenge (see
+# _discover_protected_resource_metadata). Local fallback in case a future SDK
+# moves the helper.
+try:
+    from mcp.client.auth.utils import build_protected_resource_metadata_discovery_urls
+except ImportError:  # pragma: no cover - exercised only on older/newer SDK layouts
+
+    def build_protected_resource_metadata_discovery_urls(www_auth_url, server_url):
+        """Fallback RFC 9728 discovery URL builder: path-inserted, then root."""
+        del www_auth_url  # only used by the SDK's 401-challenge path
+        parsed = urlsplit(server_url)
+        base = f"{parsed.scheme}://{parsed.netloc}"
+        urls = []
+        if parsed.path and parsed.path != "/":
+            urls.append(f"{base}/.well-known/oauth-protected-resource{parsed.path}")
+        urls.append(f"{base}/.well-known/oauth-protected-resource")
+        return urls
+
+
+async def _force_json_accept_on_oauth_requests(request: httpx.Request) -> None:
+    """
+    httpx request hook: force ``Accept: application/json`` on OAuth token/refresh
+    requests. Some authorization servers (notably GitHub's
+    ``…/login/oauth/access_token``) return a form-encoded body unless the client
+    explicitly asks for JSON, which then fails the SDK's JSON token parsing.
+
+    These OAuth requests are form-encoded (``application/x-www-form-urlencoded``),
+    which uniquely distinguishes them from MCP streamable-HTTP JSON-RPC POSTs
+    (``application/json``, which must keep their ``application/json,
+    text/event-stream`` Accept header), so this never touches MCP traffic.
+    """
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith("application/x-www-form-urlencoded"):
+        request.headers["Accept"] = "application/json"
+
+
+def _mcp_http_client_factory(headers=None, timeout=None, auth=None, **kwargs) -> httpx.AsyncClient:
+    """
+    MCP http client factory that adds the OAuth Accept-JSON request hook.
+
+    Accepts and forwards any extra keyword arguments so the factory stays
+    compatible if a future MCP SDK passes additional parameters to
+    ``httpx_client_factory`` (a common forward-compat pattern). Forwarding rather
+    than dropping them means new client settings (proxy, TLS verify, etc.) still
+    reach the underlying client - and since we wrap the SDK's own
+    ``create_mcp_http_client``, anything it passes is something it accepts.
+    """
+    client = create_mcp_http_client(headers=headers, timeout=timeout, auth=auth, **kwargs)
+    client.event_hooks.setdefault("request", []).append(_force_json_accept_on_oauth_requests)
+    return client
+
+
+class _SyntheticChallengeTransport(httpx.AsyncBaseTransport):
+    """
+    Transport wrapper that answers the FIRST request with a synthetic
+    ``401 Unauthorized`` whose ``WWW-Authenticate`` challenge points at the
+    server's RFC 9728 protected-resource metadata; every later request passes
+    through to the real transport.
+
+    Auth-optional MCP servers (e.g. Google Maps, Hugging Face) answer an
+    unauthenticated ``initialize`` with 200 and only reject tool calls - so the
+    SDK's ``OAuthClientProvider``, which starts its OAuth flow exclusively from
+    a 401 response, never authorizes. When such a server still publishes
+    protected-resource metadata, this shim fakes the missing trigger; from that
+    401 onward the stock SDK flow runs unmodified (metadata fetch, client
+    registration, authorization, token exchange) over the wrapped transport.
+    """
+
+    def __init__(self, inner: httpx.AsyncBaseTransport, resource_metadata_url: str, fired: Optional[list] = None):
+        self._inner = inner
+        self._resource_metadata_url = resource_metadata_url
+        # One-shot gate. When one client wraps several transports (its default
+        # plus one per proxy mount), they must share the gate so exactly one
+        # request across the whole client is challenged. A single-element list is
+        # a tiny shared mutable cell; a fresh one => standalone (one wrapper).
+        self._fired = fired if fired is not None else [False]
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        # No await between the read and the set, so this is atomic under asyncio:
+        # concurrent requests (e.g. the POST and the GET SSE stream) can't both
+        # see False, and exactly one 401 is emitted.
+        if not self._fired[0]:
+            self._fired[0] = True
+            challenge = f'Bearer resource_metadata="{self._resource_metadata_url}"'
+            return httpx.Response(401, headers={"WWW-Authenticate": challenge}, request=request)
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def _challenge_http_client_factory(resource_metadata_url: str):
+    """
+    Build an ``httpx_client_factory`` whose clients 401 the first request with
+    a synthetic challenge pointing at ``resource_metadata_url`` (see
+    ``_SyntheticChallengeTransport``).
+    """
+
+    def _factory(headers=None, timeout=None, auth=None, **kwargs) -> httpx.AsyncClient:
+        client = _mcp_http_client_factory(headers=headers, timeout=timeout, auth=auth, **kwargs)
+        # create_mcp_http_client exposes no transport parameter, so wrap the
+        # built client's transports. httpx routes via _mounts (env-proxy
+        # transports) BEFORE falling back to _transport, so wrapping only
+        # _transport would miss every request behind an HTTPS/ALL proxy - wrap
+        # the default AND each mount, sharing one gate so still only one 401
+        # fires whichever transport httpx picks. _transport/_mounts are stable
+        # across httpx releases.
+        fired: list = [False]
+
+        def _wrap(transport):
+            if transport is None:  # a None mount means "use the default transport"
+                return None
+            return _SyntheticChallengeTransport(transport, resource_metadata_url, fired)
+
+        client._transport = _wrap(client._transport)  # pylint: disable=protected-access
+        client._mounts = {  # pylint: disable=protected-access
+            pattern: _wrap(transport)
+            for pattern, transport in client._mounts.items()  # pylint: disable=protected-access
+        }
+        return client
+
+    return _factory
+
+
+async def _discover_protected_resource_metadata(server_url: str) -> Optional[str]:
+    """
+    Return the URL of the server's RFC 9728 protected-resource metadata, or
+    None if it publishes none.
+
+    Probes the same well-known locations the SDK derives from a 401 challenge
+    (path-inserted form first, then root). Used for auth-optional servers that
+    never send that challenge: a published metadata document with an
+    ``authorization_servers`` list is the signal that the server does take
+    OAuth, and its URL seeds the synthetic challenge.
+    """
+    urls = build_protected_resource_metadata_discovery_urls(None, server_url)
+
+    async def _usable(client, url):
+        """Return url if it serves PRM naming an authorization server, else None."""
+        try:
+            response = await client.get(url, timeout=10)
+        except httpx.HTTPError:
+            return None
+        if response.status_code != 200:
+            return None
+        try:
+            data = response.json()
+        except ValueError:
+            return None
+        return url if isinstance(data, dict) and data.get("authorization_servers") else None
+
+    async with _mcp_http_client_factory() as client:
+        # Probe the well-known forms concurrently (worst case one timeout, not
+        # their sum), but keep RFC 9728 preference order: the path-inserted form
+        # wins over root when both resolve.
+        results = await asyncio.gather(*(_usable(client, url) for url in urls))
+    return next((url for url in results if url), None)

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -44,10 +44,10 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 from urllib.parse import parse_qs
+from urllib.parse import urlencode
 from urllib.parse import urlparse
 from urllib.parse import urlsplit
 
-import httpx
 from mcp import ClientSession
 from mcp.client.auth import OAuthClientProvider
 from mcp.client.auth.exceptions import OAuthTokenError
@@ -56,16 +56,9 @@ from mcp.shared.auth import OAuthClientInformationFull
 from mcp.shared.auth import OAuthClientMetadata
 from mcp.shared.auth import OAuthToken
 
-# create_mcp_http_client currently lives in the private mcp.shared._httpx_utils
-# (that is where the SDK's own client modules import it from as of mcp 1.27.x).
-# Prefer a public path if a future SDK promotes it (underscore -> public is a
-# common deprecation path), and fall back to the private module for current and
-# older versions.
-try:
-    from mcp.shared.httpx_utils import create_mcp_http_client  # type: ignore
-except ImportError:  # pragma: no cover - exercised only on older/newer SDK layouts
-    from mcp.shared._httpx_utils import create_mcp_http_client
-
+from nsflow.backend.utils.mcp.mcp_http import _challenge_http_client_factory
+from nsflow.backend.utils.mcp.mcp_http import _discover_protected_resource_metadata
+from nsflow.backend.utils.mcp.mcp_http import _mcp_http_client_factory
 from nsflow.backend.utils.mcp.mcp_refresh_provider import ReauthRequiredError
 from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
 from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
@@ -78,39 +71,6 @@ logger = logging.getLogger(__name__)
 PENDING_FLOW_TTL_SECONDS = 600
 # Refresh a token this many seconds before its actual expiry.
 TOKEN_REFRESH_MARGIN_SECONDS = 60
-
-
-async def _force_json_accept_on_oauth_requests(request: httpx.Request) -> None:
-    """
-    httpx request hook: force ``Accept: application/json`` on OAuth token/refresh
-    requests. Some authorization servers (notably GitHub's
-    ``…/login/oauth/access_token``) return a form-encoded body unless the client
-    explicitly asks for JSON, which then fails the SDK's JSON token parsing.
-
-    These OAuth requests are form-encoded (``application/x-www-form-urlencoded``),
-    which uniquely distinguishes them from MCP streamable-HTTP JSON-RPC POSTs
-    (``application/json``, which must keep their ``application/json,
-    text/event-stream`` Accept header), so this never touches MCP traffic.
-    """
-    content_type = request.headers.get("content-type", "")
-    if content_type.startswith("application/x-www-form-urlencoded"):
-        request.headers["Accept"] = "application/json"
-
-
-def _mcp_http_client_factory(headers=None, timeout=None, auth=None, **kwargs) -> httpx.AsyncClient:
-    """
-    MCP http client factory that adds the OAuth Accept-JSON request hook.
-
-    Accepts and forwards any extra keyword arguments so the factory stays
-    compatible if a future MCP SDK passes additional parameters to
-    ``httpx_client_factory`` (a common forward-compat pattern). Forwarding rather
-    than dropping them means new client settings (proxy, TLS verify, etc.) still
-    reach the underlying client - and since we wrap the SDK's own
-    ``create_mcp_http_client``, anything it passes is something it accepts.
-    """
-    client = create_mcp_http_client(headers=headers, timeout=timeout, auth=auth, **kwargs)
-    client.event_hooks.setdefault("request", []).append(_force_json_accept_on_oauth_requests)
-    return client
 
 
 @dataclass
@@ -287,6 +247,7 @@ class MCPOAuthManager:
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
         redirect_uri: Optional[str] = None,
+        extra_authorize_params: Optional[Dict[str, str]] = None,
     ) -> PendingFlow:
         """
         Kick off an OAuth flow for ``server_url`` and wait until the
@@ -333,7 +294,15 @@ class MCPOAuthManager:
         flow.preseeded_client_info = bool(client_id)
         flow.code_future = asyncio.get_running_loop().create_future()
         self._by_flow_id[flow.flow_id] = flow
-        flow.task = asyncio.create_task(self._run_oauth_flow(flow, scope, auth_method, redirect_uri))
+        flow.task = asyncio.create_task(
+            self._run_oauth_flow(
+                flow,
+                scope,
+                auth_method=auth_method,
+                redirect_uri=redirect_uri,
+                extra_authorize_params=extra_authorize_params,
+            )
+        )
 
         # Wait for redirect_handler to capture the URL, or the task to fail.
         try:
@@ -386,49 +355,113 @@ class MCPOAuthManager:
         if flow.state:
             self._by_state.pop(flow.state, None)
 
-    async def _run_oauth_flow(
+    def _flow_provider(  # pylint: disable=too-many-arguments  # independent optional OAuth knobs, keyword-only
         self,
         flow: PendingFlow,
         scope: Optional[str],
+        *,
+        auth_method: str,
+        redirect_uri: Optional[str],
+        extra_authorize_params: Optional[Dict[str, str]] = None,
+    ) -> OAuthClientProvider:
+        """Build the SDK provider an interactive (re)connect flow runs through."""
+        return OAuthClientProvider(
+            server_url=flow.server_url,
+            client_metadata=self._build_client_metadata(scope, auth_method, redirect_uri),
+            # ReauthFlowTokenStorage hides any stored (dead) tokens: on a
+            # reconnect the stock provider would otherwise present the old
+            # Bearer token, a tolerant server answers 200, and the flow
+            # aborts without ever authorizing.
+            storage=ReauthFlowTokenStorage(FileTokenStorage(flow.server_url)),
+            redirect_handler=self._make_redirect_handler(flow, extra_authorize_params),
+            callback_handler=self._make_callback_handler(flow),
+        )
+
+    @staticmethod
+    async def _probe_mcp_session(server_url: str, provider: OAuthClientProvider, http_client_factory) -> None:
+        """
+        Open a real MCP streamable-HTTP session through the auth provider.
+
+        An unauthenticated request normally returns 401, which triggers the
+        SDK's discovery -> DCR -> authorization (our redirect_handler) ->
+        callback (our callback_handler) -> token exchange. A plain GET does not
+        work: MCP endpoints answer GET with 405, so the challenge never fires.
+        """
+        async with streamablehttp_client(
+            url=server_url, auth=provider, httpx_client_factory=http_client_factory
+        ) as (read, write, _get_id):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+
+    async def _run_oauth_flow(  # pylint: disable=too-many-arguments  # independent optional OAuth knobs, keyword-only
+        self,
+        flow: PendingFlow,
+        scope: Optional[str],
+        *,
         auth_method: str = "none",
         redirect_uri: Optional[str] = None,
+        extra_authorize_params: Optional[Dict[str, str]] = None,
     ) -> None:
         """Background task: drive the SDK auth flow to completion."""
         provider: Optional[OAuthClientProvider] = None
         try:
-            provider = OAuthClientProvider(
-                server_url=flow.server_url,
-                client_metadata=self._build_client_metadata(scope, auth_method, redirect_uri),
-                # ReauthFlowTokenStorage hides any stored (dead) tokens: on a
-                # reconnect the stock provider would otherwise present the old
-                # Bearer token, a tolerant server answers 200, and the flow
-                # aborts with "no 401 challenge was returned".
-                storage=ReauthFlowTokenStorage(FileTokenStorage(flow.server_url)),
-                redirect_handler=self._make_redirect_handler(flow),
-                callback_handler=self._make_callback_handler(flow),
+            provider = self._flow_provider(
+                flow,
+                scope,
+                auth_method=auth_method,
+                redirect_uri=redirect_uri,
+                extra_authorize_params=extra_authorize_params,
             )
-            # Open a real MCP streamable-HTTP session through the auth provider.
-            # The unauthenticated request returns 401, which triggers the SDK's
-            # discovery -> DCR -> authorization (our redirect_handler) -> callback
-            # (our callback_handler) -> token exchange. A plain GET does not work:
-            # MCP endpoints answer GET with 405, so the 401 challenge never fires.
-            async with streamablehttp_client(
-                url=flow.server_url, auth=provider, httpx_client_factory=_mcp_http_client_factory
-            ) as (read, write, _get_id):
-                async with ClientSession(read, write) as session:
-                    await session.initialize()
-            # Reached here without the provider needing to authorize.
-            if await asyncio.to_thread(FileTokenStorage.has_connection, flow.server_url):
+            await self._probe_mcp_session(flow.server_url, provider, _mcp_http_client_factory)
+            connected = await asyncio.to_thread(FileTokenStorage.has_connection, flow.server_url)
+            prm_url = None
+            if not connected:
+                # Auth-optional server: it answered the probe without demanding
+                # authentication (e.g. Google Maps and Hugging Face 200 an
+                # anonymous initialize and only reject tool calls), so the SDK's
+                # 401-driven flow never started. If the server still publishes
+                # RFC 9728 protected-resource metadata, OAuth is available -
+                # re-probe with a synthetic challenge pointing at it; the stock
+                # SDK flow runs unmodified from that 401 onward.
+                prm_url = await _discover_protected_resource_metadata(flow.server_url)
+                if prm_url:
+                    logger.info(
+                        "MCP server %s is auth-optional; retrying with a synthetic challenge (%s)",
+                        flow.server_url,
+                        prm_url,
+                    )
+                    provider = self._flow_provider(
+                        flow,
+                        scope,
+                        auth_method=auth_method,
+                        redirect_uri=redirect_uri,
+                        extra_authorize_params=extra_authorize_params,
+                    )
+                    await self._probe_mcp_session(flow.server_url, provider, _challenge_http_client_factory(prm_url))
+                    connected = await asyncio.to_thread(FileTokenStorage.has_connection, flow.server_url)
+            if connected:
                 flow.status = "completed"
                 await self._persist_token_endpoint(provider, flow.server_url)
             else:
                 flow.status = "error"
-                flow.error = (
-                    "Connected to the MCP server but it did not start an OAuth "
-                    "authorization (no 401 challenge was returned). The server may "
-                    "be open, use a different auth scheme, or require static client "
-                    "credentials."
-                )
+                if prm_url:
+                    # We DID find protected-resource metadata and drove the
+                    # synthetic-challenge flow, but no token landed - the user
+                    # cancelled/closed the popup, it timed out, or the provider
+                    # rejected the authorization.
+                    flow.error = (
+                        "Found the MCP server's OAuth metadata but authorization "
+                        "did not complete (it was cancelled, timed out, or the "
+                        "provider rejected it). Please try connecting again."
+                    )
+                else:
+                    flow.error = (
+                        "Connected to the MCP server without authentication: it "
+                        "returned no 401 challenge and publishes no OAuth "
+                        "protected-resource metadata (RFC 9728). It may be an open "
+                        "server, or use an auth scheme nsflow cannot bootstrap "
+                        "(e.g. API keys)."
+                    )
                 logger.warning("MCP OAuth flow for %s: %s", flow.server_url, flow.error)
                 await self._cleanup_failed_preseed(flow)
         except Exception as exc:  # noqa: BLE001 - report any failure back to the UI
@@ -510,11 +543,26 @@ class MCPOAuthManager:
             return url
         return f"{head}?{tail.replace('?', '&')}"
 
-    def _make_redirect_handler(self, flow: PendingFlow):
+    def _make_redirect_handler(self, flow: PendingFlow, extra_authorize_params: Optional[Dict[str, str]] = None):
         async def redirect_handler(authorization_url: str) -> None:
             authorization_url = self._normalize_authorization_url(authorization_url)
-            flow.authorization_url = authorization_url
             params = parse_qs(urlparse(authorization_url).query)
+            if extra_authorize_params:
+                # Provider-specific authorize knobs the SDK has no notion of -
+                # e.g. Google only issues a refresh token when the authorize
+                # request carries access_type=offline (and prompt=consent for
+                # repeat grants). Supplied by the connector catalog or the user.
+                # Only append keys the SDK didn't already set: the SDK's own
+                # params (state, redirect_uri, client_id, code_challenge, scope)
+                # are authoritative and must not be duplicated or overridden by a
+                # stray/malicious catalog or /start value.
+                extra = {k: v for k, v in extra_authorize_params.items() if k not in params}
+                if extra:
+                    separator = "&" if "?" in authorization_url else "?"
+                    authorization_url = f"{authorization_url}{separator}{urlencode(extra)}"
+            flow.authorization_url = authorization_url
+            # state was parsed above and is never among the appended keys (the
+            # SDK's params are authoritative), so `params` still holds it.
             state_values = params.get("state")
             flow.state = state_values[0] if state_values else None
             if flow.state:
@@ -769,7 +817,25 @@ class MCPOAuthManager:
                 exc,
             )
             return needs_reauth
-        return False
+        # No exception, but the probe may have succeeded on a dead token: an
+        # auth-optional server (Google Maps, Hugging Face) answers 200 without a
+        # valid token, so a rejected refresh never surfaces as a 401/exception.
+        # The recorded refresh status is then the only signal - a client error
+        # (invalid_grant, revoked/expired refresh token) means re-auth.
+        return self._refresh_status_needs_reauth(provider.refresh_http_status)
+
+    @staticmethod
+    def _refresh_status_needs_reauth(status: Optional[int]) -> bool:
+        """
+        Classify a refresh-grant HTTP status when the probe raised nothing.
+
+        A 4xx (invalid_grant, revoked/expired refresh token) definitively needs
+        re-auth. A 5xx / rate-limit (408, 429) is transient - retry later. None
+        means no refresh was attempted (nothing to mark), and 200 succeeded.
+        """
+        if status is None:
+            return False
+        return 400 <= status < 500 and status not in (408, 429)
 
 
 # Process-wide singleton.

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -72,6 +72,24 @@ PENDING_FLOW_TTL_SECONDS = 600
 # Refresh a token this many seconds before its actual expiry.
 TOKEN_REFRESH_MARGIN_SECONDS = 60
 
+# Core OAuth authorize parameters the SDK owns and computes for security
+# (PKCE, CSRF, resource binding). extra_authorize_params may never set or
+# override these - not even ones the SDK happens to omit for a given flow -
+# so a catalog or /start value can't alter the request's security semantics;
+# only provider-specific knobs (access_type, prompt, login_hint, ...) pass.
+_RESERVED_AUTHORIZE_PARAMS = frozenset(
+    {
+        "response_type",
+        "client_id",
+        "redirect_uri",
+        "scope",
+        "state",
+        "code_challenge",
+        "code_challenge_method",
+        "resource",
+    }
+)
+
 
 @dataclass
 class PendingFlow:  # pylint: disable=too-many-instance-attributes  # dataclass aggregating flow fields
@@ -552,11 +570,15 @@ class MCPOAuthManager:
                 # e.g. Google only issues a refresh token when the authorize
                 # request carries access_type=offline (and prompt=consent for
                 # repeat grants). Supplied by the connector catalog or the user.
-                # Only append keys the SDK didn't already set: the SDK's own
-                # params (state, redirect_uri, client_id, code_challenge, scope)
-                # are authoritative and must not be duplicated or overridden by a
-                # stray/malicious catalog or /start value.
-                extra = {k: v for k, v in extra_authorize_params.items() if k not in params}
+                # Drop any core OAuth param (whether or not the SDK set it this
+                # flow) and any key already in the URL, so a stray/malicious
+                # catalog or /start value can't override the SDK's authoritative,
+                # security-relevant params. Values coerced to str defensively.
+                extra = {
+                    k: str(v)
+                    for k, v in extra_authorize_params.items()
+                    if k not in params and k not in _RESERVED_AUTHORIZE_PARAMS
+                }
                 if extra:
                     separator = "&" if "?" in authorization_url else "?"
                     authorization_url = f"{authorization_url}{separator}{urlencode(extra)}"

--- a/nsflow/backend/utils/mcp/mcp_refresh_provider.py
+++ b/nsflow/backend/utils/mcp/mcp_refresh_provider.py
@@ -120,6 +120,17 @@ class SilentRefreshOAuthProvider(OAuthClientProvider):
         )
         self._stored_token_expiry_time = token_expiry_time
         self.token_endpoint = token_endpoint
+        # HTTP status of the most recent refresh-grant response (None until one
+        # is attempted). Auth-optional servers answer the follow-up request with
+        # 200 even when the refresh was rejected, so the SDK never reaches its
+        # 401 re-auth path and raises nothing; this status is then the only
+        # evidence the refresh failed. See _handle_refresh_response.
+        self.refresh_http_status: Optional[int] = None
+
+    async def _handle_refresh_response(self, response: httpx.Response) -> bool:
+        """Record the refresh-grant HTTP status, then defer to the base handler."""
+        self.refresh_http_status = response.status_code
+        return await super()._handle_refresh_response(response)
 
     async def _initialize(self) -> None:
         """Load stored tokens/client info, then restore the token expiry."""

--- a/nsflow/frontend/src/components/mcp/McpConnectorsPanel.tsx
+++ b/nsflow/frontend/src/components/mcp/McpConnectorsPanel.tsx
@@ -45,6 +45,14 @@ interface OAuthMessage {
   message?: string;
 }
 
+// Normalize a server URL for comparison so a trailing slash / host case
+// difference doesn't treat two forms of the same server as distinct. Module
+// scope (pure) so handleConnect can reference it and the catalog map below.
+const normalizeUrl = (u: string) => u.trim().replace(/\/+$/, '').toLowerCase();
+// Catalog lookup by normalized URL (icons, extra authorize params). Built from
+// the module constant, so it's stable across renders.
+const KNOWN_BY_URL = new Map(KNOWN_MCP_SERVERS.map((s) => [normalizeUrl(s.url), s]));
+
 const McpConnectorsPanel: React.FC = () => {
   const { theme } = useTheme();
   const { apiUrl, isReady } = useApiPort();
@@ -284,6 +292,10 @@ const McpConnectorsPanel: React.FC = () => {
     setAwaitingAuth(false);
     setError(null);
     pendingServerRef.current = url;
+    // Catalog-supplied authorize knobs (e.g. Google's access_type=offline) ride
+    // along, matched on the normalized URL so they apply on Quick Connect,
+    // pre-registered, reconnect, and a manually typed known URL.
+    const extraAuthorizeParams = KNOWN_BY_URL.get(normalizeUrl(url))?.extraAuthorizeParams;
     try {
       const res = await fetch(`${apiUrl}/api/v1/mcp/oauth/start`, {
         method: 'POST',
@@ -292,6 +304,7 @@ const McpConnectorsPanel: React.FC = () => {
           server_url: url,
           ...(clientId.trim() ? { client_id: clientId.trim() } : {}),
           ...(clientSecret.trim() ? { client_secret: clientSecret.trim() } : {}),
+          ...(extraAuthorizeParams ? { extra_authorize_params: extraAuthorizeParams } : {}),
         }),
       });
       // Parse defensively: a backend/proxy can return a non-JSON error body
@@ -433,19 +446,16 @@ const McpConnectorsPanel: React.FC = () => {
   // Known servers the user hasn't connected yet (matched on a normalized URL so
   // a trailing slash / host case difference doesn't show an already-connected
   // server as still suggested), split by connection method.
-  const normalizeUrl = (u: string) => u.trim().replace(/\/+$/, '').toLowerCase();
   const connectedUrls = new Set(connections.map((c) => normalizeUrl(c.server_url)));
   const unconnected = KNOWN_MCP_SERVERS.filter((s) => !connectedUrls.has(normalizeUrl(s.url)));
   const dcrSuggestions = unconnected.filter((s) => s.auth !== 'pre_registered');
   const preRegSuggestions = unconnected.filter((s) => s.auth === 'pre_registered');
-  // Look up a known server (for its icon) by a connection's normalized URL.
-  const knownByUrl = new Map(KNOWN_MCP_SERVERS.map((s) => [normalizeUrl(s.url), s]));
 
-  // Re-run the OAuth flow for a connection whose silent refresh failed. The
-  // backend reuses the stored client registration (DCR result or previously
-  // supplied credentials), so nothing needs to be re-entered: known DCR servers
-  // get their one-click dialog; everything else (custom or pre-registered)
-  // opens the Add-server dialog pre-seeded with the URL, credentials optional.
+  // Re-run the OAuth flow for a connection whose silent refresh failed. Nothing
+  // needs to be re-entered: pre-registered credentials are reused, and DCR
+  // servers register a fresh client automatically. Known DCR servers get their
+  // one-click dialog; everything else (custom or pre-registered) opens the
+  // Add-server dialog pre-seeded with the URL, credentials optional.
   //
   // The flow is always seeded with conn.server_url - the exact key the token
   // store holds - never the catalog's canonical URL. If the two differ
@@ -454,7 +464,7 @@ const McpConnectorsPanel: React.FC = () => {
   // one as a permanent "Reconnect required" row.
   const openReconnect = (conn: McpConnection) => {
     if (!beginConnectAttempt(conn.server_url)) return;
-    const known = knownByUrl.get(normalizeUrl(conn.server_url));
+    const known = KNOWN_BY_URL.get(normalizeUrl(conn.server_url));
     if (known && known.auth !== 'pre_registered') {
       setKnownServer(known);
     } else {
@@ -558,7 +568,7 @@ const McpConnectorsPanel: React.FC = () => {
         ) : (
           <List dense>
             {connections.map((conn) => {
-              const known = knownByUrl.get(normalizeUrl(conn.server_url));
+              const known = KNOWN_BY_URL.get(normalizeUrl(conn.server_url));
               return (
               <ListItem
                 key={conn.server_url}

--- a/nsflow/frontend/src/components/mcp/knownMcpServers.ts
+++ b/nsflow/frontend/src/components/mcp/knownMcpServers.ts
@@ -38,6 +38,15 @@ export interface KnownMcpServer {
   iconUrl?: string;
   /** Client registration method; defaults to 'dcr' when omitted. */
   auth?: KnownMcpAuth;
+  /**
+   * Extra query params appended to the authorization URL for providers the
+   * plain OAuth flow can't satisfy - e.g. Google issues a refresh token only
+   * when the authorize request carries ``access_type=offline`` (with
+   * ``prompt=consent`` so a repeat grant still returns one). The backend
+   * forwards these verbatim; scopes are NOT set here (the SDK derives them from
+   * the server's RFC 9728 protected-resource metadata).
+   */
+  extraAuthorizeParams?: Record<string, string>;
 }
 
 /**
@@ -50,12 +59,30 @@ export interface KnownMcpServer {
  * server's OAuth metadata (`/.well-known/oauth-authorization-server`) for a
  * `registration_endpoint` - is a future enhancement.
  */
+// Entries are ordered alphabetically by name within each group (DCR first, then
+// pre-registered), matching the two sections the Connectors tab renders.
 export const KNOWN_MCP_SERVERS: KnownMcpServer[] = [
   {
-    id: 'you',
-    name: 'You.com',
-    url: 'https://api.you.com/mcp',
-    iconUrl: 'https://you.com/favicon.ico',
+    id: 'atlassian',
+    name: 'Atlassian',
+    url: 'https://mcp.atlassian.com/v1/mcp/authv2',
+    iconUrl: 'https://www.atlassian.com/favicon.ico',
+  },
+  {
+    // Auth-optional: 200s an anonymous initialize and only 401s at tool-call
+    // time, so the SDK's 401-driven flow never starts. The backend detects this
+    // and re-probes with a synthetic challenge pointing at Hugging Face's RFC
+    // 9728 metadata; DCR then works normally (huggingface.co/oauth/register).
+    id: 'huggingface',
+    name: 'Hugging Face',
+    url: 'https://huggingface.co/mcp',
+    iconUrl: 'https://huggingface.co/favicon.ico',
+  },
+  {
+    id: 'intercom',
+    name: 'Intercom',
+    url: 'https://mcp.intercom.com/mcp',
+    iconUrl: 'https://www.google.com/s2/favicons?domain=intercom.com&sz=64',
   },
   {
     id: 'linear',
@@ -70,16 +97,22 @@ export const KNOWN_MCP_SERVERS: KnownMcpServer[] = [
     iconUrl: 'https://www.notion.so/images/favicon.ico',
   },
   {
+    id: 'paypal',
+    name: 'PayPal',
+    url: 'https://mcp.paypal.com/mcp',
+    iconUrl: 'https://www.paypal.com/favicon.ico',
+  },
+  {
+    id: 'postman',
+    name: 'Postman',
+    url: 'https://mcp.postman.com/mcp',
+    iconUrl: 'https://voyager.postman.com/logo/postman-logo-icon-orange.svg',
+  },
+  {
     id: 'sentry',
     name: 'Sentry',
     url: 'https://mcp.sentry.dev/mcp',
     iconUrl: 'https://sentry.io/favicon.ico',
-  },
-  {
-    id: 'atlassian',
-    name: 'Atlassian',
-    url: 'https://mcp.atlassian.com/v1/mcp/authv2',
-    iconUrl: 'https://www.atlassian.com/favicon.ico',
   },
   {
     id: 'stripe',
@@ -88,16 +121,10 @@ export const KNOWN_MCP_SERVERS: KnownMcpServer[] = [
     iconUrl: 'https://stripe.com/favicon.ico',
   },
   {
-    id: 'paypal',
-    name: 'PayPal',
-    url: 'https://mcp.paypal.com/mcp',
-    iconUrl: 'https://www.paypal.com/favicon.ico',
-  },
-  {
-    id: 'intercom',
-    name: 'Intercom',
-    url: 'https://mcp.intercom.com/mcp',
-    iconUrl: 'https://www.google.com/s2/favicons?domain=intercom.com&sz=64',
+    id: 'you',
+    name: 'You.com',
+    url: 'https://api.you.com/mcp',
+    iconUrl: 'https://you.com/favicon.ico',
   },
   {
     id: 'zapier',
@@ -105,13 +132,14 @@ export const KNOWN_MCP_SERVERS: KnownMcpServer[] = [
     url: 'https://mcp.zapier.com/api/mcp/mcp',
     iconUrl: 'https://zapier.com/favicon.ico',
   },
-  {
-    id: 'postman',
-    name: 'Postman',
-    url: 'https://mcp.postman.com/mcp',
-    iconUrl: 'https://voyager.postman.com/logo/postman-logo-icon-orange.svg',
-  },
   // --- Pre-registered: no DCR, user supplies a Client ID / Secret ---
+  {
+    id: 'asana',
+    name: 'Asana',
+    url: 'https://mcp.asana.com/v2/mcp',
+    iconUrl: 'https://asana.com/favicon.ico',
+    auth: 'pre_registered',
+  },
   {
     id: 'github',
     name: 'GitHub',
@@ -119,11 +147,53 @@ export const KNOWN_MCP_SERVERS: KnownMcpServer[] = [
     iconUrl: 'https://github.com/favicon.ico',
     auth: 'pre_registered',
   },
+  // Google MCP services (Gmail, Calendar, Drive, Maps): all auth-optional like
+  // Hugging Face (handled by the backend's synthetic-challenge fallback), and
+  // all lack DCR - register one OAuth client in the Google Cloud Console and
+  // enable the relevant API + scopes on its consent screen. access_type=offline
+  // + prompt=consent make Google return a refresh token (it omits one
+  // otherwise); scopes come from each server's protected-resource metadata.
   {
-    id: 'asana',
-    name: 'Asana',
-    url: 'https://mcp.asana.com/v2/mcp',
-    iconUrl: 'https://asana.com/favicon.ico',
+    id: 'gmail',
+    name: 'Gmail',
+    url: 'https://gmailmcp.googleapis.com/mcp/v1',
+    // The s2 favicon service returns the generic Google "G" for mail/calendar/
+    // drive subdomains; use Google's per-product logos so each tile is distinct.
+    iconUrl: 'https://ssl.gstatic.com/images/branding/product/1x/gmail_2020q4_48dp.png',
+    auth: 'pre_registered',
+    extraAuthorizeParams: { access_type: 'offline', prompt: 'consent' },
+  },
+  {
+    id: 'googlecalendar',
+    name: 'Google Calendar',
+    url: 'https://calendarmcp.googleapis.com/mcp/v1',
+    iconUrl: 'https://ssl.gstatic.com/images/branding/product/1x/calendar_2020q4_48dp.png',
+    auth: 'pre_registered',
+    extraAuthorizeParams: { access_type: 'offline', prompt: 'consent' },
+  },
+  {
+    id: 'googledrive',
+    name: 'Google Drive',
+    url: 'https://drivemcp.googleapis.com/mcp/v1',
+    iconUrl: 'https://ssl.gstatic.com/images/branding/product/1x/drive_2020q4_48dp.png',
+    auth: 'pre_registered',
+    extraAuthorizeParams: { access_type: 'offline', prompt: 'consent' },
+  },
+  {
+    id: 'googlemaps',
+    name: 'Google Maps',
+    url: 'https://mapstools.googleapis.com/mcp',
+    iconUrl: 'https://www.google.com/s2/favicons?domain=maps.google.com&sz=64',
+    auth: 'pre_registered',
+    extraAuthorizeParams: { access_type: 'offline', prompt: 'consent' },
+  },
+  {
+    // Sends a real 401 challenge (not auth-optional) and has no DCR, so register
+    // a Salesforce External Client App and paste its Client ID / Secret.
+    id: 'salesforce',
+    name: 'Salesforce',
+    url: 'https://api.salesforce.com/platform/mcp/v1/platform/sobject-all',
+    iconUrl: 'https://www.salesforce.com/favicon.ico',
     auth: 'pre_registered',
   },
   {
@@ -161,8 +231,9 @@ export const KNOWN_MCP_SERVERS: KnownMcpServer[] = [
  *     only honors Claude's registered redirect URIs, so it rejects nsflow's
  *     loopback callback ("redirect URI is incorrect"). Not a general endpoint.
  *
- * Also excluded - auth-optional servers that never return a 401 challenge, so
- * the OAuth flow never starts (the endpoint serves anonymous requests):
- * Hugging Face (https://huggingface.co/mcp) and Google Drive/Gmail/Calendar
- * (https://{drive,gmail,calendar}mcp.googleapis.com/mcp/v1).
+ * Auth-optional servers (200 an anonymous initialize, only 401 at tool-call
+ * time) used to be excluded because the OAuth flow never started. They are now
+ * supported via the backend's synthetic-challenge fallback when they publish
+ * RFC 9728 protected-resource metadata - Hugging Face and the Google services
+ * (Maps, Gmail, Calendar, Drive) are all listed above.
  */

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -685,6 +685,13 @@ def test_discover_protected_resource_metadata(monkeypatch):
     documents["/.well-known/oauth-protected-resource/mcp"] = {"resource": SERVER_URL}
     assert asyncio.run(discover(SERVER_URL)) is None
 
+    # authorization_servers must be a NON-EMPTY ARRAY per RFC 9728: a truthy
+    # string or an empty list is malformed and must not classify as OAuth-capable.
+    documents["/.well-known/oauth-protected-resource/mcp"] = {"authorization_servers": "https://auth.example.com"}
+    assert asyncio.run(discover(SERVER_URL)) is None
+    documents["/.well-known/oauth-protected-resource/mcp"] = {"authorization_servers": []}
+    assert asyncio.run(discover(SERVER_URL)) is None
+
     # Real metadata at the path-inserted form (Google Maps / Hugging Face shape).
     documents["/.well-known/oauth-protected-resource/mcp"] = {
         "resource": SERVER_URL,

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -32,10 +32,12 @@ import time
 import httpx
 import pytest
 from mcp.client.auth.exceptions import OAuthTokenError
+from mcp.client.auth.utils import extract_field_from_www_auth
 from mcp.shared.auth import OAuthClientInformationFull
 from mcp.shared.auth import OAuthClientMetadata
 from mcp.shared.auth import OAuthToken
 
+import nsflow.backend.utils.mcp.mcp_http as mh
 import nsflow.backend.utils.mcp.mcp_oauth_manager as om
 from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
 from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
@@ -274,6 +276,121 @@ def test_definitive_refresh_failure_marks_needs_reauth(tmp_path, monkeypatch):
     assert _read_store(tmp_path).get("needs_reauth") is True
 
 
+def test_refresh_status_needs_reauth_classification():
+    """Only a 4xx (except rate-limit) is a definitive re-auth signal."""
+    classify = om.MCPOAuthManager._refresh_status_needs_reauth  # pylint: disable=protected-access  # unit under test
+    assert classify(400) is True  # invalid_grant
+    assert classify(401) is True
+    assert classify(403) is True
+    assert classify(408) is False  # request timeout - transient
+    assert classify(429) is False  # rate limited - transient
+    assert classify(500) is False  # server error - transient
+    assert classify(503) is False
+    assert classify(200) is False  # refreshed
+    assert classify(None) is False  # no refresh attempted
+
+
+def test_refresh_provider_records_refresh_status(tmp_path):
+    """
+    SilentRefreshOAuthProvider records the refresh-grant HTTP status so a
+    rejected refresh is detectable even when the follow-up request succeeds
+    (auth-optional servers 200 a dead token). _silent_refresh reads this.
+    """
+    provider = SilentRefreshOAuthProvider(
+        server_url=SERVER_URL,
+        client_metadata=_client_metadata(),
+        storage=FileTokenStorage(SERVER_URL, storage_dir=tmp_path),
+    )
+    assert provider.refresh_http_status is None
+    # A non-200 refresh: the base handler returns False; we recorded the status.
+    result = asyncio.run(provider._handle_refresh_response(httpx.Response(400)))  # pylint: disable=protected-access  # exercising the override
+    assert result is False
+    assert provider.refresh_http_status == 400
+
+
+def test_auth_optional_dead_refresh_marks_needs_reauth(tmp_path, monkeypatch):
+    """
+    The Hugging Face bug: an auth-optional server answers the refresh probe with
+    200 even though the refresh grant was rejected (400), so no exception is
+    raised. The recorded refresh status must still mark the entry needs_reauth,
+    or the dead connection shows as healthy and the reconnect gate never fires.
+    """
+    monkeypatch.setenv("NSFLOW_MCP_STORAGE_DIR", str(tmp_path))
+    _seed_store(tmp_path)  # expired token WITH a (now-dead) refresh token
+
+    class _FakeStreams:
+        async def __aenter__(self):
+            return (None, None, None)
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    def _fake_streamable(**kwargs):
+        # Simulate the SDK recording a rejected refresh, then the probe 200ing.
+        kwargs["auth"].refresh_http_status = 400
+        return _FakeStreams()
+
+    class _FakeSession:
+        def __init__(self, *_a, **_k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def initialize(self):
+            """No-op MCP handshake for the stubbed session."""
+            return None
+
+    monkeypatch.setattr(om, "streamablehttp_client", _fake_streamable)
+    monkeypatch.setattr(om, "ClientSession", _FakeSession)
+
+    assert asyncio.run(om.mcp_oauth_manager.get_fresh_token(SERVER_URL)) is None
+    assert _read_store(tmp_path).get("needs_reauth") is True
+
+
+def test_auth_optional_transient_refresh_not_marked(tmp_path, monkeypatch):
+    """
+    A 5xx on the refresh endpoint (with the auth-optional 200 probe) is
+    transient: don't mark needs_reauth, so a later attempt can recover it.
+    """
+    monkeypatch.setenv("NSFLOW_MCP_STORAGE_DIR", str(tmp_path))
+    _seed_store(tmp_path)
+
+    class _FakeStreams:
+        async def __aenter__(self):
+            return (None, None, None)
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    def _fake_streamable(**kwargs):
+        kwargs["auth"].refresh_http_status = 503
+        return _FakeStreams()
+
+    class _FakeSession:
+        def __init__(self, *_a, **_k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def initialize(self):
+            """No-op MCP handshake for the stubbed session."""
+            return None
+
+    monkeypatch.setattr(om, "streamablehttp_client", _fake_streamable)
+    monkeypatch.setattr(om, "ClientSession", _FakeSession)
+
+    assert asyncio.run(om.mcp_oauth_manager.get_fresh_token(SERVER_URL)) is None
+    assert "needs_reauth" not in _read_store(tmp_path)
+
+
 def test_marked_entry_skips_refresh_probe(tmp_path, monkeypatch):
     """
     Once marked, an entry is not re-probed (only a reconnect recovers it) - so a
@@ -438,6 +555,215 @@ def test_set_client_info_records_manual_flag(tmp_path):
 
     asyncio.run(storage.set_client_info(info, manual=True))  # the /start pre-seed path
     assert _read_store(tmp_path)["client_info_manual"] is True
+
+
+def test_synthetic_challenge_transport_401s_only_the_first_request():
+    """
+    The synthetic 401 must fire exactly once (the SDK's OAuth trigger), carry a
+    challenge the SDK's own parser reads back, and every later request - the
+    flow's discovery/registration/token calls and the authenticated retry -
+    must reach the real transport untouched.
+    """
+    prm_url = "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+
+    class _Inner(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request):
+            return httpx.Response(200, request=request)
+
+    transport = mh._SyntheticChallengeTransport(_Inner(), prm_url)  # pylint: disable=protected-access  # unit under test
+    request = httpx.Request("POST", SERVER_URL)
+
+    first = asyncio.run(transport.handle_async_request(request))
+    assert first.status_code == 401
+    # The SDK's own WWW-Authenticate parser must recover the metadata URL.
+    assert extract_field_from_www_auth(first, "resource_metadata") == prm_url
+
+    second = asyncio.run(transport.handle_async_request(request))
+    assert second.status_code == 200
+
+
+def test_challenge_factory_injects_401_into_the_auth_flow():
+    """
+    End-to-end wiring: a client from _challenge_http_client_factory must route
+    the synthetic 401 into httpx's auth flow (not just exist as a transport), so
+    the SDK's OAuthClientProvider would see the challenge. Drives a real client
+    with a stub auth and a stubbed inner transport (no network).
+    """
+    prm_url = "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+    client = om._challenge_http_client_factory(prm_url)()  # pylint: disable=protected-access  # unit under test
+    # Replace the real network transport under the wrapper with a 200 stub, so
+    # the retry after the synthetic 401 stays in-process.
+    client._transport._inner = httpx.MockTransport(  # pylint: disable=protected-access  # swap inner for a stub
+        lambda _req: httpx.Response(200, json={"ok": True})
+    )
+    seen = []
+
+    class _RecordingAuth(httpx.Auth):
+        async def async_auth_flow(self, request):
+            response = yield request
+            seen.append(response.status_code)
+            if response.status_code == 401:
+                # The challenge reached the auth flow; retry once (the stub 200s).
+                retry = yield request
+                seen.append(retry.status_code)
+
+    async def run():
+        try:
+            return await client.get("https://mcp.example.com/mcp", auth=_RecordingAuth())
+        finally:
+            await client.aclose()
+
+    response = asyncio.run(run())
+    assert seen == [401, 200]  # auth flow saw the synthetic 401, then the inner 200
+    assert response.status_code == 200
+
+
+def test_challenge_factory_wraps_proxy_mounts_with_shared_gate(monkeypatch):
+    """
+    Behind an env proxy, httpx routes via _mounts before _transport, so wrapping
+    only _transport would let the real 200 through and the synthetic 401 would
+    never fire. The factory must wrap the default AND each mount, sharing one
+    gate so still exactly one request is challenged.
+    """
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+    client = om._challenge_http_client_factory(  # pylint: disable=protected-access  # unit under test
+        "https://mcp.example.com/.well-known/oauth-protected-resource"
+    )()
+    try:
+        transport = client._transport  # pylint: disable=protected-access  # asserting wiring
+        mounts = [t for t in client._mounts.values() if t is not None]  # pylint: disable=protected-access
+        assert isinstance(transport, mh._SyntheticChallengeTransport)  # pylint: disable=protected-access
+        assert mounts and all(
+            isinstance(t, mh._SyntheticChallengeTransport) for t in mounts  # pylint: disable=protected-access
+        )
+        # One shared one-shot gate across default + proxy transports.
+        assert all(t._fired is transport._fired for t in mounts)  # pylint: disable=protected-access
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_discover_protected_resource_metadata(monkeypatch):
+    """
+    The PRM probe returns the path-inserted well-known URL when the server
+    publishes RFC 9728 metadata there, and None when nothing (or junk) is
+    served - the signal separating 'OAuth available, fake the challenge' from
+    'nothing to connect'.
+    """
+    documents = {}
+
+    def _handler(request):
+        doc = documents.get(request.url.path)
+        if doc is None:
+            return httpx.Response(404)
+        return httpx.Response(200, json=doc) if isinstance(doc, dict) else httpx.Response(200, text=doc)
+
+    def _factory(**_kwargs):
+        return httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+
+    # Patch the factory in mcp_http, where _discover_protected_resource_metadata
+    # lives and references it.
+    monkeypatch.setattr(mh, "_mcp_http_client_factory", _factory)
+    discover = mh._discover_protected_resource_metadata  # pylint: disable=protected-access  # unit under test
+
+    # Nothing published -> None (both well-known forms 404).
+    assert asyncio.run(discover(SERVER_URL)) is None
+
+    # Junk (HTML error page served with 200) -> None.
+    documents["/.well-known/oauth-protected-resource/mcp"] = "<html>not json</html>"
+    assert asyncio.run(discover(SERVER_URL)) is None
+
+    # A 200 JSON document without authorization_servers is not usable metadata.
+    documents["/.well-known/oauth-protected-resource/mcp"] = {"resource": SERVER_URL}
+    assert asyncio.run(discover(SERVER_URL)) is None
+
+    # Real metadata at the path-inserted form (Google Maps / Hugging Face shape).
+    documents["/.well-known/oauth-protected-resource/mcp"] = {
+        "resource": SERVER_URL,
+        "authorization_servers": ["https://auth.example.com"],
+    }
+    assert asyncio.run(discover(SERVER_URL)) == "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+
+
+def test_auth_optional_server_retries_with_synthetic_challenge(tmp_path, monkeypatch):
+    """
+    A server that answers the probe without demanding auth (Google Maps /
+    Hugging Face) but publishes PRM gets a second probe whose client fakes the
+    401 challenge; tokens obtained by that probe complete the flow.
+    """
+    monkeypatch.setenv("NSFLOW_MCP_STORAGE_DIR", str(tmp_path))
+    factories = []
+
+    async def _fake_probe(server_url, _provider, http_client_factory):
+        factories.append(http_client_factory)
+        if len(factories) == 2:  # the challenge-driven probe obtains tokens
+            await FileTokenStorage(server_url).set_tokens(OAuthToken(access_token="fresh", expires_in=3600))
+
+    async def _fake_discover(_server_url):
+        return "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+
+    monkeypatch.setattr(om.MCPOAuthManager, "_probe_mcp_session", staticmethod(_fake_probe))
+    monkeypatch.setattr(om, "_discover_protected_resource_metadata", _fake_discover)
+    flow = om.PendingFlow(flow_id="f6", server_url=SERVER_URL, created_at=0.0)
+
+    asyncio.run(om.mcp_oauth_manager._run_oauth_flow(flow, None))  # pylint: disable=protected-access  # exercising a private method under test
+
+    assert flow.status == "completed"
+    assert len(factories) == 2
+    assert factories[0] is om._mcp_http_client_factory  # pylint: disable=protected-access  # asserting wiring
+    # The second probe's clients must carry the synthetic-challenge transport.
+    client = factories[1]()
+    try:
+        transport = client._transport  # pylint: disable=protected-access  # asserting wiring
+        assert isinstance(transport, mh._SyntheticChallengeTransport)  # pylint: disable=protected-access  # asserting wiring
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_auth_optional_server_without_prm_fails_with_clear_error(tmp_path, monkeypatch):
+    """
+    No 401 challenge AND no published PRM -> the flow fails with a message
+    naming both facts (open server / API-key server), not the old generic one.
+    """
+    monkeypatch.setenv("NSFLOW_MCP_STORAGE_DIR", str(tmp_path))
+
+    async def _fake_probe(_server_url, _provider, _http_client_factory):
+        return None
+
+    async def _fake_discover(_server_url):
+        return None
+
+    monkeypatch.setattr(om.MCPOAuthManager, "_probe_mcp_session", staticmethod(_fake_probe))
+    monkeypatch.setattr(om, "_discover_protected_resource_metadata", _fake_discover)
+    flow = om.PendingFlow(flow_id="f7", server_url=SERVER_URL, created_at=0.0)
+
+    asyncio.run(om.mcp_oauth_manager._run_oauth_flow(flow, None))  # pylint: disable=protected-access  # exercising a private method under test
+
+    assert flow.status == "error"
+    assert "protected-resource metadata" in flow.error
+    assert "401" in flow.error
+
+
+def test_redirect_handler_appends_extra_authorize_params():
+    """
+    Catalog-supplied authorize knobs (e.g. Google's access_type=offline &
+    prompt=consent, required for a refresh token) are appended to the
+    authorization URL after normalization; without them the URL is untouched.
+    """
+    flow = om.PendingFlow(flow_id="f8", server_url=SERVER_URL, created_at=0.0)
+    handler = om.mcp_oauth_manager._make_redirect_handler(  # pylint: disable=protected-access  # unit under test
+        flow, {"access_type": "offline", "prompt": "consent"}
+    )
+    asyncio.run(handler("https://auth.example.com/authorize?client_id=x&state=st-extra"))
+    assert flow.authorization_url == (
+        "https://auth.example.com/authorize?client_id=x&state=st-extra&access_type=offline&prompt=consent"
+    )
+    assert flow.state == "st-extra"
+    om.mcp_oauth_manager._by_state.pop("st-extra", None)  # pylint: disable=protected-access  # test cleanup
+
+    plain = om.mcp_oauth_manager._make_redirect_handler(flow)  # pylint: disable=protected-access  # unit under test
+    asyncio.run(plain("https://auth.example.com/authorize?client_id=x&state=st-plain"))
+    assert flow.authorization_url == "https://auth.example.com/authorize?client_id=x&state=st-plain"
+    om.mcp_oauth_manager._by_state.pop("st-plain", None)  # pylint: disable=protected-access  # test cleanup
 
 
 def test_cleanup_failed_preseed_keeps_token_bearing_entry(tmp_path, monkeypatch):

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -775,6 +775,29 @@ def test_redirect_handler_appends_extra_authorize_params():
     om.mcp_oauth_manager._by_state.pop("st-plain", None)  # pylint: disable=protected-access  # test cleanup
 
 
+def test_redirect_handler_drops_reserved_authorize_params():
+    """
+    Core OAuth params the SDK owns (state, redirect_uri, scope, ...) must never
+    be injectable via extra_authorize_params - even ones the SDK omitted from
+    this authorize URL (e.g. scope when none was requested) - so a stray/hostile
+    catalog or /start value can't alter the request's security semantics. Only
+    provider-specific knobs pass through.
+    """
+    flow = om.PendingFlow(flow_id="f9", server_url=SERVER_URL, created_at=0.0)
+    handler = om.mcp_oauth_manager._make_redirect_handler(  # pylint: disable=protected-access  # unit under test
+        flow,
+        # scope/state/redirect_uri are reserved (scope is NOT in the URL below,
+        # proving the denylist blocks omitted reserved params, not just present
+        # ones); access_type is a legitimate provider knob that must survive.
+        {"scope": "evil", "state": "forged", "redirect_uri": "http://evil", "access_type": "offline"},
+    )
+    asyncio.run(handler("https://auth.example.com/authorize?client_id=x&state=st-safe"))
+
+    assert flow.authorization_url == "https://auth.example.com/authorize?client_id=x&state=st-safe&access_type=offline"
+    assert flow.state == "st-safe"  # the SDK's state won, not the injected one
+    om.mcp_oauth_manager._by_state.pop("st-safe", None)  # pylint: disable=protected-access  # test cleanup
+
+
 def test_cleanup_failed_preseed_keeps_token_bearing_entry(tmp_path, monkeypatch):
     """
     A canceled/failed credentialed reconnect must NOT delete a token-bearing

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -620,23 +620,32 @@ def test_challenge_factory_injects_401_into_the_auth_flow():
 
 def test_challenge_factory_wraps_proxy_mounts_with_shared_gate(monkeypatch):
     """
-    Behind an env proxy, httpx routes via _mounts before _transport, so wrapping
-    only _transport would let the real 200 through and the synthetic 401 would
-    never fire. The factory must wrap the default AND each mount, sharing one
-    gate so still exactly one request is challenged.
+    Behind a proxy, httpx routes via _mounts before _transport, so wrapping only
+    _transport would let the real 200 through and the synthetic 401 would never
+    fire. The factory must wrap the default AND each mount, sharing one gate so
+    still exactly one request is challenged. A mount is injected directly (rather
+    than via a proxy env var) so the test doesn't depend on httpx's env handling.
     """
-    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
-    client = om._challenge_http_client_factory(  # pylint: disable=protected-access  # unit under test
+
+    def _base_factory(**_kwargs):
+        client = httpx.AsyncClient()
+        # Stand in for the proxy transport httpx would put in _mounts from a
+        # proxy env var; _transport_for_url consults this before _transport.
+        client._mounts = {"all://": httpx.MockTransport(lambda _req: httpx.Response(200))}  # pylint: disable=protected-access
+        return client
+
+    monkeypatch.setattr(mh, "_mcp_http_client_factory", _base_factory)
+    client = mh._challenge_http_client_factory(  # pylint: disable=protected-access  # unit under test
         "https://mcp.example.com/.well-known/oauth-protected-resource"
     )()
     try:
         transport = client._transport  # pylint: disable=protected-access  # asserting wiring
         mounts = [t for t in client._mounts.values() if t is not None]  # pylint: disable=protected-access
         assert isinstance(transport, mh._SyntheticChallengeTransport)  # pylint: disable=protected-access
-        assert mounts and all(
-            isinstance(t, mh._SyntheticChallengeTransport) for t in mounts  # pylint: disable=protected-access
-        )
-        # One shared one-shot gate across default + proxy transports.
+        assert mounts  # the proxy mount is present...
+        # ...and both the default transport and the mount are wrapped...
+        assert all(isinstance(t, mh._SyntheticChallengeTransport) for t in mounts)  # pylint: disable=protected-access
+        # ...sharing one one-shot gate so exactly one 401 fires either way.
         assert all(t._fired is transport._fired for t in mounts)  # pylint: disable=protected-access
     finally:
         asyncio.run(client.aclose())


### PR DESCRIPTION


<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Some MCP servers (Google Maps/Gmail/Calendar/Drive, Hugging Face) answer an unauthenticated initialize with 200 and only require a token at tool-call time, so the SDK's OAuthClientProvider - which starts its OAuth flow only from a 401 - never authorizes. When the connect probe succeeds without a token, discover the server's RFC 9728 protected-resource metadata; if present, re-probe through a transport that injects a synthetic 401 pointing at it, and the stock SDK flow runs unchanged from there. Servers with no such metadata report a precise error (open server / API-key auth) instead of the generic "no 401 challenge".

The same 200-on-dead-token behavior also masked expired refresh tokens: the silent refresh probe succeeded so no exception surfaced and the connection looked healthy. SilentRefreshOAuthProvider now records the refresh-grant HTTP status; a 4xx (invalid_grant) marks the entry needs_reauth so the reconnect gate fires, while 5xx/rate-limit stays transient.

Thread extra_authorize_params through /start -> flow -> redirect handler so Google gets access_type=offline & prompt=consent (required for a refresh token); they are appended without overriding the SDK's own params.

Catalog: add Gmail, Google Calendar, Google Drive, Google Maps, Hugging Face, and Salesforce; order both groups alphabetically; give each Google service its real product logo (the favicon service returns the generic "G").

Extract the httpx-level machinery (client factory, synthetic transport, PRM discovery) into mcp_http.py to keep mcp_oauth_manager focused on flow orchestration. Wrap proxy mounts as well as the default transport so the synthetic 401 still fires behind an HTTPS/ALL proxy.


Fixes #245 


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
