### PR TITLE
Normalize progress websocket frames to one dict wire shape

### DIFF
--- a/nsflow/backend/utils/agentutils/agent_log_processor.py
+++ b/nsflow/backend/utils/agentutils/agent_log_processor.py
@@ -112,7 +112,7 @@ class AgentLogProcessor(MessageProcessor):
             # log progress messages if any
             progress = chat_message_dict.get("structure", progress)
             if progress:
-                await self.logs_manager.progress_event(json.dumps({"progress": progress}))
+                await self.logs_manager.progress_event({"text": progress})
 
                 # Process with state manager only if the manual editor plugin is enabled
                 if self.NSFLOW_PLUGIN_MANUAL_EDITOR:

--- a/nsflow/backend/utils/logutils/websocket_logs_manager.py
+++ b/nsflow/backend/utils/logutils/websocket_logs_manager.py
@@ -97,6 +97,9 @@ class WebsocketLogsManager:  # pylint: disable=too-many-instance-attributes  # a
         """
         Send a structured message to all connected clients.
         :param message: A dictionary representing the chat message and metadata.
+            Must be a dict of the form {"text": <dict payload>} — the canonical wire
+            shape on the progress channel is {"message": {"text": {...}}}; never pass
+            a JSON-encoded string, clients only dual-parse strings for legacy compat.
         """
         entry = {"message": message}
         self.logger.debug(message)
@@ -187,14 +190,10 @@ class WebsocketLogsManager:  # pylint: disable=too-many-instance-attributes  # a
         """
         await websocket.accept()
         self.active_progress_connections.append(websocket)
-        await self.progress_event(
-            {"text": json.dumps({"event": "progress_client_connected", "agent": self.agent_name})}
-        )
+        await self.progress_event({"text": {"event": "progress_client_connected", "agent": self.agent_name}})
         try:
             while True:
                 await asyncio.sleep(ASYNCIO_SLEEP_INTERVAL)
         except WebSocketDisconnect:
             self.active_progress_connections.remove(websocket)
-            await self.progress_event(
-                {"text": json.dumps({"event": "progress_client_connected", "agent": self.agent_name})}
-            )
+            await self.progress_event({"text": {"event": "progress_client_disconnected", "agent": self.agent_name}})

--- a/nsflow/frontend/src/components/TabbedChatPanel.tsx
+++ b/nsflow/frontend/src/components/TabbedChatPanel.tsx
@@ -196,7 +196,9 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
             }
           }
         } else if (typeof msg === "string") {
-          // AGENT_PROGRESS events arrive as a JSON string: '{"progress": {...}}'
+          // Legacy compat: older backends sent AGENT_PROGRESS as a JSON string
+          // '{"progress": {...}}'. The backend now always sends {"text": <dict>};
+          // keep this branch for one release, then remove.
           try {
             const parsed = JSON.parse(msg);
             payload = "progress" in parsed ? parsed.progress : parsed;

--- a/tests/nsflow/test_agent_log_processor.py
+++ b/tests/nsflow/test_agent_log_processor.py
@@ -16,7 +16,7 @@
 import unittest
 from unittest.mock import patch
 
-from neuro_san.internals.messages.chat_message_type import ChatMessageType
+from neuro_san.message.types.chat_message_type import ChatMessageType
 
 from nsflow.backend.utils.agentutils.agent_log_processor import AgentLogProcessor
 

--- a/tests/nsflow/test_agent_log_processor.py
+++ b/tests/nsflow/test_agent_log_processor.py
@@ -1,0 +1,151 @@
+# Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import unittest
+from unittest.mock import patch
+
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
+
+from nsflow.backend.utils.agentutils.agent_log_processor import AgentLogProcessor
+
+
+class _FakeLogsManager:
+    """Stand-in for WebsocketLogsManager that records every event it receives."""
+
+    def __init__(self):
+        self.progress_events = []
+        self.log_events = []
+        self.internal_chat_events = []
+
+    async def progress_event(self, message):
+        """Record a progress-channel event exactly as emitted."""
+        self.progress_events.append(message)
+
+    async def log_event(self, message, source):
+        """Record a log-channel event."""
+        self.log_events.append((message, source))
+
+    async def internal_chat_event(self, message):
+        """Record an internal-chat event."""
+        self.internal_chat_events.append(message)
+
+
+class TestProgressWireShape(unittest.IsolatedAsyncioTestCase):
+    """The progress channel must emit one canonical shape: {"text": <dict>} (issue #260).
+
+    Historically AGENT_PROGRESS frames were emitted as a JSON string
+    '{"progress": {...}}' while AGENT tool_output frames were emitted as a
+    dict {"text": {...}}, forcing clients to dual-parse.
+    """
+
+    def setUp(self):
+        self.logs_manager = _FakeLogsManager()
+        registry_patch = patch(
+            "nsflow.backend.utils.agentutils.agent_log_processor.LogsRegistry.register",
+            return_value=self.logs_manager,
+        )
+        # Keep the manual-editor mirroring out of these tests regardless of env.
+        plugin_patch = patch.object(AgentLogProcessor, "NSFLOW_PLUGIN_MANUAL_EDITOR", None)
+        registry_patch.start()
+        plugin_patch.start()
+        self.addCleanup(registry_patch.stop)
+        self.addCleanup(plugin_patch.stop)
+        self.processor = AgentLogProcessor("agent_network_designer", "session-1")
+
+    async def test_agent_progress_emits_canonical_dict_shape(self):
+        """AGENT_PROGRESS frames go out as {"text": <structure dict>}, not a JSON string."""
+        structure = {
+            "agent_network_name": "my_network",
+            "agent_network_definition": {"frontman": {"instructions": "hi", "tools": ["helper"]}},
+        }
+        message = {"structure": structure, "origin": []}
+
+        await self.processor.async_process_message(message, ChatMessageType.AGENT_PROGRESS)
+
+        self.assertEqual(len(self.logs_manager.progress_events), 1)
+        event = self.logs_manager.progress_events[0]
+        self.assertIsInstance(event, dict, "progress events must be dicts, never JSON strings")
+        self.assertEqual(event, {"text": structure})
+
+    async def test_agent_tool_output_emits_canonical_dict_shape(self):
+        """AGENT editor-tool frames keep their existing {"text": {...}} dict shape."""
+        definition = {"frontman": {"instructions": "hi", "tools": []}}
+        message = {
+            "origin": [{"tool": "add_agent_to_network"}],
+            "structure": {"tool_end": True, "tool_output": definition},
+            "text": "",
+        }
+
+        await self.processor.async_process_message(message, ChatMessageType.AGENT)
+
+        self.assertEqual(len(self.logs_manager.progress_events), 1)
+        event = self.logs_manager.progress_events[0]
+        self.assertIsInstance(event, dict, "progress events must be dicts, never JSON strings")
+        self.assertEqual(event, {"text": {"agent_network_definition": definition}})
+
+    async def test_both_message_types_share_one_wire_shape(self):
+        """Both producer paths emit the same {"text": <dict>} envelope (incl. connectivity style)."""
+        structure = {"connectivity_info": [{"origin": "frontman", "tools": ["helper"]}]}
+        await self.processor.async_process_message(
+            {"structure": structure, "origin": []}, ChatMessageType.AGENT_PROGRESS
+        )
+        await self.processor.async_process_message(
+            {
+                "origin": [{"tool": "update_agent_in_network"}],
+                "structure": {"tool_end": True, "tool_output": {"frontman": {}}},
+                "text": "",
+            },
+            ChatMessageType.AGENT,
+        )
+
+        self.assertEqual(len(self.logs_manager.progress_events), 2)
+        for event in self.logs_manager.progress_events:
+            self.assertIsInstance(event, dict)
+            self.assertEqual(set(event.keys()), {"text"})
+            self.assertIsInstance(event["text"], dict)
+
+    async def test_string_tool_output_emits_nothing(self):
+        """Unstructured string tool_output must never reach the progress channel."""
+        message = {
+            "origin": [{"tool": "add_agent_to_network"}],
+            "structure": {"tool_end": True, "tool_output": "unstructured text"},
+            "text": "",
+        }
+
+        await self.processor.async_process_message(message, ChatMessageType.AGENT)
+
+        self.assertEqual(self.logs_manager.progress_events, [])
+
+    async def test_empty_structure_progress_emits_nothing(self):
+        """An AGENT_PROGRESS frame with an empty structure emits no progress event."""
+        await self.processor.async_process_message({"structure": {}, "origin": []}, ChatMessageType.AGENT_PROGRESS)
+
+        self.assertEqual(self.logs_manager.progress_events, [])
+
+    async def test_non_editor_tool_output_emits_nothing(self):
+        """AGENT frames from tools outside EDITOR_TOOLS never reach the progress channel."""
+        message = {
+            "origin": [{"tool": "web_search"}],
+            "structure": {"tool_end": True, "tool_output": {"results": [1, 2]}},
+            "text": "",
+        }
+
+        await self.processor.async_process_message(message, ChatMessageType.AGENT)
+
+        self.assertEqual(self.logs_manager.progress_events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/nsflow/test_websocket_logs_manager.py
+++ b/tests/nsflow/test_websocket_logs_manager.py
@@ -1,0 +1,78 @@
+# Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import json
+import unittest
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from fastapi import WebSocketDisconnect
+
+from nsflow.backend.utils.logutils.websocket_logs_manager import WebsocketLogsManager
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket stand-in recording everything sent to it."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def accept(self):
+        """Accept the connection (no-op)."""
+
+    async def send_text(self, text):
+        """Record the serialized frame."""
+        self.sent.append(text)
+
+
+class TestProgressChannelWireShape(unittest.IsolatedAsyncioTestCase):
+    """The progress channel wire format is {"message": {"text": <dict>}} (issue #260)."""
+
+    def setUp(self):
+        self.manager = WebsocketLogsManager("my_agent", "session-1")
+
+    async def test_progress_event_wire_shape(self):
+        """progress_event wraps the payload as {"message": {"text": <dict>}} on the wire."""
+        ws = _FakeWebSocket()
+        self.manager.active_progress_connections.append(ws)
+
+        await self.manager.progress_event({"text": {"agent_network_name": "net"}})
+
+        self.assertEqual(len(ws.sent), 1)
+        frame = json.loads(ws.sent[0])
+        self.assertEqual(frame, {"message": {"text": {"agent_network_name": "net"}}})
+        self.assertIsInstance(frame["message"]["text"], dict)
+
+    async def test_lifecycle_events_are_dicts_with_correct_names(self):
+        """Connect/disconnect lifecycle frames carry dict payloads and distinct event names."""
+        ws = _FakeWebSocket()
+        events = AsyncMock()
+        sleep_patch = patch(
+            "nsflow.backend.utils.logutils.websocket_logs_manager.asyncio.sleep",
+            side_effect=WebSocketDisconnect,
+        )
+        with patch.object(self.manager, "progress_event", events), sleep_patch:
+            await self.manager.handle_progress_websocket(ws)
+
+        self.assertEqual(events.await_count, 2)
+        connected = events.await_args_list[0].args[0]
+        disconnected = events.await_args_list[1].args[0]
+        self.assertEqual(connected, {"text": {"event": "progress_client_connected", "agent": "my_agent"}})
+        self.assertEqual(disconnected, {"text": {"event": "progress_client_disconnected", "agent": "my_agent"}})
+        self.assertEqual(self.manager.active_progress_connections, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

The progress websocket emitted two inconsistent wire shapes depending on the message type:

- `ChatMessageType.AGENT` editor-tool frames: `{"message": {"text": {...}}}` (nested dict)
- `ChatMessageType.AGENT_PROGRESS` frames: `{"message": "{\"progress\": ...}"}` (JSON string requiring a second parse)

Every consumer had to dual-parse, and this fragile chain already produced one bug (#251). This PR normalizes all producers on the progress channel to a single canonical shape, `{"message": {"text": <dict>}}`:

- `agent_log_processor.py`: `AGENT_PROGRESS` now emits `progress_event({"text": progress})` instead of `progress_event(json.dumps({"progress": progress}))`.
- `websocket_logs_manager.py`: the connect/disconnect lifecycle events emit dict payloads instead of JSON-strings-inside-text; the `progress_event` docstring documents the canonical shape as the contract; and the disconnect lifecycle event is now correctly named `progress_client_disconnected` (was a copy-paste of `progress_client_connected`).
- `TabbedChatPanel.tsx`: no behavior change — the string-parsing branch is kept for one release as legacy compat and marked as such.

Note: #260 suggested `{"message": {"progress": {...}}}` as an example canonical shape; this PR unifies on `{"text": <dict>}` instead because the frontend already parses that shape natively (it is what the AGENT path and all other channel events use), so old frontends and the new backend remain compatible in both directions.

Fixes #260

## Impact

- Consumers of `/api/v1/ws/progress/...` receive one consistent frame shape for all message types. The existing frontend handles the dict shape through its pre-existing object branch, so rendering behavior is unchanged (verified by tracing all consumers: `TabbedChatPanel` → `ChatContext` → `EditorAgentFlow`/`EditorSidebar`/`NetworkAgentEditorPanel` via `extractProgressPayload`, including `connectivity_info`-style payloads from the #251 regression area).
- `process_for_manual_editor` and the sly_data channel are untouched (the old `json.dumps` was wire-only).
- New tests: `tests/nsflow/test_agent_log_processor.py` (6 tests pinning the canonical shape and the no-emit guards) and `tests/nsflow/test_websocket_logs_manager.py` (2 tests covering the wire envelope and lifecycle events).

## Screenshots / Logs / Examples (optional)

Wire frame for an AGENT_PROGRESS message, before → after:

```
{"message": "{\"progress\": {\"agent_network_name\": \"my_net\", \"agent_network_definition\": {...}}}"}
{"message": {"text": {"agent_network_name": "my_net", "agent_network_definition": {...}}}}
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---