### PR TITLE
Work around Salesforce rejecting PKCE code_verifiers containing '~'

### DIFF
--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -36,6 +36,7 @@ them when needed so the token injected into ``sly_data`` is never stale.
 import asyncio
 import base64
 import hashlib
+import inspect
 import logging
 import os
 import secrets
@@ -170,9 +171,21 @@ class MCPOAuthManager:
         The SDK exposes no hook to supply our own verifier, so we swap its
         ``PKCEParameters.generate`` for :meth:`_base64url_pkce_parameters`.
         base64url is the subset every provider accepts, so this is safe globally.
+
+        Raises ``RuntimeError`` if the SDK no longer exposes ``generate`` as a
+        classmethod (e.g. a bump renamed or inlined PKCE generation). Blindly
+        assigning to a missing attribute would leave the stock ``~``-containing
+        verifier on the real flow - a silent regression that unit tests calling
+        ``generate()`` directly would not catch - so we fail loud at import/CI.
         """
         if cls._pkce_verifier_patched:
             return
+        if not isinstance(inspect.getattr_static(PKCEParameters, "generate", None), classmethod):
+            raise RuntimeError(
+                "MCP SDK PKCEParameters.generate is missing or no longer a classmethod; "
+                "the base64url PKCE workaround cannot be installed. Re-verify the SDK's "
+                "PKCE code_verifier generation (Salesforce rejects '~') after this dependency bump."
+            )
         PKCEParameters.generate = classmethod(cls._base64url_pkce_parameters)
         cls._pkce_verifier_patched = True
 

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -96,32 +96,6 @@ _RESERVED_AUTHORIZE_PARAMS = frozenset(
 )
 
 
-def _install_salesforce_pkce_workaround() -> None:
-    """
-    Patch the MCP SDK's PKCE generator so the code_verifier never contains ``~``.
-
-    Salesforce's token endpoint rejects a ``code_verifier`` that contains ``~``
-    with ``invalid_grant`` / "invalid code verifier", even though RFC 7636 lists
-    ``~`` as an allowed *unreserved* character (``A-Z a-z 0-9 - . _ ~``). The MCP
-    SDK's ``PKCEParameters.generate()`` draws each of 128 chars from that full
-    set, so ~86% of generated verifiers include a ``~`` and Salesforce rejects
-    the otherwise-cryptographically-valid pair. The SDK offers no hook to supply
-    our own verifier, so we replace the generator with one that draws from the
-    same set minus ``~`` - still RFC-compliant and accepted by every provider.
-    """
-    charset = string.ascii_letters + string.digits + "-._"  # RFC 7636 unreserved, minus '~'
-
-    def _generate(cls):
-        verifier = "".join(secrets.choice(charset) for _ in range(128))
-        challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
-        return cls(code_verifier=verifier, code_challenge=challenge)
-
-    PKCEParameters.generate = classmethod(_generate)
-
-
-_install_salesforce_pkce_workaround()
-
-
 @dataclass
 class PendingFlow:  # pylint: disable=too-many-instance-attributes  # dataclass aggregating flow fields
     """In-flight OAuth authorization for a single MCP server connection."""
@@ -168,6 +142,10 @@ class MCPOAuthManager:
     MCP OAuth. Keep the backend single-worker.
     """
 
+    # Set once the SDK's PKCE generator has been replaced; class-level so the
+    # global patch installs exactly once (see _ensure_base64url_pkce_verifier).
+    _pkce_verifier_patched: bool = False
+
     def __init__(self):
         self._by_flow_id: Dict[str, PendingFlow] = {}
         self._by_state: Dict[str, PendingFlow] = {}
@@ -176,6 +154,42 @@ class MCPOAuthManager:
         self._cleanup_tasks: set = set()
         # Per-server locks serializing silent refreshes (see _refresh_lock).
         self._refresh_locks: Dict[str, asyncio.Lock] = {}
+        self._ensure_base64url_pkce_verifier()
+
+    @classmethod
+    def _ensure_base64url_pkce_verifier(cls) -> None:
+        """
+        Replace the MCP SDK's PKCE generator with a base64url one, once.
+
+        Salesforce's token endpoint rejects a ``code_verifier`` containing ``~``
+        with ``invalid_grant`` / "invalid code verifier" - it documents the
+        verifier as base64url (RFC 4648 §5), which is stricter than RFC 7636's
+        unreserved set (RFC 7636 additionally allows ``.`` and ``~``). The MCP
+        SDK draws verifier chars from the full unreserved set, so ~86% include a
+        ``~`` and are rejected even though the pair is cryptographically valid.
+        The SDK exposes no hook to supply our own verifier, so we swap its
+        ``PKCEParameters.generate`` for :meth:`_base64url_pkce_parameters`.
+        base64url is the subset every provider accepts, so this is safe globally.
+        """
+        if cls._pkce_verifier_patched:
+            return
+        PKCEParameters.generate = classmethod(cls._base64url_pkce_parameters)
+        cls._pkce_verifier_patched = True
+
+    @staticmethod
+    def _base64url_pkce_parameters(pkce_cls: type) -> PKCEParameters:
+        """
+        Build PKCE parameters whose ``code_verifier`` is base64url (``A-Za-z0-9-_``).
+
+        Installed as the SDK's ``PKCEParameters.generate`` (see
+        :meth:`_ensure_base64url_pkce_verifier`), hence ``pkce_cls`` is the SDK's
+        ``PKCEParameters`` class passed in by the classmethod protocol. Still 128
+        chars (~768 bits of entropy) and a valid S256 pair.
+        """
+        charset = string.ascii_letters + string.digits + "-_"  # base64url (RFC 4648 §5)
+        verifier = "".join(secrets.choice(charset) for _ in range(128))
+        challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+        return pkce_cls(code_verifier=verifier, code_challenge=challenge)
 
     def _refresh_lock(self, server_url: str) -> asyncio.Lock:
         """

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -34,8 +34,12 @@ them when needed so the token injected into ``sly_data`` is never stale.
 """
 
 import asyncio
+import base64
+import hashlib
 import logging
 import os
+import secrets
+import string
 import time
 import uuid
 from dataclasses import dataclass
@@ -51,6 +55,7 @@ from urllib.parse import urlsplit
 from mcp import ClientSession
 from mcp.client.auth import OAuthClientProvider
 from mcp.client.auth.exceptions import OAuthTokenError
+from mcp.client.auth.oauth2 import PKCEParameters
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.auth import OAuthClientInformationFull
 from mcp.shared.auth import OAuthClientMetadata
@@ -89,6 +94,32 @@ _RESERVED_AUTHORIZE_PARAMS = frozenset(
         "resource",
     }
 )
+
+
+def _install_salesforce_pkce_workaround() -> None:
+    """
+    Patch the MCP SDK's PKCE generator so the code_verifier never contains ``~``.
+
+    Salesforce's token endpoint rejects a ``code_verifier`` that contains ``~``
+    with ``invalid_grant`` / "invalid code verifier", even though RFC 7636 lists
+    ``~`` as an allowed *unreserved* character (``A-Z a-z 0-9 - . _ ~``). The MCP
+    SDK's ``PKCEParameters.generate()`` draws each of 128 chars from that full
+    set, so ~86% of generated verifiers include a ``~`` and Salesforce rejects
+    the otherwise-cryptographically-valid pair. The SDK offers no hook to supply
+    our own verifier, so we replace the generator with one that draws from the
+    same set minus ``~`` - still RFC-compliant and accepted by every provider.
+    """
+    charset = string.ascii_letters + string.digits + "-._"  # RFC 7636 unreserved, minus '~'
+
+    def _generate(cls):
+        verifier = "".join(secrets.choice(charset) for _ in range(128))
+        challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+        return cls(code_verifier=verifier, code_challenge=challenge)
+
+    PKCEParameters.generate = classmethod(_generate)
+
+
+_install_salesforce_pkce_workaround()
 
 
 @dataclass

--- a/tests/nsflow/test_mcp_pkce_verifier.py
+++ b/tests/nsflow/test_mcp_pkce_verifier.py
@@ -41,7 +41,10 @@ from mcp.client.auth.oauth2 import PKCEParameters
 # bind the same class object and .generate resolves at call time.
 from nsflow.backend.utils.mcp.mcp_oauth_manager import MCPOAuthManager
 
-# The base64url alphabet (RFC 4648 §5) - the only chars the verifier may contain.
+# The base64url alphabet (RFC 4648 §5): the only chars *our patched* verifier emits.
+# This is a strict subset of RFC 7636's unreserved set (which also permits '.' and
+# '~'); we pin the narrower set because that's what the Salesforce-safe workaround
+# produces, not because the protocol requires it.
 _BASE64URL = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
 
 
@@ -51,8 +54,11 @@ def _expected_challenge(verifier: str) -> str:
 
 
 def test_generated_verifier_is_base64url_only():
-    """Across many draws, the verifier never contains '~' or '.' (both outside base64url)."""
-    for _ in range(3000):
+    """Across repeated draws, the verifier never contains '~' or '.' (both outside base64url)."""
+    # If the patch regressed to the SDK's unreserved charset, ~86% of draws would
+    # contain a '~', so even this modest sample makes a miss astronomically unlikely
+    # (0.14**200) - no need for thousands of generations.
+    for _ in range(200):
         verifier = PKCEParameters.generate().code_verifier
         assert "~" not in verifier  # the char Salesforce rejects
         assert "." not in verifier  # also outside base64url, dropped for strictness
@@ -101,7 +107,10 @@ def test_sdk_auth_code_grant_still_calls_generate():
     ``PKCEParameters.generate`` - the exact attribute we patch. If a future SDK
     inlines or renames PKCE generation, our patch silently no-ops and Salesforce
     breaks again; failing here forces a re-verify instead of a silent regression."""
-    assert "PKCEParameters.generate(" in inspect.getsource(sdk_oauth2)
+    # Strip whitespace so a non-semantic SDK reformat (added spaces, a line wrap)
+    # doesn't trip the canary - only an actual inline/rename should.
+    source_no_ws = "".join(inspect.getsource(sdk_oauth2).split())
+    assert "PKCEParameters.generate(" in source_no_ws
 
 
 def test_ensure_verifier_raises_on_sdk_shape_change():

--- a/tests/nsflow/test_mcp_pkce_verifier.py
+++ b/tests/nsflow/test_mcp_pkce_verifier.py
@@ -28,14 +28,18 @@ while still producing a valid S256 pair.
 
 import base64
 import hashlib
+import inspect
 
+import mcp.client.auth.oauth2 as sdk_oauth2
+import pytest
 from mcp.client.auth.oauth2 import PKCEParameters
 
-# Importing this module installs the PKCE workaround as a side effect: creating
-# the module-level singleton runs MCPOAuthManager.__init__, which patches
-# PKCEParameters.generate. Order vs the mcp import above doesn't matter - both
+# Importing this module installs the PKCE workaround as a side effect: importing
+# any name from it runs the module body, which creates the module-level singleton
+# (MCPOAuthManager.__init__ -> _ensure_base64url_pkce_verifier, which patches
+# PKCEParameters.generate). Order vs the mcp imports above doesn't matter - both
 # bind the same class object and .generate resolves at call time.
-import nsflow.backend.utils.mcp.mcp_oauth_manager  # noqa: F401  pylint: disable=unused-import
+from nsflow.backend.utils.mcp.mcp_oauth_manager import MCPOAuthManager
 
 # The base64url alphabet (RFC 4648 §5) - the only chars the verifier may contain.
 _BASE64URL = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
@@ -74,3 +78,48 @@ def test_verifier_has_high_entropy_charset():
         seen.update(PKCEParameters.generate().code_verifier)
     assert seen <= _BASE64URL
     assert len(seen) > 40
+
+
+# The tests below exercise the patch as wired into the SDK/manager, not just the
+# generator in isolation - so a regression that decouples the workaround from the
+# real OAuth flow (SDK drift or the manager failing to install) is caught here.
+# pylint: disable=protected-access  # asserting on the workaround's internals
+
+
+def test_patch_installed_on_sdk_class():
+    """The manager installed *our* generator onto the SDK class - not merely that
+    generate() happens to return base64url. This ties the workaround to the exact
+    attribute the real authorization-code flow calls."""
+    assert MCPOAuthManager._pkce_verifier_patched is True
+    # PKCEParameters.generate is our classmethod; its __func__ is the manager's
+    # generator function object (same object accessed via either class).
+    assert PKCEParameters.generate.__func__ is MCPOAuthManager._base64url_pkce_parameters
+
+
+def test_sdk_auth_code_grant_still_calls_generate():
+    """Canary: the SDK's authorization-code grant still routes through
+    ``PKCEParameters.generate`` - the exact attribute we patch. If a future SDK
+    inlines or renames PKCE generation, our patch silently no-ops and Salesforce
+    breaks again; failing here forces a re-verify instead of a silent regression."""
+    assert "PKCEParameters.generate(" in inspect.getsource(sdk_oauth2)
+
+
+def test_ensure_verifier_raises_on_sdk_shape_change():
+    """If the SDK no longer exposes ``generate`` as a classmethod (rename/inline),
+    installing the workaround must raise rather than silently overwrite a
+    missing/foreign attribute and regress the real flow."""
+    original = inspect.getattr_static(PKCEParameters, "generate", None)
+    was_patched = MCPOAuthManager._pkce_verifier_patched
+    try:
+        # Simulate SDK drift: generate is present but no longer a classmethod.
+        PKCEParameters.generate = staticmethod(lambda: None)
+        MCPOAuthManager._pkce_verifier_patched = False
+        with pytest.raises(RuntimeError, match="PKCEParameters.generate"):
+            MCPOAuthManager._ensure_base64url_pkce_verifier()
+    finally:
+        # Restore the real workaround so later tests keep base64url verifiers.
+        PKCEParameters.generate = original
+        MCPOAuthManager._pkce_verifier_patched = was_patched
+
+
+# pylint: enable=protected-access

--- a/tests/nsflow/test_mcp_pkce_verifier.py
+++ b/tests/nsflow/test_mcp_pkce_verifier.py
@@ -14,15 +14,16 @@
 #
 # END COPYRIGHT
 """
-Tests for the Salesforce PKCE code_verifier workaround.
+Tests for the base64url PKCE code_verifier workaround.
 
-Importing ``mcp_oauth_manager`` patches the MCP SDK's ``PKCEParameters.generate``
-so the generated ``code_verifier`` never contains ``~``. Salesforce's token
-endpoint rejects a verifier containing ``~`` with ``invalid_grant`` / "invalid
-code verifier", even though RFC 7636 allows it; the stock SDK draws from a set
-that includes ``~``, so ~86% of verifiers would be rejected. These tests pin that
-the patched generator excludes ``~`` while still producing a valid, RFC-compliant
-pair.
+Importing ``mcp_oauth_manager`` (which creates its singleton) patches the MCP SDK's
+``PKCEParameters.generate`` so the generated ``code_verifier`` is base64url
+(``A-Za-z0-9-_``). Salesforce's token endpoint rejects a verifier containing ``~``
+with ``invalid_grant`` / "invalid code verifier" - it documents the verifier as
+base64url, stricter than RFC 7636 (which also allows ``.`` and ``~``). The stock SDK
+draws from the full unreserved set including ``~``, so ~86% of verifiers would be
+rejected. These tests pin that the patched generator emits only base64url chars
+while still producing a valid S256 pair.
 """
 
 import base64
@@ -30,14 +31,14 @@ import hashlib
 
 from mcp.client.auth.oauth2 import PKCEParameters
 
-# Importing this module installs the PKCE workaround as a module-level side
-# effect (it patches PKCEParameters.generate). Order vs the mcp import above
-# doesn't matter: both bind the same class object and .generate resolves at call
-# time, so the patched generator is used regardless.
+# Importing this module installs the PKCE workaround as a side effect: creating
+# the module-level singleton runs MCPOAuthManager.__init__, which patches
+# PKCEParameters.generate. Order vs the mcp import above doesn't matter - both
+# bind the same class object and .generate resolves at call time.
 import nsflow.backend.utils.mcp.mcp_oauth_manager  # noqa: F401  pylint: disable=unused-import
 
-# RFC 7636 unreserved characters that a code_verifier may contain.
-_RFC7636_UNRESERVED = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
+# The base64url alphabet (RFC 4648 §5) - the only chars the verifier may contain.
+_BASE64URL = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
 
 
 def _expected_challenge(verifier: str) -> str:
@@ -45,19 +46,21 @@ def _expected_challenge(verifier: str) -> str:
     return base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
 
 
-def test_generated_verifier_never_contains_tilde():
-    """Across many draws, the patched generator never emits '~' (the char Salesforce rejects)."""
+def test_generated_verifier_is_base64url_only():
+    """Across many draws, the verifier never contains '~' or '.' (both outside base64url)."""
     for _ in range(3000):
-        assert "~" not in PKCEParameters.generate().code_verifier
+        verifier = PKCEParameters.generate().code_verifier
+        assert "~" not in verifier  # the char Salesforce rejects
+        assert "." not in verifier  # also outside base64url, dropped for strictness
 
 
-def test_generated_pair_is_valid_and_rfc_compliant():
-    """The patched generator still yields a valid S256 pair using only RFC 7636 chars."""
+def test_generated_pair_is_valid_and_base64url():
+    """The patched generator yields a valid S256 pair using only base64url chars."""
     params = PKCEParameters.generate()
     # Length within RFC 7636 bounds (the SDK model also enforces 43..128).
     assert 43 <= len(params.code_verifier) <= 128
-    # Only unreserved characters, and specifically none outside the allowed set.
-    assert set(params.code_verifier) <= _RFC7636_UNRESERVED
+    # Only base64url characters.
+    assert set(params.code_verifier) <= _BASE64URL
     # The challenge matches the verifier (S256), so the pair is cryptographically valid.
     assert params.code_challenge == _expected_challenge(params.code_verifier)
 
@@ -65,9 +68,9 @@ def test_generated_pair_is_valid_and_rfc_compliant():
 def test_verifier_has_high_entropy_charset():
     """The verifier still draws from a broad charset (not degenerate) - sanity on the workaround."""
     # 20 verifiers * 128 chars should exercise well over 40 distinct characters if the
-    # charset (letters+digits+"-._", 65 chars) is intact.
+    # base64url charset (64 chars) is intact.
     seen = set()
     for _ in range(20):
         seen.update(PKCEParameters.generate().code_verifier)
-    assert "~" not in seen
+    assert seen <= _BASE64URL
     assert len(seen) > 40

--- a/tests/nsflow/test_mcp_pkce_verifier.py
+++ b/tests/nsflow/test_mcp_pkce_verifier.py
@@ -1,0 +1,73 @@
+# Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for the Salesforce PKCE code_verifier workaround.
+
+Importing ``mcp_oauth_manager`` patches the MCP SDK's ``PKCEParameters.generate``
+so the generated ``code_verifier`` never contains ``~``. Salesforce's token
+endpoint rejects a verifier containing ``~`` with ``invalid_grant`` / "invalid
+code verifier", even though RFC 7636 allows it; the stock SDK draws from a set
+that includes ``~``, so ~86% of verifiers would be rejected. These tests pin that
+the patched generator excludes ``~`` while still producing a valid, RFC-compliant
+pair.
+"""
+
+import base64
+import hashlib
+
+from mcp.client.auth.oauth2 import PKCEParameters
+
+# Importing this module installs the PKCE workaround as a module-level side
+# effect (it patches PKCEParameters.generate). Order vs the mcp import above
+# doesn't matter: both bind the same class object and .generate resolves at call
+# time, so the patched generator is used regardless.
+import nsflow.backend.utils.mcp.mcp_oauth_manager  # noqa: F401  pylint: disable=unused-import
+
+# RFC 7636 unreserved characters that a code_verifier may contain.
+_RFC7636_UNRESERVED = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
+
+
+def _expected_challenge(verifier: str) -> str:
+    """The S256 challenge for a verifier: BASE64URL(SHA256(verifier)) without padding."""
+    return base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+
+
+def test_generated_verifier_never_contains_tilde():
+    """Across many draws, the patched generator never emits '~' (the char Salesforce rejects)."""
+    for _ in range(3000):
+        assert "~" not in PKCEParameters.generate().code_verifier
+
+
+def test_generated_pair_is_valid_and_rfc_compliant():
+    """The patched generator still yields a valid S256 pair using only RFC 7636 chars."""
+    params = PKCEParameters.generate()
+    # Length within RFC 7636 bounds (the SDK model also enforces 43..128).
+    assert 43 <= len(params.code_verifier) <= 128
+    # Only unreserved characters, and specifically none outside the allowed set.
+    assert set(params.code_verifier) <= _RFC7636_UNRESERVED
+    # The challenge matches the verifier (S256), so the pair is cryptographically valid.
+    assert params.code_challenge == _expected_challenge(params.code_verifier)
+
+
+def test_verifier_has_high_entropy_charset():
+    """The verifier still draws from a broad charset (not degenerate) - sanity on the workaround."""
+    # 20 verifiers * 128 chars should exercise well over 40 distinct characters if the
+    # charset (letters+digits+"-._", 65 chars) is intact.
+    seen = set()
+    for _ in range(20):
+        seen.update(PKCEParameters.generate().code_verifier)
+    assert "~" not in seen
+    assert len(seen) > 40


### PR DESCRIPTION
## Summary

Fixes Salesforce MCP OAuth failing at the token exchange with `invalid_grant: invalid code verifier`.

**Root cause:** Salesforce's token endpoint rejects any PKCE `code_verifier` containing `~`, even though RFC 7636 lists `~` as an allowed *unreserved* character — Salesforce documents the verifier as base64url (RFC 4648 §5), which is stricter. The MCP SDK's `PKCEParameters.generate()` draws each of 128 verifier chars from `A-Za-z0-9-._~`, so **~86%** of verifiers include a `~` and are rejected — even though the pair is always cryptographically valid (`code_challenge == BASE64URL(SHA256(code_verifier))`). This is why it failed on nearly every attempt yet occasionally worked (the ~14% with no `~`), and why it was independent of app, account, session, and `prompt`.

## Change

`MCPOAuthManager._ensure_base64url_pkce_verifier()` replaces the SDK's `PKCEParameters.generate` with `MCPOAuthManager._base64url_pkce_parameters`, which draws from strict **base64url** (`A-Za-z0-9-_`) — dropping both `~` **and** `.` to match exactly the charset Salesforce documents (RFC 4648 §5). base64url is a subset of RFC 7636's unreserved set, so every compliant provider accepts it; still 128 chars of entropy and a valid S256 pair.

It installs once (guarded by the class attr `_pkce_verifier_patched`) as a side effect of `MCPOAuthManager.__init__`, which runs at import via the module-level `mcp_oauth_manager` singleton — so it's in place before any MCP OAuth connect/refresh flow.

Before overwriting, it asserts the SDK still exposes `generate` as a classmethod and **raises `RuntimeError` on drift**, so a future SDK bump that renames/inlines PKCE generation trips at import/CI instead of silently reverting to `~`-containing verifiers in production.

## Verification

- With the fix, the Salesforce token exchange returns `200 OK` and the connection completes on the first attempt (confirmed against a live Salesforce External Client App).
- Diagnosis was confirmed by logging both sides of the pair: `code_challenge == sha256(code_verifier)`, yet Salesforce rejected verifiers that happened to contain `~`.
- New tests (`test_mcp_pkce_verifier.py`): the patched generator emits only base64url chars (never `~` or `.`) and yields a valid S256 pair; the manager actually installs our generator onto the SDK class; a canary asserts the SDK's auth-code grant still calls `PKCEParameters.generate`; and simulated SDK drift makes installation raise.
- `ruff format`/`ruff check`/`pylint` clean (10.00/10); full `tests/nsflow` suite passes (142 tests).

## Follow-up (out of scope)

Worth reporting upstream to `modelcontextprotocol/python-sdk`: dropping `~` from its default verifier charset would fix this for every Salesforce MCP client. If the SDK fixes it, this workaround becomes a harmless no-op.

Fixes #249
