### PR TITLE
Gate MCP connect requirement on http_headers.required, not every declared server

### DIFF
--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -218,8 +218,17 @@ authorize request and file it.
 polls the flow status as a fallback, so completion is still detected if the
 popup can't message back.
 
-**A network prompts you to connect before chatting** — if a network's
-`sly_data_schema` declares `http_headers` for an MCP URL you haven't connected —
-or one whose connection expired and could not be renewed — nsflow surfaces a
-gate directing you to the Connectors tab. Connect (or reconnect) the server,
-then retry.
+**A network prompts you to connect before chatting** — if a network *requires* an
+MCP URL you haven't connected — or one whose connection expired and could not be
+renewed — nsflow surfaces a gate directing you to the Connectors tab. Connect (or
+reconnect) the server, then retry.
+
+Which URLs are *required* comes from the network's `sly_data_schema`: the
+`http_headers.required` array (a sibling of `http_headers.properties`) lists the
+URLs the network cannot function without. A network author who wants a URL to
+receive an injected token **when connected** without *forcing* the connection —
+because the server accepts an alternative credential (an API key via
+`MCP_SERVERS_INFO_FILE`) or needs no auth at all — should declare it under
+`http_headers.properties` but leave it out of `http_headers.required`. If a tool
+declares no `required` array, every URL it declares is treated as required
+(gate on all).

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -498,11 +498,11 @@ class NsWebsocketUtils:
         return self.collect_network_mcp_urls(self.agent_name)
 
     @classmethod
-    def collect_network_mcp_urls(cls, agent_name: str):
+    def _load_schema_mcp_urls(cls, agent_name: str):
         """
-        Collect the MCP server URLs a network expects auth headers for.
+        Load the network and return ``(declared, required)`` schema URL sets.
 
-        These come solely from the network's declared ``sly_data_schema`` - the
+        Both come solely from the network's declared ``sly_data_schema`` - the
         MCP URLs listed under
         ``tools[].function.sly_data_schema.properties.http_headers.properties``.
         This is the explicit contract: a network that requires authenticated MCP
@@ -512,29 +512,73 @@ class NsWebsocketUtils:
         auth at all - those must not be flagged as a missing connection nor have
         a token injected for them.
 
+        The two sets serve different jobs (see :meth:`collect_network_mcp_urls`
+        and :meth:`collect_required_mcp_urls`): ``declared`` is every URL under
+        ``http_headers.properties`` (the injection set), while ``required`` is the
+        subset the network cannot function without (the gating set), read from the
+        ``http_headers.required`` array when present.
+
         Loads the network through ``AgentNetworkUtils.get_agent_network`` - the
         same restore path the rest of the app uses - so the config is plain and
         fully resolved (commondefs/defaults applied), and missing/remote networks
         raise.
 
-        :return: The set of schema-declared URLs (possibly empty), or None if the
-                 network is not readable locally (invalid name, or a network on a
-                 remote neuro-san server), signalling the caller to fall back to
-                 all connections.
+        :return: ``(declared, required)`` sets (each possibly empty), or
+                 ``(None, None)`` if the network is not readable locally (invalid
+                 name, or a network on a remote neuro-san server), signalling the
+                 caller to fall back to all connections.
         """
         try:
             agent_network = AgentNetworkUtils().get_agent_network(agent_name)
             if agent_network is None:
-                return None
+                return None, None
             config = agent_network.get_config()
         except Exception as e:  # noqa: BLE001 - invalid/remote/unreadable network
             logging.info("MCP auth: network '%s' not readable locally: %s", agent_name, e)
-            return None
+            return None, None
 
-        # Schema-declared URLs are the explicit auth contract.
-        urls: set = set()
-        cls._collect_schema_http_header_urls(config, urls)
-        return urls
+        declared: set = set()
+        required: set = set()
+        cls._collect_schema_http_header_urls(config, declared, required)
+        return declared, required
+
+    @classmethod
+    def collect_network_mcp_urls(cls, agent_name: str):
+        """
+        The MCP URLs a network may need an auth header for - the *injection* set.
+
+        Every URL declared under ``http_headers.properties`` is returned, so a
+        token is injected opportunistically whenever one is connected. Whether the
+        user is *forced* to connect a URL is a separate question answered by
+        :meth:`collect_required_mcp_urls`.
+
+        :return: The set of schema-declared URLs (possibly empty), or None if the
+                 network is not readable locally, signalling the caller to fall
+                 back to all connections.
+        """
+        declared, _ = cls._load_schema_mcp_urls(agent_name)
+        return declared
+
+    @classmethod
+    def collect_required_mcp_urls(cls, agent_name: str):
+        """
+        The MCP URLs a network cannot function without - the *gating* set.
+
+        A network narrows the gate by adding an ``http_headers.required`` array
+        (a sibling of ``http_headers.properties``, per JSON Schema) listing only
+        the URLs it truly needs. This lets a network declare a URL for
+        opportunistic token injection without forcing a connection - useful when
+        the server accepts an alternative credential (an API key via
+        ``MCP_SERVERS_INFO_FILE``) or needs no auth at all.
+
+        When a tool's ``http_headers`` has no ``required`` array, every declared
+        URL is treated as required (backward-compatible default: gate on all).
+
+        :return: The set of required URLs (possibly empty), or None if the network
+                 is not readable locally.
+        """
+        _, required = cls._load_schema_mcp_urls(agent_name)
+        return required
 
     @classmethod
     def missing_mcp_connections(cls, agent_name: str) -> Optional[List[str]]:
@@ -568,7 +612,7 @@ class NsWebsocketUtils:
         :return: ``{"missing": [...], "needs_reauth": [...]}`` (sorted), or None
                  if the network is not locally readable.
         """
-        required = cls.collect_network_mcp_urls(agent_name)
+        required = cls.collect_required_mcp_urls(agent_name)
         if required is None:
             return None
         return cls._gaps_from(required, FileTokenStorage.list_connections())
@@ -611,7 +655,7 @@ class NsWebsocketUtils:
         hung server can't block the gate; on timeout or per-URL failure the gaps
         are computed from the state on disk.
         """
-        required = await asyncio.to_thread(cls.collect_network_mcp_urls, agent_name)
+        required = await asyncio.to_thread(cls.collect_required_mcp_urls, agent_name)
         if required is None:
             return None
         connections = await asyncio.to_thread(FileTokenStorage.list_connections)
@@ -650,19 +694,34 @@ class NsWebsocketUtils:
         return cls._gaps_from(required, connections)
 
     @staticmethod
-    def _collect_schema_http_header_urls(config: Any, urls: set) -> None:
+    def _clean_schema_url(value: Any) -> Optional[str]:
         """
-        Add MCP URLs declared in any tool's ``sly_data_schema`` to ``urls``.
+        Normalize a schema URL key/entry, or return None if it is not an http URL.
+
+        A URL key must be quoted in HOCON (it contains ``:`` and ``/``), and
+        neuro-san's restorer preserves those surrounding quotes in the parsed
+        key (e.g. ``'"https://api.githubcopilot.com/mcp"'``), so the surrounding
+        quotes are stripped before the ``http(s)`` check.
+        """
+        if not isinstance(value, str):
+            return None
+        value = value.strip().strip('"').strip("'").strip()
+        return value if value.startswith(("http://", "https://")) else None
+
+    @classmethod
+    def _collect_schema_http_header_urls(cls, config: Any, urls: set, required_urls: set) -> None:
+        """
+        Add MCP URLs declared in any tool's ``sly_data_schema`` to ``urls``, and
+        the *gating* subset (the URLs the network cannot function without) to
+        ``required_urls``.
 
         Reads ``tools[].function.sly_data_schema.properties.http_headers.properties``
         - each key there is an MCP URL the network advertises it needs an
         ``http_headers`` entry for. Every level is type-guarded so a partial or
         unconventional schema is simply skipped rather than raising.
 
-        A URL key must be quoted in HOCON (it contains ``:`` and ``/``), and
-        neuro-san's restorer preserves those surrounding quotes in the parsed
-        key (e.g. ``'"https://api.githubcopilot.com/mcp"'``), so each key is
-        unquoted before the ``http(s)`` check.
+        The gating subset comes from each tool's ``http_headers.required`` array;
+        see :meth:`_required_urls_for_tool` for how it is matched.
         """
         tools = config.get("tools") if isinstance(config, dict) else None
         if not isinstance(tools, list):
@@ -677,12 +736,45 @@ class NsWebsocketUtils:
             header_props = http_headers.get("properties") if isinstance(http_headers, dict) else None
             if not isinstance(header_props, dict):
                 continue
-            for url in header_props:
-                if not isinstance(url, str):
-                    continue
-                url = url.strip().strip('"').strip("'").strip()
-                if url.startswith(("http://", "https://")):
-                    urls.add(url)
+            declared = {cleaned for url in header_props if (cleaned := cls._clean_schema_url(url)) is not None}
+            urls |= declared
+            required_urls |= cls._required_urls_for_tool(http_headers, declared)
+
+    @classmethod
+    def _required_urls_for_tool(cls, http_headers: dict, declared: set) -> set:
+        """
+        The *gating* subset of a single tool's ``declared`` http_headers URLs.
+
+        Read from the ``http_headers.required`` array (a sibling of
+        ``http_headers.properties``, per JSON Schema): each required entry is
+        matched to a declared URL on its normalized form (so a cosmetic difference
+        - trailing slash / host case / default port - between the entry and its
+        properties key doesn't silently drop the gate, the same normalization the
+        rest of this module matches connections by), and the declared URL's
+        canonical form is what gates. A required entry matching no declared URL is
+        ignored (nothing to inject for it) and logged. When there is no
+        ``required`` array, every declared URL is required - the backward-compatible
+        default (gate on all).
+        """
+        required_list = http_headers.get("required")
+        if not isinstance(required_list, list):
+            return declared
+        required: set = set()
+        declared_by_norm = {cls._normalize_mcp_url(url): url for url in declared}
+        for entry in required_list:
+            cleaned = cls._clean_schema_url(entry)
+            if cleaned is None:
+                continue
+            canonical = declared_by_norm.get(cls._normalize_mcp_url(cleaned))
+            if canonical is not None:
+                required.add(canonical)
+            else:
+                logging.info(
+                    "MCP auth: network requires '%s' but it is not declared in "
+                    "http_headers.properties; ignoring.",
+                    cleaned,
+                )
+        return required
 
     @classmethod
     def get_latest_sly_data(cls, network_name: str, session_id: str = None) -> dict:

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -502,21 +502,22 @@ class NsWebsocketUtils:
         """
         Load the network and return ``(declared, required)`` schema URL sets.
 
-        Both come solely from the network's declared ``sly_data_schema`` - the
-        MCP URLs listed under
-        ``tools[].function.sly_data_schema.properties.http_headers.properties``.
+        Both are derived from the network's declared ``sly_data_schema`` and
+        serve different jobs (see :meth:`collect_network_mcp_urls` and
+        :meth:`collect_required_mcp_urls`):
+
+        * ``declared`` (the injection set) is every MCP URL listed under
+          ``tools[].function.sly_data_schema.properties.http_headers.properties``.
+        * ``required`` (the gating set) is the subset the network cannot function
+          without, selected from each tool's ``http_headers.required`` array (see
+          :meth:`_required_urls_for_tool`).
+
         This is the explicit contract: a network that requires authenticated MCP
         access advertises exactly which URLs need ``http_headers`` (see neuro-san
         ``mcp_github.hocon``). We deliberately do NOT also harvest every MCP URL
         the tools reference, because a network may call MCP servers that need no
         auth at all - those must not be flagged as a missing connection nor have
         a token injected for them.
-
-        The two sets serve different jobs (see :meth:`collect_network_mcp_urls`
-        and :meth:`collect_required_mcp_urls`): ``declared`` is every URL under
-        ``http_headers.properties`` (the injection set), while ``required`` is the
-        subset the network cannot function without (the gating set), read from the
-        ``http_headers.required`` array when present.
 
         Loads the network through ``AgentNetworkUtils.get_agent_network`` - the
         same restore path the rest of the app uses - so the config is plain and
@@ -751,14 +752,26 @@ class NsWebsocketUtils:
         - trailing slash / host case / default port - between the entry and its
         properties key doesn't silently drop the gate, the same normalization the
         rest of this module matches connections by), and the declared URL's
-        canonical form is what gates. A required entry matching no declared URL is
-        ignored (nothing to inject for it) and logged. When there is no
-        ``required`` array, every declared URL is required - the backward-compatible
-        default (gate on all).
+        canonical form is what gates.
+
+        Fail closed so a schema mistake never silently disables the gate:
+
+        * no ``required`` array (or a non-list value) -> every declared URL is
+          required (gate on all);
+        * a non-empty ``required`` array that matches *no* declared URL (a typo or
+          the array placed at the wrong nesting level) -> gate on all declared,
+          logged as a warning;
+        * only an explicit empty array (``required: []``) gates on nothing.
+
+        A required entry matching no declared URL while others do match is ignored
+        (nothing to inject for it) and logged.
         """
         required_list = http_headers.get("required")
         if not isinstance(required_list, list):
             return declared
+        if not required_list:
+            # Explicit empty array: intentional opt-out, gate on nothing.
+            return set()
         required: set = set()
         declared_by_norm = {cls._normalize_mcp_url(url): url for url in declared}
         for entry in required_list:
@@ -770,10 +783,19 @@ class NsWebsocketUtils:
                 required.add(canonical)
             else:
                 logging.info(
-                    "MCP auth: network requires '%s' but it is not declared in "
-                    "http_headers.properties; ignoring.",
+                    "MCP auth: network requires '%s' but it is not declared in http_headers.properties; ignoring.",
                     cleaned,
                 )
+        if not required:
+            # A non-empty required list that matched nothing is almost certainly an
+            # authoring error (typo / wrong nesting level), not an intent to gate
+            # nothing - fail closed on all declared URLs, don't silently drop the gate.
+            logging.warning(
+                "MCP auth: none of the required entries %s matched a declared http_headers URL; "
+                "gating on all declared URLs.",
+                required_list,
+            )
+            return declared
         return required
 
     @classmethod

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -521,8 +521,9 @@ class NsWebsocketUtils:
 
         Loads the network through ``AgentNetworkUtils.get_agent_network`` - the
         same restore path the rest of the app uses - so the config is plain and
-        fully resolved (commondefs/defaults applied), and missing/remote networks
-        raise.
+        fully resolved (commondefs/defaults applied). A missing/remote/unreadable
+        network (``get_agent_network`` returning None or raising) is caught here
+        and reported as ``(None, None)`` rather than propagating.
 
         :return: ``(declared, required)`` sets (each possibly empty), or
                  ``(None, None)`` if the network is not readable locally (invalid

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -203,6 +203,84 @@ def test_get_urls_remote_or_missing_network_returns_none(monkeypatch):
     assert _utils().get_network_mcp_urls() is None
 
 
+# --------------------------- collect_required_mcp_urls --------------------------- #
+
+
+def _two_url_tool(url_a, url_b, required=None):
+    """A front-man tool declaring two http_headers URLs, optionally with a required array."""
+    tool = _schema_tool(url_a)
+    http_headers = tool["function"]["sly_data_schema"]["properties"]["http_headers"]
+    http_headers["properties"][url_b] = {"type": "object"}
+    if required is not None:
+        http_headers["required"] = required
+    return tool
+
+
+def test_required_defaults_to_all_declared(monkeypatch):
+    """With no required array, every declared URL is required (backward-compatible)."""
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    _patch_network(monkeypatch, config={"tools": [_two_url_tool(url_a, url_b)]})
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == {url_a, url_b}
+
+
+def test_required_honors_required_array(monkeypatch):
+    """A required array narrows gating to its URLs, while injection still sees both."""
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    _patch_network(monkeypatch, config={"tools": [_two_url_tool(url_a, url_b, required=[url_a])]})
+    # Only the required URL gates...
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == {url_a}
+    # ...but both are still injection targets (opportunistic auth for the optional one).
+    assert _utils().get_network_mcp_urls() == {url_a, url_b}
+
+
+def test_required_empty_array_requires_nothing(monkeypatch):
+    """An empty required array makes every declared URL optional (gate nothing)."""
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    _patch_network(monkeypatch, config={"tools": [_two_url_tool(url_a, url_b, required=[])]})
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == set()
+    assert _utils().get_network_mcp_urls() == {url_a, url_b}
+
+
+def test_required_ignores_undeclared_entry(monkeypatch):
+    """A required URL not declared under properties is ignored (nothing to inject for it)."""
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    tool = _two_url_tool(url_a, url_b, required=[url_a, "https://ghost.example.com/mcp"])
+    _patch_network(monkeypatch, config={"tools": [tool]})
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == {url_a}
+
+
+def test_required_matches_normalized(monkeypatch):
+    """A required entry differing only cosmetically from its properties key still gates."""
+    # properties key has no trailing slash; required lists the trailing-slash
+    # form. Matching normalizes both, and the declared (canonical) form gates.
+    declared = "https://a.example.com/mcp"
+    tool = _two_url_tool(declared, "https://b.example.com/mcp", required=["https://A.example.com/mcp/"])
+    _patch_network(monkeypatch, config={"tools": [tool]})
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == {declared}
+
+
+def test_required_non_list_gates_all(monkeypatch):
+    """A malformed (non-list) required value falls back to gating on all declared URLs."""
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    _patch_network(monkeypatch, config={"tools": [_two_url_tool(url_a, url_b, required="oops")]})
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == {url_a, url_b}
+
+
+def test_required_is_per_tool(monkeypatch):
+    """A tool without a required array still gates on all its URLs even if another tool narrows."""
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    narrowed = _two_url_tool(url_a, url_b, required=[url_a])
+    default = _schema_tool("https://c.example.com/mcp")
+    _patch_network(monkeypatch, config={"tools": [narrowed, default]})
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == {url_a, "https://c.example.com/mcp"}
+
+
+def test_required_none_when_network_unreadable(monkeypatch):
+    """An unreadable network yields None so the caller does not gate on it."""
+    _patch_network(monkeypatch, raise_exc=FileNotFoundError("remote"))
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") is None
+
+
 # --------------------------- missing_mcp_connections --------------------------- #
 
 
@@ -227,6 +305,17 @@ def test_missing_mcp_connections_reports_unconnected(monkeypatch):
     _patch_network(monkeypatch, config={"tools": [tool]})
     _patch_connections(monkeypatch, ["https://connected.example.com/mcp"])
     assert nw.NsWebsocketUtils.missing_mcp_connections("net") == ["https://api.githubcopilot.com/mcp"]
+
+
+def test_missing_mcp_connections_skips_optional_url(monkeypatch):
+    """A declared-but-not-required URL with no connection does not gate the network."""
+    # `required` lists only url_a, so an unconnected url_b (optional - it may
+    # authenticate another way, or need no auth) must NOT be reported as missing.
+    url_a, url_b = "https://required.example.com/mcp", "https://optional.example.com/mcp"
+    tool = _two_url_tool(url_a, url_b, required=[url_a])
+    _patch_network(monkeypatch, config={"tools": [tool]})
+    _patch_connections(monkeypatch, [])  # neither is connected
+    assert nw.NsWebsocketUtils.missing_mcp_connections("net") == [url_a]
 
 
 def test_missing_mcp_connections_matches_normalized(monkeypatch):

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -266,6 +266,17 @@ def test_required_non_list_gates_all(monkeypatch):
     assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == {url_a, url_b}
 
 
+def test_required_all_unmatched_gates_all(monkeypatch):
+    """A non-empty required array that matches no declared URL fails closed (gate on all)."""
+    # Every required entry is a typo / wrong URL, so none match declared. Rather
+    # than silently gating nothing, fall back to requiring all declared URLs -
+    # only an explicit `required: []` opts out of gating.
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    tool = _two_url_tool(url_a, url_b, required=["https://typo.example.com/mcp"])
+    _patch_network(monkeypatch, config={"tools": [tool]})
+    assert nw.NsWebsocketUtils.collect_required_mcp_urls("net") == {url_a, url_b}
+
+
 def test_required_is_per_tool(monkeypatch):
     """A tool without a required array still gates on all its URLs even if another tool narrows."""
     url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"


### PR DESCRIPTION
## Summary

nsflow treated **every** MCP URL a network declares under `sly_data_schema.properties.http_headers.properties` as mandatory: a single collector drove both token injection *and* the connect gate, so declaring a server for opportunistic injection also **forced** the user through an OAuth connect before chatting — even when that server accepts an alternative credential (an API key via `MCP_SERVERS_INFO_FILE` / `YDC_API_KEY`) or needs no auth at all.

This PR splits those two responsibilities and keys the gate off the schema's `required` array.

## What changed

- **Injection set** (`collect_network_mcp_urls`) — every URL under `http_headers.properties`. **Unchanged**; token injection stays opportunistic.
- **Gating set** (new `collect_required_mcp_urls`) — the URLs listed in each tool's `http_headers.required` array (a sibling of `http_headers.properties`, per JSON Schema). `missing_mcp_connections` / `mcp_connection_gaps` / `mcp_connection_gaps_fresh` now gate on this narrowed set.
- Both sets come from one network read via a shared `_load_schema_mcp_urls`, returning `(declared, required)`.

## Behavior

- **Backward-compatible default:** a tool with no `required` array gates on *all* its declared URLs (today's behavior), applied per-tool.
- `required: []` → gate on nothing (auth-optional / API-key path) while still injecting a token when the server is connected.
- `required: ["<url>", ...]` → gate only on those URLs.
- Required entries are matched to declared URLs on their **normalized** form (trailing slash / host case / default port), consistent with the rest of the module, so a cosmetic difference doesn't silently drop the gate.

No frontend change: the gate endpoint returns the narrowed gaps, so the UI stops prompting for optional URLs automatically.

## Tests

Adds coverage under `tests/nsflow/test_ns_websocket_mcp.py`: default-gates-all, honors-required, empty-array-gates-nothing, ignores-undeclared-entry, per-tool scoping, normalized matching, non-list `required` fallback, unreadable→None, and an optional-URL-not-gated case. `ruff` clean, `pylint` 10.00/10, all tests pass.

## Follow-up (out of scope, separate repo)

`neuro-san-demos`' `you_search.hocon` places its `required` array one level too deep (inside `sly_data_schema.properties` rather than on the `http_headers` object), so it falls back to gate-on-all — no regression, but the example should be corrected there to opt into the new behavior.

Fixes #247
