### PR TITLE
Bound and parallelize MCP token fetch in chat-time header injection

### DIFF
--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -61,13 +61,6 @@ _SENSITIVE_HEADER_NAMES = frozenset(
 # with a fresh token rather than sent to the agent verbatim.
 REDACTED_VALUE = "***redacted***"
 
-# Upper bound on proactive token work - the network-selection freshen
-# (mcp_connection_gaps_fresh) and each per-message injection fetch
-# (_fetch_tokens_bounded): a hung/unreachable MCP server or auth server must not
-# stall the gate decision or a chat message indefinitely (SDK defaults allow up
-# to 30s connect / 300s read).
-MCP_FRESHEN_TIMEOUT_SECONDS = 15
-
 
 # pylint: disable=too-many-instance-attributes
 class NsWebsocketUtils:
@@ -264,7 +257,7 @@ class NsWebsocketUtils:
         """
         return AgentSessionFactory()
 
-    async def inject_mcp_auth_headers(  # pylint: disable=too-many-locals,too-many-branches  # header-merge logic over many optional fields
+    async def inject_mcp_auth_headers(  # pylint: disable=too-many-branches  # scoping logic over many optional fields
         self, sly_data: Dict[str, Any]
     ) -> None:
         """
@@ -281,10 +274,11 @@ class NsWebsocketUtils:
         rather than a schema-scoped subset. Any header the user already supplied
         for a given URL is left untouched.
 
-        Token fetches run concurrently, each bounded by
-        ``MCP_FRESHEN_TIMEOUT_SECONDS``, so one hung MCP/auth server can neither
-        stall the chat message indefinitely nor hold up the other servers'
-        tokens.
+        Token fetches run concurrently through the OAuth manager's
+        ``get_fresh_token_bounded``, which owns the timeout and concurrency
+        policy: one hung MCP/auth server can neither stall the chat message
+        indefinitely nor hold up the other servers' tokens, and an in-flight
+        refresh is never cancelled (it finishes in the background).
 
         :param sly_data: The sly_data dict to enrich in place.
         """
@@ -292,7 +286,7 @@ class NsWebsocketUtils:
             # Both of these do synchronous disk I/O (reading tokens.json and
             # restoring/parsing the network HOCON) and run on every chat message,
             # so offload them to a worker thread to keep the websocket handler's
-            # event loop responsive. get_fresh_token below is already async.
+            # event loop responsive. The token fetches below are already async.
             connections = await asyncio.to_thread(FileTokenStorage.list_connections)
             if not connections:
                 return
@@ -369,86 +363,105 @@ class NsWebsocketUtils:
             # server must not stall the chat message, nor delay the other
             # servers' tokens (#255). The set also dedups: several header keys
             # can resolve to the same stored connection (one fetch each).
-            tokens = await self._fetch_tokens_bounded(sorted({entry[1] for entry in to_inject}))
+            tokens = await self._fetch_tokens_bounded(sorted({token_url for _, token_url in to_inject}))
 
-            # Second pass: inject whatever resolved in time.
-            for header_key, token_url, headers, auth_key in to_inject:
-                authorization = tokens.get(token_url)
-                if not authorization:
-                    logging.warning("MCP auth: no usable token for %s (connection may need re-auth)", token_url)
-                    continue
-                # Drop any differently-cased existing key so we don't end up with
-                # two Authorization headers, then set the canonical casing.
-                if auth_key and auth_key != "Authorization":
-                    headers.pop(auth_key, None)
-                headers["Authorization"] = authorization
-                http_headers[header_key] = headers
-                logging.info("MCP auth: injected Authorization header into sly_data for %s", header_key)
+            self._inject_fetched_tokens(http_headers, to_inject, tokens)
         except Exception as e:  # noqa: BLE001 - never break chat on auth injection
             logging.warning("Failed to inject MCP auth headers: %s", e)
+
+    @classmethod
+    def _existing_user_auth(cls, headers: Dict[str, Any]) -> Optional[str]:
+        """
+        Return the user-supplied Authorization value in ``headers`` (any
+        casing), or None. Our own redaction placeholder does not count: it can
+        come back from a UI that round-trips a previously surfaced (masked)
+        sly_data, and treating it as real would send "***redacted***" to the
+        agent.
+        """
+        # HTTP header names are case-insensitive, so find any existing
+        # "Authorization" regardless of casing.
+        auth_key = cls._find_header_key(headers, "Authorization")
+        value = headers.get(auth_key) if auth_key else None
+        if value and value != REDACTED_VALUE:
+            return value
+        return None
 
     @classmethod
     def _targets_needing_tokens(cls, http_headers: Dict[str, Any], targets: List[tuple]) -> List[tuple]:
         """
         First injection pass (pure dict work, no awaits): filter ``targets``
-        down to the ones that actually need a fetched token, honoring any
-        Authorization the user supplied themselves.
+        down to the ones without a user-supplied Authorization, so no token is
+        fetched for a URL the user already authenticated themselves.
 
         :param http_headers: The (already dict-coerced) ``sly_data["http_headers"]``.
         :param targets: ``(header_key, token_url)`` pairs from scoping.
-        :return: ``(header_key, token_url, headers, auth_key)`` tuples, where
-                 ``headers`` is the existing per-URL header dict (or a fresh
-                 one) and ``auth_key`` is the casing of any existing
-                 Authorization key.
+        :return: The surviving ``(header_key, token_url)`` pairs.
         """
         to_inject = []
         for header_key, token_url in targets:
             existing = http_headers.get(header_key)
             headers = existing if isinstance(existing, dict) else {}
-            # HTTP header names are case-insensitive, so find any existing
-            # "Authorization" regardless of casing.
-            auth_key = cls._find_header_key(headers, "Authorization")
-            existing_auth = headers.get(auth_key) if auth_key else None
-            # Respect a user-provided Authorization for this URL (any casing) -
-            # but ignore our own redaction placeholder, which can come back from
-            # a UI that round-trips a previously surfaced (masked) sly_data.
-            # Treating the sentinel as real would send "***redacted***" to the agent.
-            if existing_auth and existing_auth != REDACTED_VALUE:
+            if cls._existing_user_auth(headers):
                 logging.info("MCP auth: keeping user-supplied Authorization for %s", header_key)
                 continue
-            to_inject.append((header_key, token_url, headers, auth_key))
+            to_inject.append((header_key, token_url))
         return to_inject
+
+    @classmethod
+    def _inject_fetched_tokens(
+        cls, http_headers: Dict[str, Any], to_inject: List[tuple], tokens: Dict[str, str]
+    ) -> None:
+        """
+        Second injection pass (no awaits): write the fetched Authorization
+        values into ``http_headers`` in place.
+
+        The per-URL header state is re-read here rather than trusted from pass
+        1: the token fetch suspended this coroutine, and another handler
+        sharing the session's sly_data (a reconnect, a second tab) may have
+        merged headers - including a user Authorization - in the meantime.
+        Re-checking immediately before each write keeps check-and-write atomic
+        on the event loop, so a user header can never be clobbered by a stale
+        pass-1 snapshot.
+        """
+        for header_key, token_url in to_inject:
+            authorization = tokens.get(token_url)
+            if not authorization:
+                # The cause (timeout / fetch failure / needs re-auth) was
+                # already logged by get_fresh_token_bounded with its real
+                # diagnosis; this line just maps it to the schema's header key.
+                logging.info("MCP auth: no token for %s; nothing injected", header_key)
+                continue
+            existing = http_headers.get(header_key)
+            headers = existing if isinstance(existing, dict) else {}
+            if cls._existing_user_auth(headers):
+                logging.info("MCP auth: keeping user-supplied Authorization for %s", header_key)
+                continue
+            # Drop any differently-cased existing key so we don't end up with
+            # two Authorization headers, then set the canonical casing.
+            auth_key = cls._find_header_key(headers, "Authorization")
+            if auth_key and auth_key != "Authorization":
+                headers.pop(auth_key, None)
+            headers["Authorization"] = authorization
+            http_headers[header_key] = headers
+            logging.info("MCP auth: injected Authorization header into sly_data for %s", header_key)
 
     @staticmethod
     async def _fetch_tokens_bounded(token_urls: List[str]) -> Dict[str, str]:
         """
-        Fetch Authorization values for ``token_urls`` concurrently, each fetch
-        bounded by ``MCP_FRESHEN_TIMEOUT_SECONDS``.
-
-        A token that is fresh per its stored ``expires_at`` is a disk read only;
-        an expired one triggers a network refresh against its auth server, which
-        is what the bound protects against (SDK defaults allow up to 30s connect
-        / 300s read). Each fetch is bounded individually - rather than wrapping
-        the whole batch like mcp_connection_gaps_fresh does - so a hung server
-        only forfeits its own token instead of discarding the ones that resolved
-        in time.
+        Fetch Authorization values for ``token_urls`` concurrently via the
+        OAuth manager's ``get_fresh_token_bounded``, which owns the timeout and
+        concurrency policy (``TOKEN_FETCH_TIMEOUT_SECONDS`` /
+        ``MAX_CONCURRENT_TOKEN_FETCHES``) and never cancels an in-flight
+        refresh - a fetch that outlives the wait finishes in the background
+        and its tokens persist for the next message.
 
         :param token_urls: Stored connection URLs to fetch tokens for.
         :return: token_url -> Authorization value for the fetches that produced
-                 a usable token. Failures and timeouts are logged and omitted.
+                 a usable token in time. Failures and timeouts are logged by
+                 the manager and omitted here.
         """
-
-        async def fetch_one(url: str) -> Optional[str]:
-            return await asyncio.wait_for(mcp_oauth_manager.get_fresh_token(url), timeout=MCP_FRESHEN_TIMEOUT_SECONDS)
-
-        results = await asyncio.gather(*(fetch_one(url) for url in token_urls), return_exceptions=True)
-        tokens: Dict[str, str] = {}
-        for url, result in zip(token_urls, results):
-            if isinstance(result, BaseException):
-                logging.warning("MCP auth: token fetch for %s failed: %r", url, result)
-            elif result:
-                tokens[url] = result
-        return tokens
+        results = await asyncio.gather(*(mcp_oauth_manager.get_fresh_token_bounded(url) for url in token_urls))
+        return {url: token for url, token in zip(token_urls, results) if token}
 
     @staticmethod
     def _merge_user_sly_data(state_sly_data: Dict[str, Any], incoming: Any) -> None:
@@ -743,9 +756,10 @@ class NsWebsocketUtils:
         read only - no network I/O. Connections already marked ``needs_reauth``
         are not re-probed (only a reconnect can recover them, and re-probing
         would stall every selection of the network on a dead server). Refreshes
-        run concurrently and are bounded by ``MCP_FRESHEN_TIMEOUT_SECONDS`` so a
-        hung server can't block the gate; on timeout or per-URL failure the gaps
-        are computed from the state on disk.
+        run concurrently through the manager's ``get_fresh_token_bounded`` (the
+        same mechanism chat-time injection uses) so a hung server can't block
+        the gate; on timeout or per-URL failure the gaps are computed from the
+        state on disk.
         """
         required = await asyncio.to_thread(cls.collect_required_mcp_urls, agent_name)
         if required is None:
@@ -763,23 +777,12 @@ class NsWebsocketUtils:
             {by_norm[cls._normalize_mcp_url(url)] for url in required if cls._normalize_mcp_url(url) in by_norm}
         )
         if stored_urls:
-            try:
-                results = await asyncio.wait_for(
-                    asyncio.gather(
-                        *(mcp_oauth_manager.get_fresh_token(url) for url in stored_urls),
-                        return_exceptions=True,
-                    ),
-                    timeout=MCP_FRESHEN_TIMEOUT_SECONDS,
-                )
-                for url, result in zip(stored_urls, results):
-                    if isinstance(result, BaseException):
-                        logging.warning("MCP freshen for %s failed: %s", url, result)
-            except asyncio.TimeoutError:
-                logging.warning(
-                    "MCP freshen for network '%s' timed out after %ss; gating on stored state.",
-                    agent_name,
-                    MCP_FRESHEN_TIMEOUT_SECONDS,
-                )
+            # One bounded fetch per stored URL, sharing chat-time injection's
+            # mechanism (_fetch_tokens_bounded): the manager owns the timeout
+            # and concurrency policy, never cancels an in-flight refresh, and
+            # logs each failure with its cause. The token values themselves are
+            # not needed here - the refreshed state is re-read from disk below.
+            await cls._fetch_tokens_bounded(stored_urls)
             # Re-read: a successful refresh (or a newly set needs_reauth marker)
             # changes the gate decision.
             connections = await asyncio.to_thread(FileTokenStorage.list_connections)

--- a/nsflow/backend/utils/agentutils/ns_websocket_utils.py
+++ b/nsflow/backend/utils/agentutils/ns_websocket_utils.py
@@ -61,9 +61,11 @@ _SENSITIVE_HEADER_NAMES = frozenset(
 # with a fresh token rather than sent to the agent verbatim.
 REDACTED_VALUE = "***redacted***"
 
-# Upper bound on the network-selection freshen (mcp_connection_gaps_fresh): a
-# hung/unreachable MCP server or auth server must not stall the gate decision
-# indefinitely (SDK defaults allow up to 30s connect / 300s read).
+# Upper bound on proactive token work - the network-selection freshen
+# (mcp_connection_gaps_fresh) and each per-message injection fetch
+# (_fetch_tokens_bounded): a hung/unreachable MCP server or auth server must not
+# stall the gate decision or a chat message indefinitely (SDK defaults allow up
+# to 30s connect / 300s read).
 MCP_FRESHEN_TIMEOUT_SECONDS = 15
 
 
@@ -279,6 +281,11 @@ class NsWebsocketUtils:
         rather than a schema-scoped subset. Any header the user already supplied
         for a given URL is left untouched.
 
+        Token fetches run concurrently, each bounded by
+        ``MCP_FRESHEN_TIMEOUT_SECONDS``, so one hung MCP/auth server can neither
+        stall the chat message indefinitely nor hold up the other servers'
+        tokens.
+
         :param sly_data: The sly_data dict to enrich in place.
         """
         try:
@@ -353,21 +360,20 @@ class NsWebsocketUtils:
                     )
                 http_headers = {}
                 sly_data["http_headers"] = http_headers
-            for header_key, token_url in targets:
-                existing = http_headers.get(header_key)
-                headers = existing if isinstance(existing, dict) else {}
-                # HTTP header names are case-insensitive, so find any existing
-                # "Authorization" regardless of casing.
-                auth_key = self._find_header_key(headers, "Authorization")
-                existing_auth = headers.get(auth_key) if auth_key else None
-                # Respect a user-provided Authorization for this URL (any casing) -
-                # but ignore our own redaction placeholder, which can come back from
-                # a UI that round-trips a previously surfaced (masked) sly_data.
-                # Treating the sentinel as real would send "***redacted***" to the agent.
-                if existing_auth and existing_auth != REDACTED_VALUE:
-                    logging.info("MCP auth: keeping user-supplied Authorization for %s", header_key)
-                    continue
-                authorization = await mcp_oauth_manager.get_fresh_token(token_url)
+            to_inject = self._targets_needing_tokens(http_headers, targets)
+            if not to_inject:
+                return
+
+            # The network-bound token fetches run concurrently in one bounded
+            # batch instead of being awaited target-by-target: one hung auth
+            # server must not stall the chat message, nor delay the other
+            # servers' tokens (#255). The set also dedups: several header keys
+            # can resolve to the same stored connection (one fetch each).
+            tokens = await self._fetch_tokens_bounded(sorted({entry[1] for entry in to_inject}))
+
+            # Second pass: inject whatever resolved in time.
+            for header_key, token_url, headers, auth_key in to_inject:
+                authorization = tokens.get(token_url)
                 if not authorization:
                     logging.warning("MCP auth: no usable token for %s (connection may need re-auth)", token_url)
                     continue
@@ -380,6 +386,69 @@ class NsWebsocketUtils:
                 logging.info("MCP auth: injected Authorization header into sly_data for %s", header_key)
         except Exception as e:  # noqa: BLE001 - never break chat on auth injection
             logging.warning("Failed to inject MCP auth headers: %s", e)
+
+    @classmethod
+    def _targets_needing_tokens(cls, http_headers: Dict[str, Any], targets: List[tuple]) -> List[tuple]:
+        """
+        First injection pass (pure dict work, no awaits): filter ``targets``
+        down to the ones that actually need a fetched token, honoring any
+        Authorization the user supplied themselves.
+
+        :param http_headers: The (already dict-coerced) ``sly_data["http_headers"]``.
+        :param targets: ``(header_key, token_url)`` pairs from scoping.
+        :return: ``(header_key, token_url, headers, auth_key)`` tuples, where
+                 ``headers`` is the existing per-URL header dict (or a fresh
+                 one) and ``auth_key`` is the casing of any existing
+                 Authorization key.
+        """
+        to_inject = []
+        for header_key, token_url in targets:
+            existing = http_headers.get(header_key)
+            headers = existing if isinstance(existing, dict) else {}
+            # HTTP header names are case-insensitive, so find any existing
+            # "Authorization" regardless of casing.
+            auth_key = cls._find_header_key(headers, "Authorization")
+            existing_auth = headers.get(auth_key) if auth_key else None
+            # Respect a user-provided Authorization for this URL (any casing) -
+            # but ignore our own redaction placeholder, which can come back from
+            # a UI that round-trips a previously surfaced (masked) sly_data.
+            # Treating the sentinel as real would send "***redacted***" to the agent.
+            if existing_auth and existing_auth != REDACTED_VALUE:
+                logging.info("MCP auth: keeping user-supplied Authorization for %s", header_key)
+                continue
+            to_inject.append((header_key, token_url, headers, auth_key))
+        return to_inject
+
+    @staticmethod
+    async def _fetch_tokens_bounded(token_urls: List[str]) -> Dict[str, str]:
+        """
+        Fetch Authorization values for ``token_urls`` concurrently, each fetch
+        bounded by ``MCP_FRESHEN_TIMEOUT_SECONDS``.
+
+        A token that is fresh per its stored ``expires_at`` is a disk read only;
+        an expired one triggers a network refresh against its auth server, which
+        is what the bound protects against (SDK defaults allow up to 30s connect
+        / 300s read). Each fetch is bounded individually - rather than wrapping
+        the whole batch like mcp_connection_gaps_fresh does - so a hung server
+        only forfeits its own token instead of discarding the ones that resolved
+        in time.
+
+        :param token_urls: Stored connection URLs to fetch tokens for.
+        :return: token_url -> Authorization value for the fetches that produced
+                 a usable token. Failures and timeouts are logged and omitted.
+        """
+
+        async def fetch_one(url: str) -> Optional[str]:
+            return await asyncio.wait_for(mcp_oauth_manager.get_fresh_token(url), timeout=MCP_FRESHEN_TIMEOUT_SECONDS)
+
+        results = await asyncio.gather(*(fetch_one(url) for url in token_urls), return_exceptions=True)
+        tokens: Dict[str, str] = {}
+        for url, result in zip(token_urls, results):
+            if isinstance(result, BaseException):
+                logging.warning("MCP auth: token fetch for %s failed: %r", url, result)
+            elif result:
+                tokens[url] = result
+        return tokens
 
     @staticmethod
     def _merge_user_sly_data(state_sly_data: Dict[str, Any], incoming: Any) -> None:

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -71,6 +71,7 @@ from nsflow.backend.utils.mcp.mcp_refresh_provider import ReauthRequiredError
 from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
 from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
 from nsflow.backend.utils.mcp.mcp_token_storage import ReauthFlowTokenStorage
+from nsflow.backend.utils.mcp.mcp_token_storage import RefreshGuardTokenStorage
 from nsflow.backend.utils.mcp.mcp_token_storage import _stored_expiry
 
 logger = logging.getLogger(__name__)
@@ -1010,10 +1011,17 @@ class MCPOAuthManager:
         expires_at = _stored_expiry(meta)
         token_endpoint = meta.get("token_endpoint")
 
+        # The SDK persists the refresh response through this storage. Guard
+        # that write on the entry still being the generation the refresh
+        # started from: a refresh can outlive its trigger (bounded callers
+        # abandon the wait but let the fetch finish), and the user may
+        # disconnect or re-authorize the server mid-flight - an unconditional
+        # write would resurrect deleted credentials or clobber the newer grant.
+        guarded_storage = RefreshGuardTokenStorage(server_url, expected_obtained_at=meta.get("obtained_at"))
         provider = SilentRefreshOAuthProvider(
             server_url=server_url,
             client_metadata=self._build_client_metadata(),
-            storage=storage,
+            storage=guarded_storage,
             # Report the expiry with the refresh margin already applied, so a
             # token get_fresh_token deems stale is equally invalid to the SDK's
             # is_token_valid() and the proactive refresh fires.

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -1011,13 +1011,16 @@ class MCPOAuthManager:
         expires_at = _stored_expiry(meta)
         token_endpoint = meta.get("token_endpoint")
 
-        # The SDK persists the refresh response through this storage. Guard
-        # that write on the entry still being the generation the refresh
-        # started from: a refresh can outlive its trigger (bounded callers
+        # The SDK reads the refresh token from - and persists the refresh
+        # response through - this storage. Pin both to the entry's generation
+        # at refresh start: a refresh can outlive its trigger (bounded callers
         # abandon the wait but let the fetch finish), and the user may
-        # disconnect or re-authorize the server mid-flight - an unconditional
-        # write would resurrect deleted credentials or clobber the newer grant.
-        guarded_storage = RefreshGuardTokenStorage(server_url, expected_obtained_at=meta.get("obtained_at"))
+        # disconnect or re-authorize the server mid-flight. Reads come from
+        # this snapshot (never a concurrent re-auth's fresh single-use token),
+        # and the write only lands if the stored entry is still this
+        # generation - never resurrecting a removed entry or clobbering a
+        # newer grant.
+        guarded_storage = RefreshGuardTokenStorage(server_url, snapshot=meta)
         provider = SilentRefreshOAuthProvider(
             server_url=server_url,
             client_metadata=self._build_client_metadata(),

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -175,6 +175,10 @@ class MCPOAuthManager:
         self._refresh_locks: Dict[str, asyncio.Lock] = {}
         # Bounds concurrent token fetches (see get_fresh_token_bounded).
         self._fetch_semaphore = asyncio.Semaphore(MAX_CONCURRENT_TOKEN_FETCHES)
+        # One shared in-flight fetch task per stored URL, so concurrent callers
+        # coalesce instead of stacking duplicate tasks (and semaphore slots)
+        # behind the same per-server refresh lock (see get_fresh_token_bounded).
+        self._inflight_fetches: Dict[str, asyncio.Task] = {}
         # Strong refs to fetch tasks whose caller gave up waiting, so they are
         # neither garbage-collected mid-run nor left with an unretrieved result.
         self._abandoned_fetches: set = set()
@@ -865,6 +869,15 @@ class MCPOAuthManager:
         queue time counts against ``timeout`` so the caller's latency bound
         holds regardless of how many URLs are being fetched at once.
 
+        Concurrent callers for the same URL coalesce onto one shared in-flight
+        task (each with its own wait budget). Without this, every chat message
+        or gate check against a slow server would spawn another fetch task
+        queued on the same per-server ``_refresh_lock``, each holding a
+        semaphore slot - so one hung server could starve every other server's
+        fetches and grow an unbounded abandoned-task backlog. Coalesced, a
+        hung server costs exactly one slot and one backlog entry no matter how
+        many callers time out on it.
+
         :param server_url: The stored connection URL to fetch a token for.
         :param timeout: Max seconds to wait; None means the module default
                         (read at call time so tests can shrink it).
@@ -876,11 +889,24 @@ class MCPOAuthManager:
         if timeout is None:
             timeout = TOKEN_FETCH_TIMEOUT_SECONDS
 
-        async def gated_fetch() -> Optional[str]:
-            async with self._fetch_semaphore:
-                return await self.get_fresh_token(server_url)
+        # No awaits between the lookup and the store, so this check-then-set
+        # cannot race on the single-threaded event loop.
+        task = self._inflight_fetches.get(server_url)
+        if task is None or task.done():
 
-        task = asyncio.ensure_future(gated_fetch())
+            async def gated_fetch() -> Optional[str]:
+                async with self._fetch_semaphore:
+                    return await self.get_fresh_token(server_url)
+
+            task = asyncio.ensure_future(gated_fetch())
+            self._inflight_fetches[server_url] = task
+
+            def _clear_inflight(done_task: "asyncio.Task") -> None:
+                # Guard against a newer task having already replaced this one.
+                if self._inflight_fetches.get(server_url) is done_task:
+                    del self._inflight_fetches[server_url]
+
+            task.add_done_callback(_clear_inflight)
         try:
             # wait (unlike wait_for) does NOT cancel the task on timeout.
             await asyncio.wait({task}, timeout=timeout)
@@ -916,7 +942,13 @@ class MCPOAuthManager:
         garbage-collected mid-run) and consume its eventual result so a late
         failure is logged instead of surfacing as "exception was never
         retrieved" noise at loop shutdown.
+
+        Idempotent: in-flight tasks are shared by concurrent callers
+        (coalescing in get_fresh_token_bounded), so several callers may give
+        up on the same task - it is referenced and consumed only once.
         """
+        if task in self._abandoned_fetches:
+            return
         self._abandoned_fetches.add(task)
 
         def _consume(done_task: "asyncio.Task") -> None:

--- a/nsflow/backend/utils/mcp/mcp_oauth_manager.py
+++ b/nsflow/backend/utils/mcp/mcp_oauth_manager.py
@@ -33,6 +33,8 @@ are persisted by ``FileTokenStorage``, and ``get_fresh_token`` silently refreshe
 them when needed so the token injected into ``sly_data`` is never stale.
 """
 
+# pylint: disable=too-many-lines
+
 import asyncio
 import base64
 import hashlib
@@ -77,6 +79,22 @@ logger = logging.getLogger(__name__)
 PENDING_FLOW_TTL_SECONDS = 600
 # Refresh a token this many seconds before its actual expiry.
 TOKEN_REFRESH_MARGIN_SECONDS = 60
+# How long get_fresh_token_bounded lets a caller wait for a token fetch. A
+# hung/unreachable MCP server or auth server must not stall the caller
+# (the network-selection gate, or a chat message awaiting header injection)
+# indefinitely - the SDK's own HTTP defaults allow up to 30s connect / 300s
+# read. The fetch itself is never cancelled on timeout (see
+# get_fresh_token_bounded); the caller just stops waiting.
+TOKEN_FETCH_TIMEOUT_SECONDS = 15
+# Cap on concurrent token fetches through get_fresh_token_bounded. The
+# injection path fetches one token per connected server per chat message (the
+# Agent Network Designer targets ALL of them), so after e.g. a laptop sleep
+# expires every token at once this prevents a stampede of simultaneous MCP
+# refresh probes (each opens a full streamable-HTTP session) and to_thread
+# disk reads. Queue time counts against the caller's wait budget, so the
+# message-latency bound still holds; fetches that outlive it finish in the
+# background and later messages pick their tokens up from disk.
+MAX_CONCURRENT_TOKEN_FETCHES = 4
 
 # Core OAuth authorize parameters the SDK owns and computes for security
 # (PKCE, CSRF, resource binding). extra_authorize_params may never set or
@@ -155,6 +173,11 @@ class MCPOAuthManager:
         self._cleanup_tasks: set = set()
         # Per-server locks serializing silent refreshes (see _refresh_lock).
         self._refresh_locks: Dict[str, asyncio.Lock] = {}
+        # Bounds concurrent token fetches (see get_fresh_token_bounded).
+        self._fetch_semaphore = asyncio.Semaphore(MAX_CONCURRENT_TOKEN_FETCHES)
+        # Strong refs to fetch tasks whose caller gave up waiting, so they are
+        # neither garbage-collected mid-run nor left with an unretrieved result.
+        self._abandoned_fetches: set = set()
         self._ensure_base64url_pkce_verifier()
 
     @classmethod
@@ -821,6 +844,93 @@ class MCPOAuthManager:
         if token_type.lower() == "bearer":
             token_type = "Bearer"
         return f"{token_type} {tokens.access_token}"
+
+    async def get_fresh_token_bounded(self, server_url: str, timeout: Optional[float] = None) -> Optional[str]:
+        """
+        ``get_fresh_token``, but the caller waits at most ``timeout`` seconds
+        (default ``TOKEN_FETCH_TIMEOUT_SECONDS``) and never sees an exception.
+
+        The fetch itself is NEVER cancelled on timeout - the caller just stops
+        waiting and the fetch finishes in the background. Cancelling a silent
+        refresh mid-flight is dangerous twice over: a rotation provider's
+        single-use refresh token can be consumed server-side without the
+        rotated replacement ever being persisted (the provider then revokes
+        the grant on the next attempt - see ``_refresh_lock``), and cancelling
+        the storage write would release ``FileTokenStorage``'s in-process lock
+        while its worker thread finishes the write detached. A fetch that
+        completes after the caller gave up still persists its tokens, so the
+        next caller gets them from disk.
+
+        Fetches are capped at ``MAX_CONCURRENT_TOKEN_FETCHES`` concurrent;
+        queue time counts against ``timeout`` so the caller's latency bound
+        holds regardless of how many URLs are being fetched at once.
+
+        :param server_url: The stored connection URL to fetch a token for.
+        :param timeout: Max seconds to wait; None means the module default
+                        (read at call time so tests can shrink it).
+        :return: ``"Bearer <token>"`` like ``get_fresh_token``, or None on
+                 timeout, fetch failure, or no-usable-token - each logged with
+                 its actual cause, so callers can treat None as "inject
+                 nothing" without re-diagnosing.
+        """
+        if timeout is None:
+            timeout = TOKEN_FETCH_TIMEOUT_SECONDS
+
+        async def gated_fetch() -> Optional[str]:
+            async with self._fetch_semaphore:
+                return await self.get_fresh_token(server_url)
+
+        task = asyncio.ensure_future(gated_fetch())
+        try:
+            # wait (unlike wait_for) does NOT cancel the task on timeout.
+            await asyncio.wait({task}, timeout=timeout)
+        except asyncio.CancelledError:
+            # Caller torn down (e.g. websocket closed): the mid-refresh dangers
+            # above still apply, so let the fetch finish in the background.
+            self._abandon_fetch(task, server_url)
+            raise
+        if not task.done():
+            logger.warning(
+                "MCP auth: token fetch for %s still running after %ss; giving up the wait "
+                "(the fetch continues in the background and its tokens persist for later calls)",
+                server_url,
+                timeout,
+            )
+            self._abandon_fetch(task, server_url)
+            return None
+        try:
+            token = task.result()
+        except Exception as exc:  # noqa: BLE001 - one server's failure must not break the caller's batch
+            logger.warning("MCP auth: token fetch for %s failed: %r", server_url, exc)
+            return None
+        if not token:
+            # get_fresh_token's definitive "no usable connection" answer (no
+            # tokens stored, expired and unrefreshable, needs re-auth, ...).
+            logger.warning("MCP auth: no usable token for %s (connection may need re-auth)", server_url)
+        return token
+
+    def _abandon_fetch(self, task: "asyncio.Task", server_url: str) -> None:
+        """
+        Detach a fetch task whose caller stopped waiting: hold a strong
+        reference (asyncio only keeps weak ones, so an unreferenced task can be
+        garbage-collected mid-run) and consume its eventual result so a late
+        failure is logged instead of surfacing as "exception was never
+        retrieved" noise at loop shutdown.
+        """
+        self._abandoned_fetches.add(task)
+
+        def _consume(done_task: "asyncio.Task") -> None:
+            self._abandoned_fetches.discard(done_task)
+            if done_task.cancelled():
+                # Loop shutdown cancelled it; nothing to report.
+                return
+            exc = done_task.exception()
+            if exc is not None:
+                logger.warning("MCP auth: abandoned token fetch for %s failed: %r", server_url, exc)
+            else:
+                logger.info("MCP auth: abandoned token fetch for %s completed after the wait was given up", server_url)
+
+        task.add_done_callback(_consume)
 
     @staticmethod
     def _refresh_failure_needs_reauth(exc: BaseException) -> bool:

--- a/nsflow/backend/utils/mcp/mcp_token_storage.py
+++ b/nsflow/backend/utils/mcp/mcp_token_storage.py
@@ -217,36 +217,40 @@ class FileTokenStorage:
 
     def _sync_set_tokens(self, tokens: OAuthToken, preserve_refresh_token: bool = True) -> None:
         with _interprocess_lock(self._lock_path):
-            blob = self._load_file()
-            entry = blob.get(self.server_url)
-            # Replace a corrupted/non-dict entry so a recovery write can't be
-            # blocked by an unindexable existing value.
-            if not isinstance(entry, dict):
-                entry = {}
-                blob[self.server_url] = entry
-            new_tokens = tokens.model_dump(mode="json")
-            if preserve_refresh_token and ("refresh_token" not in new_tokens or new_tokens["refresh_token"] is None):
-                # RFC 6749 section 6: a refresh response MAY omit the refresh
-                # token, meaning "keep using the existing one" (Salesforce and
-                # Google do this; You.com rotates instead). Overwriting with
-                # null would silently make the next refresh impossible. Only an
-                # omitted/None field means "keep" - an explicit empty string is
-                # stored as sent (a server clearing the token), not preserved.
-                old_tokens = entry.get("tokens")
-                old_refresh = old_tokens.get("refresh_token") if isinstance(old_tokens, dict) else None
-                if isinstance(old_refresh, str) and old_refresh:
-                    new_tokens["refresh_token"] = old_refresh
-            entry["tokens"] = new_tokens
-            entry["obtained_at"] = int(time.time())
-            if tokens.expires_in is not None:
-                entry["expires_at"] = entry["obtained_at"] + int(tokens.expires_in)
-            else:
-                entry.pop("expires_at", None)
-            # Fresh tokens mean the connection works again: clear a "reconnect
-            # required" marker left by a previously failed silent refresh
-            # (whether this write comes from a successful refresh or a re-auth).
-            entry.pop("needs_reauth", None)
-            self._write_file(blob)
+            self._locked_set_tokens(tokens, preserve_refresh_token)
+
+    def _locked_set_tokens(self, tokens: OAuthToken, preserve_refresh_token: bool) -> None:
+        """The set_tokens read-modify-write; caller must hold the inter-process lock."""
+        blob = self._load_file()
+        entry = blob.get(self.server_url)
+        # Replace a corrupted/non-dict entry so a recovery write can't be
+        # blocked by an unindexable existing value.
+        if not isinstance(entry, dict):
+            entry = {}
+            blob[self.server_url] = entry
+        new_tokens = tokens.model_dump(mode="json")
+        if preserve_refresh_token and ("refresh_token" not in new_tokens or new_tokens["refresh_token"] is None):
+            # RFC 6749 section 6: a refresh response MAY omit the refresh
+            # token, meaning "keep using the existing one" (Salesforce and
+            # Google do this; You.com rotates instead). Overwriting with
+            # null would silently make the next refresh impossible. Only an
+            # omitted/None field means "keep" - an explicit empty string is
+            # stored as sent (a server clearing the token), not preserved.
+            old_tokens = entry.get("tokens")
+            old_refresh = old_tokens.get("refresh_token") if isinstance(old_tokens, dict) else None
+            if isinstance(old_refresh, str) and old_refresh:
+                new_tokens["refresh_token"] = old_refresh
+        entry["tokens"] = new_tokens
+        entry["obtained_at"] = int(time.time())
+        if tokens.expires_in is not None:
+            entry["expires_at"] = entry["obtained_at"] + int(tokens.expires_in)
+        else:
+            entry.pop("expires_at", None)
+        # Fresh tokens mean the connection works again: clear a "reconnect
+        # required" marker left by a previously failed silent refresh
+        # (whether this write comes from a successful refresh or a re-auth).
+        entry.pop("needs_reauth", None)
+        self._write_file(blob)
 
     async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
         """Return the stored OAuth client info for this server, or None if absent/unparsable."""
@@ -538,6 +542,49 @@ class FileTokenStorage:
         except OSError:
             # Best effort (e.g. on Windows); not fatal.
             pass
+
+
+class RefreshGuardTokenStorage(FileTokenStorage):
+    """
+    ``FileTokenStorage`` whose token writes only land if the stored entry is
+    still the generation the refresh started from.
+
+    A silent refresh can outlive its trigger - ``get_fresh_token_bounded``
+    abandons the wait on timeout but deliberately lets the fetch finish in the
+    background - and even a foreground refresh runs concurrently with UI
+    actions. Between the refresh grant being sent and the SDK persisting its
+    response via ``set_tokens``, the user may have disconnected the server
+    (``remove()``) or re-authorized it (a fresh grant, new ``obtained_at``).
+    An unconditional write would then resurrect deleted credentials or
+    overwrite the newer grant with tokens from the old lineage.
+
+    The write is compare-and-swap'ed on ``obtained_at`` - stamped by every
+    token write, so it identifies the entry's generation - under the same
+    inter-process lock as the write itself: the entry must still exist and
+    carry the ``obtained_at`` captured when the refresh started, else the
+    refreshed tokens are dropped and logged. Reads are inherited unchanged.
+    """
+
+    def __init__(self, server_url: str, expected_obtained_at: Any, storage_dir: Optional[Path] = None):
+        """
+        :param expected_obtained_at: The entry's ``obtained_at`` at refresh
+               start (None if the entry predates obtained_at stamping).
+        """
+        super().__init__(server_url, storage_dir)
+        self._expected_obtained_at = expected_obtained_at
+
+    def _sync_set_tokens(self, tokens: OAuthToken, preserve_refresh_token: bool = True) -> None:
+        with _interprocess_lock(self._lock_path):
+            entry = self._load_file().get(self.server_url)
+            if not isinstance(entry, dict) or entry.get("obtained_at") != self._expected_obtained_at:
+                logger.warning(
+                    "Dropping refreshed MCP tokens for %s: the stored entry was %s while the refresh "
+                    "was in flight (disconnected or re-authorized); the refresh result is stale.",
+                    self.server_url,
+                    "removed" if not isinstance(entry, dict) else "re-written",
+                )
+                return
+            self._locked_set_tokens(tokens, preserve_refresh_token)
 
 
 class ReauthFlowTokenStorage:

--- a/nsflow/backend/utils/mcp/mcp_token_storage.py
+++ b/nsflow/backend/utils/mcp/mcp_token_storage.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -242,6 +243,10 @@ class FileTokenStorage:
                 new_tokens["refresh_token"] = old_refresh
         entry["tokens"] = new_tokens
         entry["obtained_at"] = int(time.time())
+        # Unique marker for this write. obtained_at alone is second-resolution,
+        # so two writes within one second would be indistinguishable to
+        # RefreshGuardTokenStorage's compare-and-swap.
+        entry["generation"] = uuid.uuid4().hex
         if tokens.expires_in is not None:
             entry["expires_at"] = entry["obtained_at"] + int(tokens.expires_in)
         else:
@@ -546,37 +551,69 @@ class FileTokenStorage:
 
 class RefreshGuardTokenStorage(FileTokenStorage):
     """
-    ``FileTokenStorage`` whose token writes only land if the stored entry is
-    still the generation the refresh started from.
+    ``FileTokenStorage`` view for a silent refresh, pinned to the generation
+    of the entry the refresh started from.
 
     A silent refresh can outlive its trigger - ``get_fresh_token_bounded``
     abandons the wait on timeout but deliberately lets the fetch finish in the
     background - and even a foreground refresh runs concurrently with UI
-    actions. Between the refresh grant being sent and the SDK persisting its
-    response via ``set_tokens``, the user may have disconnected the server
-    (``remove()``) or re-authorized it (a fresh grant, new ``obtained_at``).
-    An unconditional write would then resurrect deleted credentials or
-    overwrite the newer grant with tokens from the old lineage.
+    actions (a Disconnect, an interactive re-auth). Two guards pin the whole
+    refresh to one token lineage:
 
-    The write is compare-and-swap'ed on ``obtained_at`` - stamped by every
-    token write, so it identifies the entry's generation - under the same
-    inter-process lock as the write itself: the entry must still exist and
-    carry the ``obtained_at`` captured when the refresh started, else the
-    refreshed tokens are dropped and logged. Reads are inherited unchanged.
+    * Reads are served from the snapshot captured at refresh start, never the
+      live file. A lazy disk read could otherwise pick up a concurrent
+      re-auth's brand-new single-use refresh token, spend it on this
+      (logically stale) refresh, and then have the rotated result dropped by
+      the write guard below - bricking the newly authorized grant.
+    * The token write is compare-and-swapped on the entry's ``generation``
+      marker (a UUID stamped by every token write - ``obtained_at`` alone is
+      second-resolution, so two writes in one second could collide) under the
+      same inter-process lock as the write itself: the entry must still exist
+      and carry the captured generation, else the refreshed tokens are
+      dropped and logged - never resurrecting a removed entry or clobbering a
+      newer grant. Entries written before generation stamping compare as
+      None == None until any new write stamps one, which then fails the swap.
     """
 
-    def __init__(self, server_url: str, expected_obtained_at: Any, storage_dir: Optional[Path] = None):
+    def __init__(self, server_url: str, snapshot: Dict[str, Any], storage_dir: Optional[Path] = None):
         """
-        :param expected_obtained_at: The entry's ``obtained_at`` at refresh
-               start (None if the entry predates obtained_at stamping).
+        :param snapshot: The stored entry (a ``get_metadata`` result) as it
+               was when the refresh started.
         """
         super().__init__(server_url, storage_dir)
-        self._expected_obtained_at = expected_obtained_at
+        self._snapshot: Dict[str, Any] = dict(snapshot)
+
+    async def get_tokens(self) -> Optional[OAuthToken]:
+        """Serve the snapshot's tokens - never a concurrent re-auth's fresh grant."""
+        raw = self._snapshot.get("tokens")
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return OAuthToken.model_validate(raw)
+        except Exception as exc:  # noqa: BLE001 - tolerate a corrupted/hand-edited store
+            logger.warning("Ignoring unparsable snapshot MCP tokens for %s: %s", self.server_url, exc)
+            return None
+
+    async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
+        """Serve the snapshot's client registration, matching the pinned grant."""
+        raw = self._snapshot.get("client_info")
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return OAuthClientInformationFull.model_validate(raw)
+        except Exception as exc:  # noqa: BLE001 - tolerate a corrupted/hand-edited store
+            logger.warning("Ignoring unparsable snapshot MCP client info for %s: %s", self.server_url, exc)
+            return None
 
     def _sync_set_tokens(self, tokens: OAuthToken, preserve_refresh_token: bool = True) -> None:
         with _interprocess_lock(self._lock_path):
             entry = self._load_file().get(self.server_url)
-            if not isinstance(entry, dict) or entry.get("obtained_at") != self._expected_obtained_at:
+            unchanged = (
+                isinstance(entry, dict)
+                and entry.get("generation") == self._snapshot.get("generation")
+                and entry.get("obtained_at") == self._snapshot.get("obtained_at")
+            )
+            if not unchanged:
                 logger.warning(
                     "Dropping refreshed MCP tokens for %s: the stored entry was %s while the refresh "
                     "was in flight (disconnected or re-authorized); the refresh result is stale.",

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -25,6 +25,8 @@ failed refresh must leave the stored token untouched rather than falling into
 interactive re-authentication.
 """
 
+# pylint: disable=too-many-lines
+
 import asyncio
 import json
 import time
@@ -939,9 +941,9 @@ def test_set_token_endpoint_persists_and_merges(tmp_path):
 
 
 def _guard(tmp_path):
-    """Build the guard the way _silent_refresh does: capture obtained_at first."""
-    expected = FileTokenStorage(SERVER_URL, storage_dir=tmp_path).get_metadata().get("obtained_at")
-    return RefreshGuardTokenStorage(SERVER_URL, expected_obtained_at=expected, storage_dir=tmp_path)
+    """Build the guard the way _silent_refresh does: snapshot the entry first."""
+    snapshot = FileTokenStorage(SERVER_URL, storage_dir=tmp_path).get_metadata()
+    return RefreshGuardTokenStorage(SERVER_URL, snapshot=snapshot, storage_dir=tmp_path)
 
 
 def test_guarded_refresh_write_dropped_after_remove(tmp_path):
@@ -987,3 +989,45 @@ def test_guarded_refresh_write_applies_when_unchanged(tmp_path):
     # keeps the stored one, and fresh tokens clear the needs_reauth marker.
     assert entry["tokens"]["refresh_token"] == "refresh-1"
     assert "needs_reauth" not in entry
+
+
+def test_guarded_refresh_same_second_rewrite_still_dropped(tmp_path, monkeypatch):
+    """
+    obtained_at is second-resolution, so two writes in one second collide on
+    it; the UUID generation marker must still tell them apart and drop the
+    stale refresh result.
+    """
+    import nsflow.backend.utils.mcp.mcp_token_storage as ts  # pylint: disable=import-outside-toplevel
+
+    _seed_store(tmp_path)
+    storage = FileTokenStorage(SERVER_URL, storage_dir=tmp_path)
+    monkeypatch.setattr(ts.time, "time", lambda: 1_800_000_000)  # freeze the clock
+
+    asyncio.run(storage.set_tokens(OAuthToken(access_token="first-write", expires_in=3600)))
+    first_obtained_at = _read_store(tmp_path)["obtained_at"]
+    guard = _guard(tmp_path)  # refresh starts against the first write
+    # A re-auth lands within the SAME frozen second: obtained_at collides.
+    asyncio.run(storage.set_tokens(OAuthToken(access_token="reauth-token", expires_in=3600)))
+    assert _read_store(tmp_path)["obtained_at"] == first_obtained_at  # the collision is real
+
+    asyncio.run(guard.set_tokens(OAuthToken(access_token="old-lineage-token", expires_in=3600)))
+
+    assert _read_store(tmp_path)["tokens"]["access_token"] == "reauth-token"
+
+
+def test_guarded_reads_are_pinned_to_snapshot(tmp_path):
+    """
+    The refresh must only ever spend the refresh token of the generation it
+    started from: a lazy disk read could pick up a concurrent re-auth's fresh
+    single-use token, consume it, and have the result dropped by the write
+    guard - bricking the new grant.
+    """
+    _seed_store(tmp_path)  # stores refresh_token="refresh-1"
+    guard = _guard(tmp_path)
+    # A re-auth lands a new grant on disk while the refresh is in flight.
+    reauth = OAuthToken(access_token="reauth-token", refresh_token="refresh-2", expires_in=3600)
+    asyncio.run(FileTokenStorage(SERVER_URL, storage_dir=tmp_path).set_tokens(reauth, preserve_refresh_token=False))
+
+    tokens = asyncio.run(guard.get_tokens())
+
+    assert tokens.refresh_token == "refresh-1"  # pinned to the old lineage

--- a/tests/nsflow/test_mcp_refresh_provider.py
+++ b/tests/nsflow/test_mcp_refresh_provider.py
@@ -42,6 +42,7 @@ import nsflow.backend.utils.mcp.mcp_oauth_manager as om
 from nsflow.backend.utils.mcp.mcp_refresh_provider import SilentRefreshOAuthProvider
 from nsflow.backend.utils.mcp.mcp_token_storage import FileTokenStorage
 from nsflow.backend.utils.mcp.mcp_token_storage import ReauthFlowTokenStorage
+from nsflow.backend.utils.mcp.mcp_token_storage import RefreshGuardTokenStorage
 
 SERVER_URL = "https://mcp.example.com/mcp"
 TOKEN_ENDPOINT = "https://auth.example.com/oauth/token"
@@ -928,3 +929,61 @@ def test_set_token_endpoint_persists_and_merges(tmp_path):
     assert entry["token_endpoint"] == TOKEN_ENDPOINT
     assert entry["tokens"]["access_token"] == "stale-token"
     assert storage.get_metadata()["token_endpoint"] == TOKEN_ENDPOINT
+
+
+# ----------------------- RefreshGuardTokenStorage ----------------------- #
+# The silent-refresh write path uses this storage so a refresh that outlives
+# its trigger (get_fresh_token_bounded abandons the wait on timeout but lets
+# the fetch finish in the background) cannot resurrect a disconnected entry
+# or clobber a newer grant obtained by re-auth.
+
+
+def _guard(tmp_path):
+    """Build the guard the way _silent_refresh does: capture obtained_at first."""
+    expected = FileTokenStorage(SERVER_URL, storage_dir=tmp_path).get_metadata().get("obtained_at")
+    return RefreshGuardTokenStorage(SERVER_URL, expected_obtained_at=expected, storage_dir=tmp_path)
+
+
+def test_guarded_refresh_write_dropped_after_remove(tmp_path):
+    """A refresh completing after the user disconnected must not resurrect the entry."""
+    _seed_store(tmp_path)
+    guard = _guard(tmp_path)  # refresh starts: generation captured
+    asyncio.run(FileTokenStorage.remove(SERVER_URL, storage_dir=tmp_path))  # user disconnects
+
+    # The abandoned refresh finally lands its (now stale) result.
+    asyncio.run(guard.set_tokens(OAuthToken(access_token="zombie-token", expires_in=3600)))
+
+    blob = json.loads((tmp_path / "tokens.json").read_text(encoding="utf-8"))
+    assert SERVER_URL not in blob  # not resurrected
+
+
+def test_guarded_refresh_write_dropped_after_reauth(tmp_path):
+    """A refresh completing after a re-auth must not clobber the newer grant."""
+    _seed_store(tmp_path)
+    guard = _guard(tmp_path)  # refresh starts against the seeded (old) generation
+    # User re-authorizes mid-refresh: a fresh grant lands (new obtained_at -
+    # _seed_store backdates the seeded one by 2h, so the generations differ).
+    reauth = OAuthToken(access_token="reauth-token", refresh_token="refresh-2", expires_in=3600)
+    asyncio.run(FileTokenStorage(SERVER_URL, storage_dir=tmp_path).set_tokens(reauth, preserve_refresh_token=False))
+
+    # The old-lineage refresh result must be dropped, keeping the new grant.
+    asyncio.run(guard.set_tokens(OAuthToken(access_token="old-lineage-token", expires_in=3600)))
+
+    tokens = _read_store(tmp_path)["tokens"]
+    assert tokens["access_token"] == "reauth-token"
+    assert tokens["refresh_token"] == "refresh-2"
+
+
+def test_guarded_refresh_write_applies_when_unchanged(tmp_path):
+    """The common case still works: no disconnect/re-auth -> the refresh persists."""
+    _seed_store(tmp_path, needs_reauth=True)
+    guard = _guard(tmp_path)
+
+    asyncio.run(guard.set_tokens(OAuthToken(access_token="fresh-token", expires_in=3600)))
+
+    entry = _read_store(tmp_path)
+    assert entry["tokens"]["access_token"] == "fresh-token"
+    # Inherited set_tokens semantics are preserved: the omitted refresh_token
+    # keeps the stored one, and fresh tokens clear the needs_reauth marker.
+    assert entry["tokens"]["refresh_token"] == "refresh-1"
+    assert "needs_reauth" not in entry

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -27,6 +27,8 @@ these methods touch are set. External dependencies (token storage, the OAuth
 manager, the network loader) are patched.
 """
 
+# pylint: disable=too-many-lines
+
 import asyncio
 import time
 from unittest.mock import AsyncMock
@@ -743,6 +745,40 @@ def test_inject_timeout_does_not_cancel_fetch(monkeypatch):
 
     asyncio.run(main())
     assert events == ["completed"]  # finished in the background, never cancelled
+
+
+def test_bounded_fetch_coalesces_concurrent_callers(monkeypatch):
+    """
+    Concurrent bounded fetches for the same URL share ONE in-flight task, each
+    caller waiting with its own budget. Without coalescing, every caller would
+    spawn another task queued on the same per-server refresh lock - each
+    holding a fetch-semaphore slot - so a few messages against one hung server
+    would starve every other server's fetches and grow an abandoned backlog.
+    """
+    url = "https://hang.example.com/mcp"
+    calls = {"n": 0}
+
+    async def get_token(_url):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            await asyncio.sleep(0.2)  # outlives both callers' 0.05s wait budgets
+        return "Bearer tok"
+
+    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", get_token)
+    monkeypatch.setattr(om, "TOKEN_FETCH_TIMEOUT_SECONDS", 0.05)
+
+    async def main():
+        results = await asyncio.gather(
+            nw.mcp_oauth_manager.get_fresh_token_bounded(url),
+            nw.mcp_oauth_manager.get_fresh_token_bounded(url),
+        )
+        assert results == [None, None]  # both callers gave up waiting
+        await asyncio.sleep(0.5)  # let the shared background fetch finish
+        # A later call after completion starts a FRESH fetch (no stale reuse).
+        assert await nw.mcp_oauth_manager.get_fresh_token_bounded(url) == "Bearer tok"
+
+    asyncio.run(main())
+    assert calls["n"] == 2  # 1 shared by the two concurrent callers + 1 fresh
 
 
 def test_inject_fetches_tokens_concurrently(monkeypatch):

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -33,6 +33,7 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import nsflow.backend.utils.agentutils.ns_websocket_utils as nw
+import nsflow.backend.utils.mcp.mcp_oauth_manager as om
 
 # pylint: disable=protected-access  # these aliases exercise private methods under test
 NORM = nw.NsWebsocketUtils._normalize_mcp_url
@@ -511,14 +512,20 @@ def test_get_urls_network_none_returns_none(monkeypatch):
 # --------------------------- inject_mcp_auth_headers --------------------------- #
 
 
-def _patch_injection(monkeypatch, *, connections, referenced, token="Bearer tok"):
-    """Patch storage list, the network's referenced URLs, and the token fetch."""
+def _patch_injection(monkeypatch, *, connections, referenced, token="Bearer tok", get_token=None):
+    """
+    Patch storage list, the network's referenced URLs, and the token fetch.
+
+    ``get_token`` overrides the default constant-token AsyncMock with a custom
+    coroutine when a test needs URL-dependent behavior (hang, raise, count).
+    """
     monkeypatch.setattr(
         nw.FileTokenStorage,
         "list_connections",
         MagicMock(return_value=[{"server_url": u} for u in connections]),
     )
-    get_token = AsyncMock(return_value=token)
+    if get_token is None:
+        get_token = AsyncMock(return_value=token)
     monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", get_token)
     inst = _utils()
     inst.get_network_mcp_urls = lambda: (None if referenced is None else set(referenced))
@@ -681,22 +688,21 @@ def test_inject_ignores_redaction_sentinel(monkeypatch):
 
 def test_inject_hung_fetch_is_bounded_and_others_still_inject(monkeypatch):
     """
-    A hung token fetch is cut off at MCP_FRESHEN_TIMEOUT_SECONDS instead of
-    stalling the chat message, and it only forfeits its own token - the other
-    server's token is still injected (#255).
+    A hung token fetch stops being waited on at TOKEN_FETCH_TIMEOUT_SECONDS
+    instead of stalling the chat message, and it only forfeits its own token -
+    the other server's token is still injected (#255).
     """
     url_hang, url_fast = "https://hang.example.com/mcp", "https://fast.example.com/mcp"
-    _patch_connections(monkeypatch, [url_hang, url_fast])
-    monkeypatch.setattr(nw, "MCP_FRESHEN_TIMEOUT_SECONDS", 0.05)
 
     async def get_token(url):
         if url == url_hang:
             await asyncio.sleep(10)  # would stall the old sequential, unbounded loop
         return "Bearer tok"
 
-    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", get_token)
-    inst = _utils()
-    inst.get_network_mcp_urls = lambda: {url_hang, url_fast}
+    inst, _ = _patch_injection(
+        monkeypatch, connections=[url_hang, url_fast], referenced=[url_hang, url_fast], get_token=get_token
+    )
+    monkeypatch.setattr(om, "TOKEN_FETCH_TIMEOUT_SECONDS", 0.05)
 
     sly = {}
     start = time.monotonic()
@@ -707,13 +713,44 @@ def test_inject_hung_fetch_is_bounded_and_others_still_inject(monkeypatch):
     assert elapsed < 5  # bounded by the (patched) timeout, not the 10s hang
 
 
+def test_inject_timeout_does_not_cancel_fetch(monkeypatch):
+    """
+    Giving up the wait must NOT cancel the fetch itself: cancelling a silent
+    refresh mid-flight can burn a rotation provider's single-use refresh token
+    before the rotated one is persisted, and can cancel the storage write
+    mid-flight. The abandoned fetch runs to completion in the background.
+    """
+    url = "https://slow.example.com/mcp"
+    events = []
+
+    async def get_token(_url):
+        try:
+            await asyncio.sleep(0.2)  # outlives the 0.05s wait budget below
+        except asyncio.CancelledError:
+            events.append("cancelled")
+            raise
+        events.append("completed")
+        return "Bearer tok"
+
+    inst, _ = _patch_injection(monkeypatch, connections=[url], referenced=[url], get_token=get_token)
+    monkeypatch.setattr(om, "TOKEN_FETCH_TIMEOUT_SECONDS", 0.05)
+
+    async def main():
+        sly = {}
+        await inst.inject_mcp_auth_headers(sly)
+        assert sly["http_headers"] == {}  # nothing resolved within the wait budget
+        await asyncio.sleep(0.5)  # keep the loop alive for the abandoned fetch
+
+    asyncio.run(main())
+    assert events == ["completed"]  # finished in the background, never cancelled
+
+
 def test_inject_fetches_tokens_concurrently(monkeypatch):
     """
     Token fetches for multiple targets overlap instead of running one-by-one,
     so per-server latency does not accumulate across connections (#255).
     """
-    urls = [f"https://s{i}.example.com/mcp" for i in range(3)]
-    _patch_connections(monkeypatch, urls)
+    urls = [f"https://s{i}.example.com/mcp" for i in range(3)]  # under the concurrency cap
     in_flight = {"now": 0, "max": 0}
 
     async def get_token(_url):
@@ -723,15 +760,38 @@ def test_inject_fetches_tokens_concurrently(monkeypatch):
         in_flight["now"] -= 1
         return "Bearer tok"
 
-    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", get_token)
-    inst = _utils()
-    inst.get_network_mcp_urls = lambda: set(urls)
+    inst, _ = _patch_injection(monkeypatch, connections=urls, referenced=urls, get_token=get_token)
 
     sly = {}
     asyncio.run(inst.inject_mcp_auth_headers(sly))
 
     assert in_flight["max"] == len(urls)  # all fetches were in flight together
     assert set(sly["http_headers"]) == set(urls)
+
+
+def test_inject_concurrent_fetches_capped(monkeypatch):
+    """
+    The fetch fan-out is capped at MAX_CONCURRENT_TOKEN_FETCHES so a pile of
+    simultaneously expired tokens can't stampede every auth server at once;
+    the queued fetches still run and inject once a slot frees up.
+    """
+    urls = [f"https://s{i}.example.com/mcp" for i in range(om.MAX_CONCURRENT_TOKEN_FETCHES + 2)]
+    in_flight = {"now": 0, "max": 0}
+
+    async def get_token(_url):
+        in_flight["now"] += 1
+        in_flight["max"] = max(in_flight["max"], in_flight["now"])
+        await asyncio.sleep(0.01)
+        in_flight["now"] -= 1
+        return "Bearer tok"
+
+    inst, _ = _patch_injection(monkeypatch, connections=urls, referenced=urls, get_token=get_token)
+
+    sly = {}
+    asyncio.run(inst.inject_mcp_auth_headers(sly))
+
+    assert in_flight["max"] == om.MAX_CONCURRENT_TOKEN_FETCHES
+    assert set(sly["http_headers"]) == set(urls)  # the queued fetches were not dropped
 
 
 def test_inject_one_failing_fetch_does_not_break_others(monkeypatch):
@@ -741,21 +801,43 @@ def test_inject_one_failing_fetch_does_not_break_others(monkeypatch):
     aborted the entire injection via the outer catch-all.)
     """
     url_bad, url_good = "https://bad.example.com/mcp", "https://good.example.com/mcp"
-    _patch_connections(monkeypatch, [url_bad, url_good])
 
     async def get_token(url):
         if url == url_bad:
             raise RuntimeError("refresh exploded")
         return "Bearer tok"
 
-    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", get_token)
-    inst = _utils()
-    inst.get_network_mcp_urls = lambda: {url_bad, url_good}
+    inst, _ = _patch_injection(
+        monkeypatch, connections=[url_bad, url_good], referenced=[url_bad, url_good], get_token=get_token
+    )
 
     sly = {}
     asyncio.run(inst.inject_mcp_auth_headers(sly))
 
     assert sly["http_headers"] == {url_good: {"Authorization": "Bearer tok"}}
+
+
+def test_inject_recheck_keeps_user_auth_added_during_fetch(monkeypatch):
+    """
+    A user Authorization merged into the shared sly_data WHILE the token fetch
+    is in flight wins: the second pass re-checks the live headers right before
+    writing instead of trusting its pre-fetch snapshot, so a concurrent
+    handler's merge (reconnect, second tab) is never clobbered.
+    """
+    url = "https://api.example.com/mcp"
+    sly = {}
+
+    async def get_token(_url):
+        # Simulate another handler on the same session merging user sly_data
+        # while this injection awaits the fetch.
+        MERGE(sly, {"http_headers": {url: {"Authorization": "Bearer user-tok", "X-Api-Key": "k"}}})
+        return "Bearer fetched"
+
+    inst, _ = _patch_injection(monkeypatch, connections=[url], referenced=[url], get_token=get_token)
+    asyncio.run(inst.inject_mcp_auth_headers(sly))
+
+    # The user's headers survive; the fetched token is discarded for this URL.
+    assert sly["http_headers"][url] == {"Authorization": "Bearer user-tok", "X-Api-Key": "k"}
 
 
 def test_inject_shared_connection_fetched_once(monkeypatch):

--- a/tests/nsflow/test_ns_websocket_mcp.py
+++ b/tests/nsflow/test_ns_websocket_mcp.py
@@ -28,6 +28,7 @@ manager, the network loader) are patched.
 """
 
 import asyncio
+import time
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
@@ -676,6 +677,98 @@ def test_inject_ignores_redaction_sentinel(monkeypatch):
     asyncio.run(inst.inject_mcp_auth_headers(sly))
     assert sly["http_headers"][url]["Authorization"] == "Bearer tok"
     get_token.assert_awaited_once_with(url)
+
+
+def test_inject_hung_fetch_is_bounded_and_others_still_inject(monkeypatch):
+    """
+    A hung token fetch is cut off at MCP_FRESHEN_TIMEOUT_SECONDS instead of
+    stalling the chat message, and it only forfeits its own token - the other
+    server's token is still injected (#255).
+    """
+    url_hang, url_fast = "https://hang.example.com/mcp", "https://fast.example.com/mcp"
+    _patch_connections(monkeypatch, [url_hang, url_fast])
+    monkeypatch.setattr(nw, "MCP_FRESHEN_TIMEOUT_SECONDS", 0.05)
+
+    async def get_token(url):
+        if url == url_hang:
+            await asyncio.sleep(10)  # would stall the old sequential, unbounded loop
+        return "Bearer tok"
+
+    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", get_token)
+    inst = _utils()
+    inst.get_network_mcp_urls = lambda: {url_hang, url_fast}
+
+    sly = {}
+    start = time.monotonic()
+    asyncio.run(inst.inject_mcp_auth_headers(sly))
+    elapsed = time.monotonic() - start
+
+    assert sly["http_headers"] == {url_fast: {"Authorization": "Bearer tok"}}
+    assert elapsed < 5  # bounded by the (patched) timeout, not the 10s hang
+
+
+def test_inject_fetches_tokens_concurrently(monkeypatch):
+    """
+    Token fetches for multiple targets overlap instead of running one-by-one,
+    so per-server latency does not accumulate across connections (#255).
+    """
+    urls = [f"https://s{i}.example.com/mcp" for i in range(3)]
+    _patch_connections(monkeypatch, urls)
+    in_flight = {"now": 0, "max": 0}
+
+    async def get_token(_url):
+        in_flight["now"] += 1
+        in_flight["max"] = max(in_flight["max"], in_flight["now"])
+        await asyncio.sleep(0.01)
+        in_flight["now"] -= 1
+        return "Bearer tok"
+
+    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", get_token)
+    inst = _utils()
+    inst.get_network_mcp_urls = lambda: set(urls)
+
+    sly = {}
+    asyncio.run(inst.inject_mcp_auth_headers(sly))
+
+    assert in_flight["max"] == len(urls)  # all fetches were in flight together
+    assert set(sly["http_headers"]) == set(urls)
+
+
+def test_inject_one_failing_fetch_does_not_break_others(monkeypatch):
+    """
+    An exception from one server's fetch is contained to that server; the other
+    token is still injected. (Under the old sequential loop, the exception
+    aborted the entire injection via the outer catch-all.)
+    """
+    url_bad, url_good = "https://bad.example.com/mcp", "https://good.example.com/mcp"
+    _patch_connections(monkeypatch, [url_bad, url_good])
+
+    async def get_token(url):
+        if url == url_bad:
+            raise RuntimeError("refresh exploded")
+        return "Bearer tok"
+
+    monkeypatch.setattr(nw.mcp_oauth_manager, "get_fresh_token", get_token)
+    inst = _utils()
+    inst.get_network_mcp_urls = lambda: {url_bad, url_good}
+
+    sly = {}
+    asyncio.run(inst.inject_mcp_auth_headers(sly))
+
+    assert sly["http_headers"] == {url_good: {"Authorization": "Bearer tok"}}
+
+
+def test_inject_shared_connection_fetched_once(monkeypatch):
+    """Two referenced URL forms resolving to one stored connection fetch its token once."""
+    stored = "https://api.example.com/mcp"
+    ref_a, ref_b = "https://api.example.com/mcp", "https://api.example.com/mcp/"
+    inst, get_token = _patch_injection(monkeypatch, connections=[stored], referenced=[ref_a, ref_b])
+    sly = {}
+    asyncio.run(inst.inject_mcp_auth_headers(sly))
+    # Both referenced forms get the header, but the shared connection is only probed once.
+    assert sly["http_headers"][ref_a] == {"Authorization": "Bearer tok"}
+    assert sly["http_headers"][ref_b] == {"Authorization": "Bearer tok"}
+    get_token.assert_awaited_once_with(stored)
 
 
 # --------------------------- redact_sly_data_for_surface --------------------------- #


### PR DESCRIPTION
## Description

`inject_mcp_auth_headers` runs on every chat message and used to await `get_fresh_token` for each injection target **sequentially, with no timeout**. One expired token whose auth server hangs could stall the chat message by the SDK's network timeouts (up to 30s connect / 300s read), and multiple stale connections accumulated that delay. The Agent Network Designer's inject-all path (#254) amplified the worst case to every stored connection.

This PR restructures injection into three steps and moves the token-fetch latency policy into the OAuth manager:

1. **First pass** (`_targets_needing_tokens`, pure dict work): skip targets where the user supplied their own `Authorization` (the redaction sentinel doesn't count), collecting only the targets that need a fetched token.
2. **Bounded concurrent fetch** (`MCPOAuthManager.get_fresh_token_bounded`): all needed tokens are fetched concurrently. Each caller waits at most `TOKEN_FETCH_TIMEOUT_SECONDS` (15s), and the fan-out is capped at `MAX_CONCURRENT_TOKEN_FETCHES` (4) so a pile of simultaneously expired tokens can't stampede every auth server at once.
3. **Second pass** (`_inject_fetched_tokens`, no awaits): re-reads the live headers and **re-checks for a user-supplied `Authorization` immediately before each write**, so a header merged into the shared session sly_data while the fetch was in flight is never clobbered by a stale pre-fetch snapshot.

The key safety decision: **a timeout never cancels the fetch**. `get_fresh_token_bounded` uses `asyncio.wait` (which leaves the task running) rather than `asyncio.wait_for` (which cancels it). Cancelling a silent refresh mid-flight is dangerous twice over:

- A rotation provider's **single-use refresh token can be consumed server-side** with the rotated replacement never persisted — the provider then treats the next (re)use as theft and revokes the whole grant, bricking a healthy connection.
- Cancelling the storage write releases `FileTokenStorage`'s in-process lock while the `to_thread` worker finishes the write detached, breaking `remove()`'s documented no-resurrection guarantee.

Instead, a fetch that outlives the wait is *abandoned*: it completes in the background (held by a strong reference, its eventual result consumed and logged), persists its tokens, and the next message picks them up from disk.

`mcp_connection_gaps_fresh` (the network-selection freshen) drops its inline copy of the bounded batch and reuses the same helper, so the gate and chat-time injection share one token-fetch policy. Failure logging moved into the manager with accurate causes — the "connection may need re-auth" hint now fires only for a genuine no-usable-token answer, not for transient timeouts.

Incidental improvements, all pinned by tests: an exception from one server's fetch no longer aborts the entire injection; a connection referenced under two URL forms is fetched once per message.

Fixes #255.

## Impact

- A hung or unreachable MCP auth server delays a chat message by at most ~15s (previously up to 300s per stale connection, accumulating), and never delays the *other* servers' tokens.
- In-flight refreshes are never cancelled, so slow-but-healthy refreshes always complete and persist — no connection can be bricked by a timeout.
- User-supplied `Authorization` headers now win even against concurrent injection (re-checked at write time).
- No API surface or schema change; behavior for networks with fast/valid tokens is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)