### PR TITLE
Inject all connected MCP tokens for the Agent Network Designer

### DIFF
--- a/nsflow/backend/api/v1/app_configs.py
+++ b/nsflow/backend/api/v1/app_configs.py
@@ -24,7 +24,7 @@ from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
 from nsflow.backend.models.config_model import ConfigRequest
-from nsflow.backend.utils.agentutils.agent_log_processor import AGENT_NETWORK_DESIGNER_NAME
+from nsflow.backend.utils.agentutils.constants import AGENT_NETWORK_DESIGNER_NAME
 from nsflow.backend.utils.tools.auth_utils import AuthUtils
 from nsflow.backend.utils.tools.ns_configs_registry import NsConfigsRegistry
 from nsflow.backend.utils.version import DISTRIBUTION_NAME

--- a/nsflow/backend/api/v1/app_configs.py
+++ b/nsflow/backend/api/v1/app_configs.py
@@ -24,6 +24,7 @@ from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
 from nsflow.backend.models.config_model import ConfigRequest
+from nsflow.backend.utils.agentutils.agent_log_processor import AGENT_NETWORK_DESIGNER_NAME
 from nsflow.backend.utils.tools.auth_utils import AuthUtils
 from nsflow.backend.utils.tools.ns_configs_registry import NsConfigsRegistry
 from nsflow.backend.utils.version import DISTRIBUTION_NAME
@@ -53,7 +54,10 @@ def get_runtime_config():
             "VITE_WS_PROTOCOL": os.getenv("VITE_WS_PROTOCOL", "ws"),
             # Default kept as bool so the JSON response field stays a boolean for the frontend.
             "VITE_USE_SPEECH": os.getenv("VITE_USE_SPEECH", True),  # pylint: disable=invalid-envvar-default
-            "NSFLOW_WAND_NAME": os.getenv("NSFLOW_WAND_NAME", "agent_network_designer"),
+            # Shared constant (read once at import time) rather than a fresh
+            # os.getenv here, so the designer network the UI routes to is exactly
+            # the one the backend treats as the designer - see AGENT_NETWORK_DESIGNER_NAME.
+            "NSFLOW_WAND_NAME": AGENT_NETWORK_DESIGNER_NAME,
             # Subdirectory under registries/ where the Agent Network Designer persists
             # generated networks. Mirrors neuro-san-studio's AGENT_NETWORK_DESIGNER_SUBDIRECTORY
             # so the Editor can build the served agent path (e.g. "generated/<name>") for launch.

--- a/nsflow/backend/utils/agentutils/agent_log_processor.py
+++ b/nsflow/backend/utils/agentutils/agent_log_processor.py
@@ -25,18 +25,9 @@ from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.message_processing.message_processor import MessageProcessor
 
 from nsflow.backend.trust.rai_service import RaiService
+from nsflow.backend.utils.agentutils.constants import AGENT_NETWORK_DESIGNER_NAME
 from nsflow.backend.utils.editor.simple_state_registry import get_registry
 from nsflow.backend.utils.logutils.websocket_logs_registry import LogsRegistry
-
-# Single source of truth for the Agent Network Designer (the "wand") network
-# name. The designer builds *other* networks, so several places key off this
-# exact value: this log processor (rendering its copilot state updates), the MCP
-# token injector (ns_websocket_utils, which sends the designer every connected
-# token), and the runtime-config endpoint (app_configs, which serves the same
-# value to the UI). Defining it once means the network the frontend routes to
-# and the one the backend treats as the designer can never silently drift. Read
-# once at import time, matching how the backend logic consumes it.
-AGENT_NETWORK_DESIGNER_NAME = os.getenv("NSFLOW_WAND_NAME", "agent_network_designer")
 
 EDITOR_TOOLS = {
     "create_new_network",

--- a/nsflow/backend/utils/agentutils/agent_log_processor.py
+++ b/nsflow/backend/utils/agentutils/agent_log_processor.py
@@ -28,6 +28,16 @@ from nsflow.backend.trust.rai_service import RaiService
 from nsflow.backend.utils.editor.simple_state_registry import get_registry
 from nsflow.backend.utils.logutils.websocket_logs_registry import LogsRegistry
 
+# Single source of truth for the Agent Network Designer (the "wand") network
+# name. The designer builds *other* networks, so several places key off this
+# exact value: this log processor (rendering its copilot state updates), the MCP
+# token injector (ns_websocket_utils, which sends the designer every connected
+# token), and the runtime-config endpoint (app_configs, which serves the same
+# value to the UI). Defining it once means the network the frontend routes to
+# and the one the backend treats as the designer can never silently drift. Read
+# once at import time, matching how the backend logic consumes it.
+AGENT_NETWORK_DESIGNER_NAME = os.getenv("NSFLOW_WAND_NAME", "agent_network_designer")
+
 EDITOR_TOOLS = {
     "create_new_network",
     "add_agent_to_network",
@@ -43,7 +53,6 @@ class AgentLogProcessor(MessageProcessor):
     Tells the UI there's an agent message to process.
     """
 
-    AGENT_NETWORK_DESIGNER_NAME = os.getenv("NSFLOW_WAND_NAME", "agent_network_designer")
     NSFLOW_PLUGIN_MANUAL_EDITOR = os.getenv("NSFLOW_PLUGIN_MANUAL_EDITOR", None)
 
     def __init__(self, agent_name: str, session_id: str = None):
@@ -191,7 +200,7 @@ class AgentLogProcessor(MessageProcessor):
 
     def process_for_manual_editor(self, progress: Dict[str, Any]) -> str:
         """process progress message for manual editor's consumption"""
-        if self.agent_name == self.AGENT_NETWORK_DESIGNER_NAME:
+        if self.agent_name == AGENT_NETWORK_DESIGNER_NAME:
             # Use simple state registry for copilot state updates
             try:
                 network_name = progress.get("agent_network_name", "new_network")

--- a/nsflow/backend/utils/agentutils/constants.py
+++ b/nsflow/backend/utils/agentutils/constants.py
@@ -1,0 +1,35 @@
+# Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""
+Lightweight, dependency-free constants shared across the backend.
+
+Kept deliberately import-cheap: modules such as the runtime-config API endpoint
+import from here without dragging in the heavier agent/log-processing stack
+(neuro_san message types, RaiService, registries, ...).
+"""
+
+import os
+
+# The Agent Network Designer (the "wand") network name. The designer builds
+# *other* networks, so several places key off this exact value: the log
+# processor (rendering its copilot state updates), the MCP token injector
+# (ns_websocket_utils, which sends the designer every connected token), and the
+# runtime-config endpoint (app_configs, which serves the same value to the UI).
+# Defining it once means the network the frontend routes to and the one the
+# backend treats as the designer can never silently drift. Read once at import
+# time, matching how the backend logic consumes it.
+AGENT_NETWORK_DESIGNER_NAME = os.getenv("NSFLOW_WAND_NAME", "agent_network_designer")

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -65,6 +65,13 @@ REDACTED_VALUE = "***redacted***"
 # indefinitely (SDK defaults allow up to 30s connect / 300s read).
 MCP_FRESHEN_TIMEOUT_SECONDS = 15
 
+# The Agent Network Designer (the "wand") builds *other* networks, so it needs to
+# see every MCP server the user has connected - it offers the available ones when
+# generating networks. When the chat target IS this network we inject all connected
+# tokens rather than the schema-scoped subset. Read from the same env used for the
+# designer elsewhere (agent_log_processor.AGENT_NETWORK_DESIGNER_NAME).
+AGENT_NETWORK_DESIGNER_NAME = os.getenv("NSFLOW_WAND_NAME", "agent_network_designer")
+
 
 # pylint: disable=too-many-instance-attributes
 class NsWebsocketUtils:
@@ -272,8 +279,11 @@ class NsWebsocketUtils:
         ``sly_data_schema``) are injected, so a token is never broadcast to an
         unrelated network or to an MCP server that needs no auth. If the network's
         HOCON cannot be read locally (e.g. it lives on a remote neuro-san server),
-        we fall back to injecting every connected server. Any header the user
-        already supplied for a given URL is left untouched.
+        we fall back to injecting every connected server. The Agent Network
+        Designer (``NSFLOW_WAND_NAME``) is treated the same way on purpose: it
+        builds other networks, so it receives every connected MCP server's token
+        rather than a schema-scoped subset. Any header the user already supplied
+        for a given URL is left untouched.
 
         :param sly_data: The sly_data dict to enrich in place.
         """
@@ -291,7 +301,15 @@ class NsWebsocketUtils:
             # exists, filtering ensures injection resolves to the healthy one.
             connected_urls = [conn["server_url"] for conn in connections if not conn.get("needs_reauth")]
 
-            referenced = await asyncio.to_thread(self.get_network_mcp_urls)
+            # The Agent Network Designer is the exception to schema-scoping: it
+            # needs to see every connected MCP server so it can offer them when
+            # generating networks, so inject all connected tokens (like the
+            # unreadable-HOCON fallback) instead of the network's declared subset.
+            is_designer = self.agent_name == AGENT_NETWORK_DESIGNER_NAME
+            if is_designer:
+                referenced = None
+            else:
+                referenced = await asyncio.to_thread(self.get_network_mcp_urls)
             # Build (header_key, token_url) pairs. URLs are matched on a normalized
             # form so cosmetic differences (trailing slash, host case, default
             # port) between the stored connection URL and the network's declared
@@ -314,7 +332,7 @@ class NsWebsocketUtils:
                 "MCP auth injection for network '%s': connected=%s referenced=%s targets=%s",
                 self.agent_name,
                 sorted(connected_urls),
-                "ALL(fallback)" if referenced is None else sorted(referenced),
+                "ALL(designer)" if is_designer else ("ALL(fallback)" if referenced is None else sorted(referenced)),
                 sorted({header_key for header_key, _ in targets}),
             )
             if not targets:

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -31,6 +31,7 @@ from fastapi import WebSocket
 from fastapi import WebSocketDisconnect
 from neuro_san.client.agent_session_factory import AgentSessionFactory
 
+from nsflow.backend.utils.agentutils.agent_log_processor import AGENT_NETWORK_DESIGNER_NAME
 from nsflow.backend.utils.agentutils.agent_log_processor import AgentLogProcessor
 from nsflow.backend.utils.agentutils.agent_network_utils import AgentNetworkUtils
 from nsflow.backend.utils.agentutils.async_streaming_input_processor import AsyncStreamingInputProcessor
@@ -64,13 +65,6 @@ REDACTED_VALUE = "***redacted***"
 # hung/unreachable MCP server or auth server must not stall the gate decision
 # indefinitely (SDK defaults allow up to 30s connect / 300s read).
 MCP_FRESHEN_TIMEOUT_SECONDS = 15
-
-# The Agent Network Designer (the "wand") builds *other* networks, so it needs to
-# see every MCP server the user has connected - it offers the available ones when
-# generating networks. When the chat target IS this network we inject all connected
-# tokens rather than the schema-scoped subset. Read from the same env used for the
-# designer elsewhere (agent_log_processor.AGENT_NETWORK_DESIGNER_NAME).
-AGENT_NETWORK_DESIGNER_NAME = os.getenv("NSFLOW_WAND_NAME", "agent_network_designer")
 
 
 # pylint: disable=too-many-instance-attributes

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -31,10 +31,10 @@ from fastapi import WebSocket
 from fastapi import WebSocketDisconnect
 from neuro_san.client.agent_session_factory import AgentSessionFactory
 
-from nsflow.backend.utils.agentutils.agent_log_processor import AGENT_NETWORK_DESIGNER_NAME
 from nsflow.backend.utils.agentutils.agent_log_processor import AgentLogProcessor
 from nsflow.backend.utils.agentutils.agent_network_utils import AgentNetworkUtils
 from nsflow.backend.utils.agentutils.async_streaming_input_processor import AsyncStreamingInputProcessor
+from nsflow.backend.utils.agentutils.constants import AGENT_NETWORK_DESIGNER_NAME
 from nsflow.backend.utils.logutils.websocket_logs_registry import LogsRegistry
 from nsflow.backend.utils.mcp.mcp_oauth_manager import mcp_oauth_manager
 from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
@@ -322,11 +322,20 @@ class NsWebsocketUtils:
                     token_url = connected_by_norm.get(self._normalize_mcp_url(ref))
                     if token_url is not None:
                         targets.append((ref, token_url))
+            # What we scoped injection to, for the log line: the designer and the
+            # unreadable-HOCON fallback both inject every connection (referenced is
+            # None); a normal network logs its declared subset.
+            if is_designer:
+                referenced_label = "ALL(designer)"
+            elif referenced is None:
+                referenced_label = "ALL(fallback)"
+            else:
+                referenced_label = sorted(referenced)
             logging.info(
                 "MCP auth injection for network '%s': connected=%s referenced=%s targets=%s",
                 self.agent_name,
                 sorted(connected_urls),
-                "ALL(designer)" if is_designer else ("ALL(fallback)" if referenced is None else sorted(referenced)),
+                referenced_label,
                 sorted({header_key for header_key, _ in targets}),
             )
             if not targets:

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -460,6 +460,41 @@ def test_non_designer_injection_stays_schema_scoped(monkeypatch):
     assert sly_data["http_headers"] == {url_a: {"Authorization": "Bearer tok"}}
 
 
+def test_designer_skips_needs_reauth_connections(monkeypatch):
+    """
+    The designer's inject-all path still honors the needs_reauth filter: a
+    connection whose refresh already failed definitively is not injected, so
+    inject-all never means inject-broken.
+    """
+    good, dead = "https://good.example.com/mcp", "https://dead.example.com/mcp"
+    _patch_connections(monkeypatch, [good], reauth_urls=[dead])
+    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", AsyncMock(return_value="Bearer tok"))
+    inst = _utils(agent_name=nw.AGENT_NETWORK_DESIGNER_NAME)
+
+    sly_data = {}
+    asyncio.run(inst.inject_mcp_auth_headers(sly_data))
+
+    assert sly_data["http_headers"] == {good: {"Authorization": "Bearer tok"}}
+
+
+def test_designer_preserves_user_supplied_authorization(monkeypatch):
+    """
+    The designer's inject-all path leaves a user-supplied Authorization untouched
+    (never overwriting it with a freshly fetched token) while still injecting the
+    other connected servers.
+    """
+    url_user, url_auto = "https://user.example.com/mcp", "https://auto.example.com/mcp"
+    _patch_connections(monkeypatch, [url_user, url_auto])
+    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", AsyncMock(return_value="Bearer fresh"))
+    inst = _utils(agent_name=nw.AGENT_NETWORK_DESIGNER_NAME)
+
+    sly_data = {"http_headers": {url_user: {"Authorization": "Bearer user-token"}}}
+    asyncio.run(inst.inject_mcp_auth_headers(sly_data))
+
+    assert sly_data["http_headers"][url_user] == {"Authorization": "Bearer user-token"}
+    assert sly_data["http_headers"][url_auto] == {"Authorization": "Bearer fresh"}
+
+
 def test_gaps_fresh_none_when_network_unreadable(monkeypatch):
     """An unreadable network yields None (caller reports nothing missing)."""
     _patch_network(monkeypatch, raise_exc=FileNotFoundError("remote"))

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -420,6 +420,46 @@ def test_gaps_fresh_tolerates_refresh_errors(monkeypatch):
     assert gaps == {"missing": [], "needs_reauth": []}
 
 
+# --------------------------- inject_mcp_auth_headers --------------------------- #
+
+
+def test_designer_injects_all_connected_tokens(monkeypatch):
+    """
+    The Agent Network Designer gets every connected MCP token - even ones its own
+    sly_data_schema does not declare - so it can offer them when generating
+    networks. It must not scope them via get_network_mcp_urls.
+    """
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    _patch_connections(monkeypatch, [url_a, url_b])
+    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", AsyncMock(return_value="Bearer tok"))
+    inst = _utils(agent_name=nw.AGENT_NETWORK_DESIGNER_NAME)
+    # A scoped schema result would drop url_b; the designer branch must ignore it.
+    inst.get_network_mcp_urls = MagicMock(return_value={url_a})
+
+    sly_data = {}
+    asyncio.run(inst.inject_mcp_auth_headers(sly_data))
+
+    assert sly_data["http_headers"] == {
+        url_a: {"Authorization": "Bearer tok"},
+        url_b: {"Authorization": "Bearer tok"},
+    }
+    inst.get_network_mcp_urls.assert_not_called()
+
+
+def test_non_designer_injection_stays_schema_scoped(monkeypatch):
+    """A normal network only gets tokens for the URLs its sly_data_schema declares."""
+    url_a, url_b = "https://a.example.com/mcp", "https://b.example.com/mcp"
+    _patch_connections(monkeypatch, [url_a, url_b])
+    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", AsyncMock(return_value="Bearer tok"))
+    inst = _utils(agent_name="net")
+    inst.get_network_mcp_urls = MagicMock(return_value={url_a})  # only url_a is declared
+
+    sly_data = {}
+    asyncio.run(inst.inject_mcp_auth_headers(sly_data))
+
+    assert sly_data["http_headers"] == {url_a: {"Authorization": "Bearer tok"}}
+
+
 def test_gaps_fresh_none_when_network_unreadable(monkeypatch):
     """An unreadable network yields None (caller reports nothing missing)."""
     _patch_network(monkeypatch, raise_exc=FileNotFoundError("remote"))

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -420,7 +420,7 @@ def test_gaps_fresh_tolerates_refresh_errors(monkeypatch):
     assert gaps == {"missing": [], "needs_reauth": []}
 
 
-# --------------------------- inject_mcp_auth_headers --------------------------- #
+# ----------------- inject_mcp_auth_headers: Agent Network Designer ----------------- #
 
 
 def test_designer_injects_all_connected_tokens(monkeypatch):


### PR DESCRIPTION
## Description

The Agent Network Designer (the "wand", `NSFLOW_WAND_NAME`) builds *other* networks, so it needs to know which MCP servers the user has connected in order to offer the available ones when generating a network.

Normally MCP token injection is **schema-scoped**: for a given chat target we only inject `Authorization` headers for the MCP URLs that network declares in its `sly_data_schema.http_headers`. That's wrong for the designer, which declares no such servers itself but must see them all.

This PR:

1. **Injects every connected MCP token when the chat target is the designer.** When `agent_name == AGENT_NETWORK_DESIGNER_NAME` we reuse the existing "inject all" path (the same one used as a fallback when a network's HOCON can't be read locally) instead of the schema-scoped subset. That path already refreshes tokens when possible, **skips `needs_reauth`/expired-no-refresh connections**, and **never clobbers a user-supplied header**. All other networks stay schema-scoped exactly as before.

2. **Collapses the designer network name to a single shared constant.** It was read from `NSFLOW_WAND_NAME` in three places (`agent_log_processor`, `ns_websocket_utils`, `app_configs`). If the default literal ever drifted between them, the injector could silently stop treating the real designer as the designer while the UI still routed to it — with no error. It's now defined once as `AGENT_NETWORK_DESIGNER_NAME` in `agent_log_processor` and imported by the other two. `app_configs` serves that constant instead of re-reading the env, so the network the frontend routes to is exactly the one the backend treats as the designer.

Tokens remain backend-only: they are injected into `sly_data.http_headers` server-side and are redacted at every surfaced (logged / streamed / persisted) boundary.

## Impact

- Chatting with the Agent Network Designer now forwards every non-expired connected MCP token (refreshing where possible), so generated networks can reference any connected server.
- No behavior change for any other network — injection stays scoped to each network's declared `sly_data_schema`.
- Pure backend change; no API surface or schema change.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)