### PR TITLE
Convert connectivity_info before the name short-circuit in progress payloads

### DIFF
--- a/nsflow/frontend/src/utils/progressHelper.ts
+++ b/nsflow/frontend/src/utils/progressHelper.ts
@@ -45,14 +45,17 @@ export function asObjectText(text: string | object): Record<string, any> | undef
 
 /** Normalize an object that may use `connectivity_info` into a ProgressPayload. */
 function normalizePayloadObj(obj: Record<string, any>): ProgressPayload | undefined {
-  if ("agent_network_definition" in obj || "agent_network_name" in obj) {
-    return obj as ProgressPayload;
-  }
+  // Check connectivity_info first: a connectivity-style payload may also carry
+  // agent_network_name, and matching on the name alone would return it without
+  // an agent_network_definition, causing consumers to drop the frame.
   if ("connectivity_info" in obj && Array.isArray(obj.connectivity_info)) {
     return {
       agent_network_definition: obj.connectivity_info as Array<Record<string, any>>,
       agent_network_name: obj.agent_network_name,
     };
+  }
+  if ("agent_network_definition" in obj || "agent_network_name" in obj) {
+    return obj as ProgressPayload;
   }
   return undefined;
 }


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

NormalizePayloadObj matched on agent_network_name before checking connectivity_info, so a connectivity-style progress frame that also carried the network name was returned without an agent_network_definition and every consumer dropped it at the `!payload?.agent_network_definition` guard. Those frames are exactly the guaranteed updates from the designer (create_new_network, forced middleware reports, end-of-run throttle flushes), which left the editor graph frozen between per-edit reports.

Check connectivity_info first so name-carrying frames get converted like the rest; internal-style payloads are unaffected. Includes the rebuilt prebuilt_frontend bundle.

Fixes #251

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---
