### PR TITLE
Editor chat: send the sly_data the canvas renders, selected in one place

### DIFF
--- a/nsflow/frontend/src/components/ChatPanel.tsx
+++ b/nsflow/frontend/src/components/ChatPanel.tsx
@@ -57,7 +57,6 @@ import { Mp3Encoder } from "@breezystack/lamejs";
 
 // NEW: use cache + converter to source sly_data from the editor
 import { useSlyDataCache } from "../hooks/useSlyDataCache";
-import { latestNetworkPayload } from "../utils/progressHelper";
 
 const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
   const { apiUrl } = useApiPort();
@@ -71,17 +70,13 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
     activeNetwork,
     targetNetwork,
     chatMessages,
-    slyDataMessages,
     addChatMessage,
     addSlyDataMessage,
     chatWs,
     isEditorMode,
     waitingForAgent,
     setWaitingForAgent,
-    getLastProgressMessage,
-    getLastSlyDataMessage,
-    lastProgressAt,
-    lastSlyDataAt,
+    getEditorOutgoingSlyData,
   } = useChatContext();
 
   const { stopWebSocket, clearChat } = useChatControls();
@@ -274,33 +269,13 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
     }
   }, [chatMessages, shouldAutoPlayNextAgent]);
 
-  // Build sly_data to send: editor mode reads from slyDataMessages, home mode reads from cache
+  // Build sly_data to send: editor mode reads from the shared context builder, home mode reads from cache
   const getSlyDataForSend = useCallback((): Record<string, any> | undefined => {
     if (isEditorMode) {
-      // In editor mode, always send current sly data from the messages stream (no cache, no checkbox)
-      let base: Record<string, any> = {};
-      for (let i = (slyDataMessages ?? []).length - 1; i >= 0; i--) {
-        const msg = slyDataMessages[i];
-        const raw = typeof msg?.text === 'string' ? msg.text : undefined;
-        if (!raw) continue;
-        // Extract JSON from code-fenced or raw string
-        const fence = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
-        const jsonStr = fence?.[1] ?? raw;
-        try {
-          const parsed = JSON.parse(jsonStr);
-          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) { base = parsed; break; }
-        } catch { /* skip non-JSON messages */ }
-      }
-      // Overlay the freshest network definition — the same payload the canvas
-      // renders (progress or slydata, whichever arrived last) — so the designer
-      // always receives the network the user currently sees (#261). The slydata
-      // stream alone can lag progress frames within a turn.
-      const p = getLastProgressMessage({ network: targetNetwork }) ?? getLastProgressMessage();
-      const s = getLastSlyDataMessage({ network: targetNetwork }) ?? getLastSlyDataMessage();
-      const payload = latestNetworkPayload(p, s, lastProgressAt > lastSlyDataAt);
-      if (payload?.agent_network_definition) base.agent_network_definition = payload.agent_network_definition;
-      if (payload?.agent_network_name) base.agent_network_name = payload.agent_network_name;
-      return base; // {} when no sly data yet — still send empty object
+      // Newest sly_data blob + the freshest definition/name pair overlaid (#261),
+      // built by ChatContext so the send path and the Sly Data panel agree.
+      // {} when no sly data yet — still send empty object.
+      return getEditorOutgoingSlyData();
     }
     // Home mode: use checkbox + cache
     if (!useSlyDataChecked) return undefined;
@@ -311,8 +286,7 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
       return cached.data;
     }
     return {};
-  }, [isEditorMode, slyDataMessages, useSlyDataChecked, targetNetwork, activeNetwork, loadSlyDataFromCache,
-      getLastProgressMessage, getLastSlyDataMessage, lastProgressAt, lastSlyDataAt]);
+  }, [isEditorMode, getEditorOutgoingSlyData, useSlyDataChecked, targetNetwork, activeNetwork, loadSlyDataFromCache]);
 
   const handleFileAttach = () => {
     fileInputRef.current?.click();

--- a/nsflow/frontend/src/components/ChatPanel.tsx
+++ b/nsflow/frontend/src/components/ChatPanel.tsx
@@ -57,6 +57,7 @@ import { Mp3Encoder } from "@breezystack/lamejs";
 
 // NEW: use cache + converter to source sly_data from the editor
 import { useSlyDataCache } from "../hooks/useSlyDataCache";
+import { latestNetworkPayload } from "../utils/progressHelper";
 
 const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
   const { apiUrl } = useApiPort();
@@ -77,6 +78,10 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
     isEditorMode,
     waitingForAgent,
     setWaitingForAgent,
+    getLastProgressMessage,
+    getLastSlyDataMessage,
+    lastProgressAt,
+    lastSlyDataAt,
   } = useChatContext();
 
   const { stopWebSocket, clearChat } = useChatControls();
@@ -273,6 +278,7 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
   const getSlyDataForSend = useCallback((): Record<string, any> | undefined => {
     if (isEditorMode) {
       // In editor mode, always send current sly data from the messages stream (no cache, no checkbox)
+      let base: Record<string, any> = {};
       for (let i = (slyDataMessages ?? []).length - 1; i >= 0; i--) {
         const msg = slyDataMessages[i];
         const raw = typeof msg?.text === 'string' ? msg.text : undefined;
@@ -282,10 +288,19 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
         const jsonStr = fence?.[1] ?? raw;
         try {
           const parsed = JSON.parse(jsonStr);
-          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) { base = parsed; break; }
         } catch { /* skip non-JSON messages */ }
       }
-      return {}; // no sly data yet — still send empty object
+      // Overlay the freshest network definition — the same payload the canvas
+      // renders (progress or slydata, whichever arrived last) — so the designer
+      // always receives the network the user currently sees (#261). The slydata
+      // stream alone can lag progress frames within a turn.
+      const p = getLastProgressMessage({ network: targetNetwork }) ?? getLastProgressMessage();
+      const s = getLastSlyDataMessage({ network: targetNetwork }) ?? getLastSlyDataMessage();
+      const payload = latestNetworkPayload(p, s, lastProgressAt > lastSlyDataAt);
+      if (payload?.agent_network_definition) base.agent_network_definition = payload.agent_network_definition;
+      if (payload?.agent_network_name) base.agent_network_name = payload.agent_network_name;
+      return base; // {} when no sly data yet — still send empty object
     }
     // Home mode: use checkbox + cache
     if (!useSlyDataChecked) return undefined;
@@ -296,7 +311,8 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
       return cached.data;
     }
     return {};
-  }, [isEditorMode, slyDataMessages, useSlyDataChecked, targetNetwork, activeNetwork, loadSlyDataFromCache]);
+  }, [isEditorMode, slyDataMessages, useSlyDataChecked, targetNetwork, activeNetwork, loadSlyDataFromCache,
+      getLastProgressMessage, getLastSlyDataMessage, lastProgressAt, lastSlyDataAt]);
 
   const handleFileAttach = () => {
     fileInputRef.current?.click();

--- a/nsflow/frontend/src/components/EditorAgentFlow.tsx
+++ b/nsflow/frontend/src/components/EditorAgentFlow.tsx
@@ -34,7 +34,6 @@ import {
 } from "@mui/icons-material";
 import { useChatContext } from "../context/ChatContext";
 import { getFeatureFlags, toServedNetworkPath, getManifestUpdatePeriodMs } from "../utils/config";
-import { extractProgressPayload, latestNetworkPayload } from "../utils/progressHelper";
 
 export const nodeTypes = Object.freeze({
   agent: EditableAgentNode,
@@ -88,8 +87,8 @@ const EditorAgentFlow = ({
   const launchAnchorRef = useRef<HTMLDivElement>(null);
 
   // We'll read the latest agent_network_definition from logs in view-mode
-  const { getLastProgressMessage, getLastSlyDataMessage, targetNetwork,
-    progressTick, slyDataTick, lastProgressAt, lastSlyDataAt, waitingForAgent } = useChatContext();
+  const { getLatestNetworkPayload,
+    progressTick, slyDataTick, waitingForAgent } = useChatContext();
 
   // The launch button becomes visible as soon as the designer reports a network name,
   // but a freshly-generated network isn't actually finished/registered until the agent
@@ -120,21 +119,14 @@ const EditorAgentFlow = ({
 
   // latest definition for view-mode
   const getViewDefinition = useCallback(() => {
-    const p = getLastProgressMessage({ network: targetNetwork }) ?? getLastProgressMessage();
-    const s = getLastSlyDataMessage({ network: targetNetwork }) ?? getLastSlyDataMessage();
+    return getLatestNetworkPayload()?.agent_network_definition as Record<string, any> | undefined;
+  }, [getLatestNetworkPayload]);
 
-    const payload = latestNetworkPayload(p, s, lastProgressAt > lastSlyDataAt);
-
-    return payload?.agent_network_definition as Record<string, any> | undefined;
-  }, [getLastProgressMessage, getLastSlyDataMessage, targetNetwork]);
-
-  // Get the latest agent network name for launch button
+  // Latest agent network name for the launch button — same selector as the canvas
+  // and outgoing sly_data, so all three always name the same network.
   const getLatestAgentNetworkName = useCallback(() => {
-    const p = getLastProgressMessage({ network: targetNetwork }) ?? getLastProgressMessage();
-    const s = getLastSlyDataMessage({ network: targetNetwork }) ?? getLastSlyDataMessage();
-    const payload = extractProgressPayload(s) || extractProgressPayload(p);
-    return payload?.agent_network_name;
-  }, [getLastProgressMessage, getLastSlyDataMessage, targetNetwork]);
+    return getLatestNetworkPayload()?.agent_network_name;
+  }, [getLatestNetworkPayload]);
 
   // Layout manager for position caching and intelligent layout
   const layoutManager = selectedNetwork ? createLayoutManager(selectedNetwork, {

--- a/nsflow/frontend/src/components/EditorAgentFlow.tsx
+++ b/nsflow/frontend/src/components/EditorAgentFlow.tsx
@@ -34,7 +34,7 @@ import {
 } from "@mui/icons-material";
 import { useChatContext } from "../context/ChatContext";
 import { getFeatureFlags, toServedNetworkPath, getManifestUpdatePeriodMs } from "../utils/config";
-import {extractProgressPayload } from "../utils/progressHelper";
+import { extractProgressPayload, latestNetworkPayload } from "../utils/progressHelper";
 
 export const nodeTypes = Object.freeze({
   agent: EditableAgentNode,
@@ -123,12 +123,7 @@ const EditorAgentFlow = ({
     const p = getLastProgressMessage({ network: targetNetwork }) ?? getLastProgressMessage();
     const s = getLastSlyDataMessage({ network: targetNetwork }) ?? getLastSlyDataMessage();
 
-    // Decide which one to use based on which tick was updated last basis timestamp
-    const preferProgress = lastProgressAt > lastSlyDataAt;
-
-    const payload = preferProgress
-      ? extractProgressPayload(p) || extractProgressPayload(s)
-      : extractProgressPayload(s) || extractProgressPayload(p);
+    const payload = latestNetworkPayload(p, s, lastProgressAt > lastSlyDataAt);
 
     return payload?.agent_network_definition as Record<string, any> | undefined;
   }, [getLastProgressMessage, getLastSlyDataMessage, targetNetwork]);

--- a/nsflow/frontend/src/components/EditorSidebar.tsx
+++ b/nsflow/frontend/src/components/EditorSidebar.tsx
@@ -24,7 +24,6 @@ import { useChatContext } from "../context/ChatContext";
 import { useChatControls } from "../hooks/useChatControls";
 import { useNeuroSan } from "../context/NeuroSanContext";
 import { getFeatureFlags, toServedNetworkPath } from "../utils/config";
-import {extractProgressPayload } from "../utils/progressHelper";
 
 
 interface EditingSession {
@@ -89,8 +88,8 @@ const EditorSidebar = ({
   const [selectedNetworkOption, setSelectedNetworkOption] = useState<NetworkOption | null>(null);
   const [agentNetworkDefinition, setAgentNetworkDefinition] = useState<Record<string, any> | null>(null);
   const { apiUrl, isReady } = useApiPort();
-  const { chatMessages, getLastProgressMessage, getLastSlyDataMessage,
-    progressTick, slyDataTick, lastProgressAt, lastSlyDataAt, targetNetwork,
+  const { chatMessages, getLatestNetworkPayload,
+    progressTick, slyDataTick, targetNetwork,
     activeNetwork, addSlyDataMessage, regenerateSessionId, waitingForAgent } = useChatContext();
   const { host, port, connectionType, isNsReady } = useNeuroSan();
   const { stopWebSocket, clearChat } = useChatControls();
@@ -263,16 +262,7 @@ const EditorSidebar = ({
   };
 
   const refreshFromLogs = () => {
-    // Prefer network-scoped latest, then fallback to global
-    const latestProgress = getLastProgressMessage({ network: targetNetwork }) ?? getLastProgressMessage();
-    const latestSly = getLastSlyDataMessage({ network: targetNetwork }) ?? getLastSlyDataMessage();
-
-    // Decide which one to use based on which tick was updated last basis timestamp
-    const preferProgress = lastProgressAt > lastSlyDataAt;
-
-    const payload = preferProgress
-      ? extractProgressPayload(latestProgress) || extractProgressPayload(latestSly)
-      : extractProgressPayload(latestSly) || extractProgressPayload(latestProgress);
+    const payload = getLatestNetworkPayload();
     // silently ignore; nothing to show yet
     if (!payload?.agent_network_definition) return;
 

--- a/nsflow/frontend/src/components/NetworkAgentEditorPanel.tsx
+++ b/nsflow/frontend/src/components/NetworkAgentEditorPanel.tsx
@@ -26,7 +26,6 @@ import { useApiPort } from '../context/ApiPortContext';
 import { useJsonEditorTheme } from '../context/ThemeContext';
 import { JsonEditor, ThemeInput } from 'json-edit-react';
 import { useChatContext } from "../context/ChatContext";
-import { extractProgressPayload } from "../utils/progressHelper";
 
 interface NetworkAgentEditorPanelProps {
   selectedDesignId: string;
@@ -55,7 +54,7 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
   const [hasChanges, setHasChanges] = useState(false);
   const [, setOriginalData] = useState<any>(null);
   const [schema, setSchema] = useState<any>(null);
-  const { getLastProgressMessage, getLastSlyDataMessage, targetNetwork } = useChatContext();
+  const { getLatestNetworkPayload } = useChatContext();
   
   const panelRef = useRef<HTMLDivElement>(null);
   const theme = useTheme();
@@ -70,11 +69,8 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
   const hasChangesToSave = canEdit && hasChanges;
 
   const getViewDefinition = useCallback(() => {
-    const p = getLastProgressMessage({ network: targetNetwork }) ?? getLastProgressMessage();
-    const s = getLastSlyDataMessage({ network: targetNetwork }) ?? getLastSlyDataMessage();
-    const payload = extractProgressPayload(s) || extractProgressPayload(p);
-    return payload?.agent_network_definition as Record<string, any> | undefined;
-  }, [getLastProgressMessage, getLastSlyDataMessage, targetNetwork]);
+    return getLatestNetworkPayload()?.agent_network_definition as Record<string, any> | undefined;
+  }, [getLatestNetworkPayload]);
 
   // Handle clicking outside to collapse when not pinned
   useEffect(() => {

--- a/nsflow/frontend/src/components/TabbedChatPanel.tsx
+++ b/nsflow/frontend/src/components/TabbedChatPanel.tsx
@@ -223,7 +223,7 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
       newSlyDataWs.close();
       newProgressWs.close();
     };
-  }, [targetNetwork, wsUrl, sessionId]);
+  }, [targetNetwork, wsUrl, sessionId, isEditorMode]);
 
   const tabConfig = [
     { id: "chat", label: "Chat", icon: <ChatIcon />, component: <ChatPanel /> },

--- a/nsflow/frontend/src/components/TabbedChatPanel.tsx
+++ b/nsflow/frontend/src/components/TabbedChatPanel.tsx
@@ -37,8 +37,8 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
   const { theme } = useTheme();
   const { sessionId, activeNetwork, targetNetwork, isEditorMode: contextIsEditorMode, setIsEditorMode,
     addChatMessage, addInternalChatMessage, addSlyDataMessage, addProgressMessage,
-    setChatWs, setInternalChatWs, setSlyDataWs, setProgressWs, chatWs, internalChatWs,
-    slyDataWs, progressWs, setNewSlyData, setNewProgress } = useChatContext();
+    setChatWs, setInternalChatWs, setSlyDataWs, setProgressWs,
+    setNewSlyData, setNewProgress } = useChatContext();
   const lastActiveNetworkRef = useRef<string | null>(null);
   const lastMessageRef = useRef<string | null>(null);
 
@@ -52,23 +52,11 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
   useEffect(() => {
     if (!targetNetwork) return;
 
-    // Close old WebSockets before creating new ones
-    if (chatWs) {
-      console.log("Closing previous Chat WebSocket...");
-      chatWs.close();
-    }
-    if (internalChatWs) {
-      console.log("Closing previous Internal Chat WebSocket...");
-      internalChatWs.close();
-    }
-    if (slyDataWs) {
-      console.log("Closing previous Sly Data WebSocket...");
-      slyDataWs.close();
-    }
-    if (progressWs) {
-      console.log("Closing previous Progress WebSocket...");
-      progressWs.close();
-    }
+    // Set when this session's sockets are torn down. Late frames from a previous
+    // session must be dropped, not recorded: ws.close() is asynchronous, and an
+    // old frame landing after a clear/reload would repopulate the per-network
+    // payload maps that editor-mode sly_data is built from.
+    let disposed = false;
 
     // Send system message for network switch only once
     if (lastActiveNetworkRef.current !== targetNetwork) {
@@ -86,6 +74,7 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
     const newChatWs = new WebSocket(chatWsUrl);
 
     newChatWs.onmessage = (event) => {
+      if (disposed) return;
       try {
         const data = JSON.parse(event.data);
         if (data.message && typeof data.message === "object" && data.message.type === "AI") {
@@ -101,12 +90,14 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
     setChatWs(newChatWs);
 
     // Setup WebSocket for Internal Chat Panel (skip in editor mode)
+    let newInternalWs: WebSocket | null = null;
     if (!isEditorMode) {
       const internalWsUrl = `${wsUrl}/api/v1/ws/internalchat/${targetNetwork}/${sessionId}`;
       console.log("Connecting Internal Chat WebSocket:", internalWsUrl);
-      const newInternalWs = new WebSocket(internalWsUrl);
+      newInternalWs = new WebSocket(internalWsUrl);
 
       newInternalWs.onmessage = (event) => {
+        if (disposed) return;
         try {
           const data = JSON.parse(event.data);
           if (data.message && typeof data.message === "object") {
@@ -136,6 +127,7 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
     const newSlyDataWs = new WebSocket(slyDataWsUrl);
 
     newSlyDataWs.onmessage = (event) => {
+      if (disposed) return;
       try {
         const data = JSON.parse(event.data);
         if (data.message && typeof data.message === "object") {
@@ -176,6 +168,7 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
     const newProgressWs = new WebSocket(progressWsUrl);
 
     newProgressWs.onmessage = (event) => {
+      if (disposed) return;
       try {
         const data = JSON.parse(event.data);
         // Expect a shape like { message: { text: string | object, ... } } OR other
@@ -223,7 +216,12 @@ const TabbedChatPanel = ({ isEditorMode = false }: TabbedChatPanelProps) => {
     setProgressWs(newProgressWs);
 
     return () => {
-      console.log("WebSockets for old network are closed.");
+      disposed = true;
+      console.log("Closing WebSockets for previous session/network...");
+      newChatWs.close();
+      newInternalWs?.close();
+      newSlyDataWs.close();
+      newProgressWs.close();
     };
   }, [targetNetwork, wsUrl, sessionId]);
 

--- a/nsflow/frontend/src/components/slydata/EditorSlyDataPanel.tsx
+++ b/nsflow/frontend/src/components/slydata/EditorSlyDataPanel.tsx
@@ -89,7 +89,8 @@ const getLatestSlyDataFromMessages = (msgs: any[]): any | undefined => {
 /* ---------------- component ---------------- */
 
 const EditorSlyDataPanel: React.FC = () => {
-  const { slyDataMessages, targetNetwork, addSlyDataMessage, isEditorMode } = useChatContext();
+  const { slyDataMessages, targetNetwork, addSlyDataMessage, isEditorMode,
+    getEditorOutgoingSlyData, progressTick } = useChatContext();
   const { theme } = useTheme();
   const jsonEditorTheme = useJsonEditorTheme();
 
@@ -141,9 +142,14 @@ const EditorSlyDataPanel: React.FC = () => {
 
   const latestSigRef = useRef<string>('INIT');
 
-  // only use the global stream; both agent + user edits go through addSlyDataMessage
+  // In editor mode, show exactly the blob a send would carry (base + freshest
+  // definition/name overlay from ChatContext) so the panel never displays
+  // something different from what the designer receives. Outside editor mode,
+  // keep deriving from the slydata stream alone.
   useEffect(() => {
-    const latest = getLatestSlyDataFromMessages(slyDataMessages ?? []);
+    const latest = isEditorMode
+      ? getEditorOutgoingSlyData()
+      : getLatestSlyDataFromMessages(slyDataMessages ?? []);
     const sig = stableStringify(latest ?? '__EMPTY__');
 
     if (sig === latestSigRef.current) return;
@@ -155,7 +161,7 @@ const EditorSlyDataPanel: React.FC = () => {
       if (targetNetwork && !isEditorMode) saveSlyDataToCache(latest, targetNetwork, 1);
       setEditorVersion(v => v + 1);
     }
-  }, [slyDataMessages, saveSlyDataToCache, targetNetwork, isEditorMode]);
+  }, [slyDataMessages, progressTick, getEditorOutgoingSlyData, saveSlyDataToCache, targetNetwork, isEditorMode]);
 
   /* ---- actions ---- */
 

--- a/nsflow/frontend/src/context/ChatContext.tsx
+++ b/nsflow/frontend/src/context/ChatContext.tsx
@@ -17,6 +17,12 @@ limitations under the License.
 import { createContext, useContext, useState, ReactNode, useRef } from "react";
 import { getWandName } from "../utils/config";
 import { getCruseAgentNames } from "../utils/config";
+import {
+  ProgressPayload,
+  asObjectText,
+  latestNetworkPayload,
+  overlayNetworkPayload,
+} from "../utils/progressHelper";
 
 // Generate a unique session ID for this browser session
 // const generateSessionId = (): string => {
@@ -107,6 +113,10 @@ type ChatContextType = {
   getLastLogMessage: (opts?: { network?: string; connectionId?: string }) => Message | undefined;
   getLastProgressMessage: (opts?: { network?: string; connectionId?: string }) => Message | undefined;
 
+  getLatestNetworkPayload: (network?: string) => ProgressPayload | undefined;
+  getEditorOutgoingSlyData: (network?: string) => Record<string, any>;
+  clearNetworkPayloadState: () => void;
+
   makeSlyDataConnectionId: () => string;
   makeLogConnectionId: () => string;
   makeProgressConnectionId: () => string;
@@ -182,6 +192,12 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
   const [lastLogByConn, setLastLogByConn] = useState<Record<string, Message | undefined>>({});
   const [lastProgressByNetwork, setLastProgressByNetwork] = useState<Record<string, Message | undefined>>({});
   const [lastProgressByConn, setLastProgressByConn] = useState<Record<string, Message | undefined>>({});
+  // Per-network arrival times. Freshness between the progress and slydata streams is
+  // decided with these, never with the global lastProgressAt/lastSlyDataAt: the globals
+  // are bumped by messages that skip the byNetwork maps (e.g. clearChat's network:""
+  // welcome), which would otherwise flip the preference toward a staler frame.
+  const [lastProgressAtByNetwork, setLastProgressAtByNetwork] = useState<Record<string, number>>({});
+  const [lastSlyDataAtByNetwork, setLastSlyDataAtByNetwork] = useState<Record<string, number>>({});
 
   // Connection-id generator (no crypto)
   const connSeq = useRef(0);
@@ -193,6 +209,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
     setSlyDataMessages(prev => [...prev, { ...msg }]);
     if (msg.network) {
       setLastSlyDataByNetwork(prev => ({ ...prev, [msg.network!]: msg }));
+      setLastSlyDataAtByNetwork(prev => ({ ...prev, [msg.network!]: Date.now() }));
     }
     if (msg.connectionId) {
       setLastSlyDataByConn(prev => ({ ...prev, [msg.connectionId!]: msg }));
@@ -227,6 +244,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
     setProgressMessages(prev => [...prev, { ...msg }]);
     if (msg.network) {
       setLastProgressByNetwork(prev => ({ ...prev, [msg.network!]: msg }));
+      setLastProgressAtByNetwork(prev => ({ ...prev, [msg.network!]: Date.now() }));
     }
     if (msg.connectionId) {
       setLastProgressByConn(prev => ({ ...prev, [msg.connectionId!]: msg }));
@@ -240,7 +258,60 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
     if (opts?.network) return lastProgressByNetwork[opts.network];
     return progressMessages[progressMessages.length - 1]; // global latest
   };
-  
+
+  // The freshest {agent_network_definition, agent_network_name} payload for a network,
+  // taken from whichever stream (progress vs slydata) delivered a frame last. This is
+  // what the editor canvas renders in view mode and what outgoing sly_data derives
+  // from. NOTE: in the manual-editor plugin mode the canvas renders from the andeditor
+  // session instead, and manual edits never reach these streams — this selector cannot
+  // see them. (When editor state moves into a store, reimplement this selector and
+  // getEditorOutgoingSlyData; all consumers follow.)
+  const getLatestNetworkPayload = (network?: string): ProgressPayload | undefined => {
+    const net = network ?? targetNetwork;
+    if (!net) return undefined;
+    const preferProgress =
+      (lastProgressAtByNetwork[net] ?? 0) > (lastSlyDataAtByNetwork[net] ?? 0);
+    return latestNetworkPayload(lastProgressByNetwork[net], lastSlyDataByNetwork[net], preferProgress);
+  };
+
+  // The sly_data blob an editor-mode chat message should carry: the newest parseable
+  // sly_data blob as the base (non-definition keys round-trip unchanged), with the
+  // freshest definition/name pair overlaid atomically — unless the newest sly_data
+  // frame is user-authored (a Sly Data panel edit or a send echo) and no fresher
+  // progress frame exists, in which case the user's blob is authoritative as-is
+  // (deliberate key deletions must not be resurrected from older frames).
+  const getEditorOutgoingSlyData = (network?: string): Record<string, any> => {
+    const net = network ?? targetNetwork;
+    let base: Record<string, any> = {};
+    for (let i = slyDataMessages.length - 1; i >= 0; i--) {
+      const obj = asObjectText(slyDataMessages[i]?.text as any);
+      if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+        base = JSON.parse(JSON.stringify(obj)); // clone: stream state must never be mutated
+        break;
+      }
+    }
+    if (!net) return base;
+    const preferProgress =
+      (lastProgressAtByNetwork[net] ?? 0) > (lastSlyDataAtByNetwork[net] ?? 0);
+    if (lastSlyDataByNetwork[net]?.sender === "user" && !preferProgress) return base;
+    return overlayNetworkPayload(base, getLatestNetworkPayload(net));
+  };
+
+  // Forget every recorded network payload. Without this, clearing a chat session
+  // leaves the byNetwork maps/timestamps populated and the next send resurrects the
+  // abandoned network's definition.
+  const clearNetworkPayloadState = () => {
+    setProgressMessages([]);
+    setLastSlyDataByNetwork({});
+    setLastProgressByNetwork({});
+    setLastSlyDataByConn({});
+    setLastProgressByConn({});
+    setLastProgressAtByNetwork({});
+    setLastSlyDataAtByNetwork({});
+    setLastProgressAt(0);
+    setLastSlyDataAt(0);
+  };
+
 
   return (
     <ChatContext.Provider value={{
@@ -260,6 +331,8 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
       newSlyData, setNewSlyData, newLog, setNewLog, newProgress, setNewProgress,
 
       getLastSlyDataMessage, getLastLogMessage, getLastProgressMessage,
+
+      getLatestNetworkPayload, getEditorOutgoingSlyData, clearNetworkPayloadState,
 
       makeSlyDataConnectionId, makeLogConnectionId, makeProgressConnectionId,
       progressTick, slyDataTick, lastProgressAt, lastSlyDataAt,

--- a/nsflow/frontend/src/context/ChatContext.tsx
+++ b/nsflow/frontend/src/context/ChatContext.tsx
@@ -275,16 +275,22 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
   };
 
   // The sly_data blob an editor-mode chat message should carry: the newest parseable
-  // sly_data blob as the base (non-definition keys round-trip unchanged), with the
-  // freshest definition/name pair overlaid atomically — unless the newest sly_data
-  // frame is user-authored (a Sly Data panel edit or a send echo) and no fresher
-  // progress frame exists, in which case the user's blob is authoritative as-is
-  // (deliberate key deletions must not be resurrected from older frames).
+  // sly_data blob recorded for that network as the base (non-definition keys
+  // round-trip unchanged), with the freshest definition/name pair overlaid
+  // atomically — unless the newest sly_data frame is user-authored (a Sly Data
+  // panel edit or a send echo) and no fresher progress frame exists, in which case
+  // the user's blob is authoritative as-is (deliberate key deletions must not be
+  // resurrected from older frames).
   const getEditorOutgoingSlyData = (network?: string): Record<string, any> => {
     const net = network ?? targetNetwork;
     let base: Record<string, any> = {};
     for (let i = slyDataMessages.length - 1; i >= 0; i--) {
-      const obj = asObjectText(slyDataMessages[i]?.text as any);
+      const msg = slyDataMessages[i];
+      // Scope the base to the target network's own stream: blobs recorded for a
+      // different network must not leak their keys into this send. (Also keeps the
+      // user-authored guard below consistent — it reads the same per-network stream.)
+      if (net && msg?.network !== net) continue;
+      const obj = asObjectText(msg?.text as any);
       if (obj && typeof obj === "object" && !Array.isArray(obj)) {
         base = JSON.parse(JSON.stringify(obj)); // clone: stream state must never be mutated
         break;

--- a/nsflow/frontend/src/hooks/useChatControls.ts
+++ b/nsflow/frontend/src/hooks/useChatControls.ts
@@ -18,17 +18,18 @@ limitations under the License.
 import { useChatContext } from "../context/ChatContext";
 
 export const useChatControls = () => {
-  const { 
-    chatWs, 
-    internalChatWs, 
-    setChatWs, 
-    setInternalChatWs, 
-    setChatMessages, 
+  const {
+    chatWs,
+    internalChatWs,
+    setChatWs,
+    setInternalChatWs,
+    setChatMessages,
     setInternalChatMessages,
     setSlyDataMessages,
     addInternalChatMessage,
     addChatMessage,
-    addSlyDataMessage
+    addSlyDataMessage,
+    clearNetworkPayloadState
   } = useChatContext();
 
   const stopWebSocket = () => {
@@ -49,6 +50,9 @@ export const useChatControls = () => {
     setChatMessages([]);
     setInternalChatMessages([]);
     setSlyDataMessages([]);
+    // Also drop the recorded per-network payloads; otherwise the next editor send
+    // resurrects the definition of the network that was just cleared.
+    clearNetworkPayloadState();
     addChatMessage({ sender: "system", text: "Welcome to the chats", network: "" });
     addInternalChatMessage({ sender: "system", text: "Welcome to internal chat logs.", network: "" });
     addSlyDataMessage({ sender: "system", text: "Welcome to sly_data logs.", network: "" });

--- a/nsflow/frontend/src/utils/progressHelper.ts
+++ b/nsflow/frontend/src/utils/progressHelper.ts
@@ -62,13 +62,13 @@ function normalizePayloadObj(obj: Record<string, any>): ProgressPayload | undefi
 
 /**
  * Pick the freshest network payload between the progress and slydata streams.
- * `preferProgress` should be `lastProgressAt > lastSlyDataAt` from ChatContext;
- * the non-preferred stream is the fallback when the preferred one has no payload.
+ * `preferProgress` decides which stream wins; the other is the fallback when
+ * the preferred one has no payload.
  *
- * This is the single definition of "the network the UI currently shows" — the
- * canvas renders from it and outgoing chat sly_data is built from it, so the
- * designer always receives what the user sees. (When editor state moves into a
- * store, reimplement this as a store selector and both consumers follow.)
+ * Pure combinator — consumers should not call this directly. The seam is
+ * ChatContext.getLatestNetworkPayload / getEditorOutgoingSlyData, which own the
+ * per-network frames and timestamps this needs. (When editor state moves into a
+ * store, those two context functions are the only places to reimplement.)
  */
 export function latestNetworkPayload(
   progressSrc: { text: string | object } | string | object | undefined,
@@ -78,6 +78,35 @@ export function latestNetworkPayload(
   return preferProgress
     ? extractProgressPayload(progressSrc) || extractProgressPayload(slyDataSrc)
     : extractProgressPayload(slyDataSrc) || extractProgressPayload(progressSrc);
+}
+
+/**
+ * Overlay a network payload onto an outgoing sly_data blob, atomically.
+ *
+ * The definition/name pair must always come from the SAME frame: the backend
+ * persists the definition under sly_data's agent_network_name, so pairing a
+ * fresh definition with a stale name can overwrite another network's file.
+ * Hence: no overlay at all unless the payload carries a definition, and when
+ * it does, the name is taken from that payload or removed — an absent name
+ * lets the designer's server-side session supply its own (which tracks the
+ * definition), never a leftover from an older blob.
+ *
+ * Values are deep-copied because payloads from the progress stream are live
+ * references into React state. NOTE: mutates and returns `base` — callers must
+ * pass a private copy, never an object shared with component or context state.
+ */
+export function overlayNetworkPayload(
+  base: Record<string, any>,
+  payload: ProgressPayload | undefined
+): Record<string, any> {
+  if (!payload?.agent_network_definition) return base;
+  base.agent_network_definition = JSON.parse(JSON.stringify(payload.agent_network_definition));
+  if (payload.agent_network_name) {
+    base.agent_network_name = payload.agent_network_name;
+  } else {
+    delete base.agent_network_name;
+  }
+  return base;
 }
 
 /**

--- a/nsflow/frontend/src/utils/progressHelper.ts
+++ b/nsflow/frontend/src/utils/progressHelper.ts
@@ -63,7 +63,12 @@ function normalizePayloadObj(obj: Record<string, any>): ProgressPayload | undefi
 /**
  * Pick the freshest network payload between the progress and slydata streams.
  * `preferProgress` decides which stream wins; the other is the fallback when
- * the preferred one has no payload.
+ * the preferred one has no payload — and payloads carrying an
+ * agent_network_definition outrank definition-less ones (e.g. a name-only
+ * frame), so a trailing frame without a definition cannot mask the other
+ * stream's definition. Consumers align the canvas and outgoing sly_data on
+ * the freshest *definition*; the overlay ignores definition-less payloads
+ * anyway.
  *
  * Pure combinator — consumers should not call this directly. The seam is
  * ChatContext.getLatestNetworkPayload / getEditorOutgoingSlyData, which own the
@@ -75,9 +80,11 @@ export function latestNetworkPayload(
   slyDataSrc: { text: string | object } | string | object | undefined,
   preferProgress: boolean
 ): ProgressPayload | undefined {
-  return preferProgress
-    ? extractProgressPayload(progressSrc) || extractProgressPayload(slyDataSrc)
-    : extractProgressPayload(slyDataSrc) || extractProgressPayload(progressSrc);
+  const preferred = extractProgressPayload(preferProgress ? progressSrc : slyDataSrc);
+  const fallback = extractProgressPayload(preferProgress ? slyDataSrc : progressSrc);
+  if (preferred?.agent_network_definition) return preferred;
+  if (fallback?.agent_network_definition) return fallback;
+  return preferred || fallback;
 }
 
 /**

--- a/nsflow/frontend/src/utils/progressHelper.ts
+++ b/nsflow/frontend/src/utils/progressHelper.ts
@@ -61,6 +61,26 @@ function normalizePayloadObj(obj: Record<string, any>): ProgressPayload | undefi
 }
 
 /**
+ * Pick the freshest network payload between the progress and slydata streams.
+ * `preferProgress` should be `lastProgressAt > lastSlyDataAt` from ChatContext;
+ * the non-preferred stream is the fallback when the preferred one has no payload.
+ *
+ * This is the single definition of "the network the UI currently shows" — the
+ * canvas renders from it and outgoing chat sly_data is built from it, so the
+ * designer always receives what the user sees. (When editor state moves into a
+ * store, reimplement this as a store selector and both consumers follow.)
+ */
+export function latestNetworkPayload(
+  progressSrc: { text: string | object } | string | object | undefined,
+  slyDataSrc: { text: string | object } | string | object | undefined,
+  preferProgress: boolean
+): ProgressPayload | undefined {
+  return preferProgress
+    ? extractProgressPayload(progressSrc) || extractProgressPayload(slyDataSrc)
+    : extractProgressPayload(slyDataSrc) || extractProgressPayload(progressSrc);
+}
+
+/**
  * Extract a { agent_network_definition, agent_network_name } payload from:
  * - a ChatContext Message-like object: { text: string|object }
  * - a raw object


### PR DESCRIPTION
## Description

In editor mode, the chat panel built its outgoing `sly_data` from the latest **slydata** message only, while the canvas rendered from **progress** frames. Once the Agent Network Designer streamed updates, the two diverged: the chat would send a stale `agent_network_definition`, and could splice a fresh definition with a leftover `agent_network_name` from an older blob — the backend persists under that name, so a spliced pair can overwrite a *different* network's HOCON.

This PR makes the payload the chat sends the same payload the canvas renders, selected in one place:

- **`ChatContext`** now owns payload selection: `getLatestNetworkPayload()` (freshest definition/name pair across the progress and slydata streams, arbitrated by per-network timestamps) and `getEditorOutgoingSlyData()` (the exact blob a send will carry). `clearNetworkPayloadState()` resets all of it.
- **`progressHelper`** gains `latestNetworkPayload()` (pure recency combinator) and `overlayNetworkPayload()` (atomic overlay: definition and name always come from the *same* frame; a definition-only frame clears the stale name so the designer session's own name wins server-side).
- **All editor consumers** (`EditorAgentFlow`, `EditorSidebar`, `NetworkAgentEditorPanel`, `EditorSlyDataPanel`, `ChatPanel`) drop their hand-rolled, subtly divergent "latest payload" copies and use the shared selectors — what the SlyData panel shows is exactly what gets sent.
- **`TabbedChatPanel`** closes all four websockets on effect cleanup with a `disposed` guard, so frames from a previous network/session can no longer land in state after a switch (also fixes a pre-existing socket leak on unmount).
- **Clear Chat** now resets payload state, so a cleared editor session sends `{}` again instead of resurrecting the old network.
- If the newest slydata frame is user-authored (manual edit in the SlyData panel) and no newer progress frame exists, it is sent verbatim — user deletions are not resurrected by the overlay.

Fixes #261

## Impact

- Editor mode only; regular chat mode send paths are untouched.
- Deliberately stays out of the manual-editor state layer (`SimpleStateManager` / `andeditor` endpoints). Consumers reach payload state only through the two `ChatContext` selectors, so the planned Zustand store refactor can re-implement that seam in one place and everything downstream keeps working.
- Trade-off: the SlyData panel now refreshes on progress frames during active generation, so an *uncommitted* inline edit in its JSON editor can be replaced by a newer frame mid-stream. Committed edits become authoritative immediately. This is the cost of the panel never showing something different from what a send would carry.

## Screenshots / Logs / Examples (optional)

Repro for the original bug: in the editor tab, ask AND to create a network, then ask it to modify the network, then send another chat message. Before this PR the outgoing `sly_data` (visible in the browser devtools websocket frames) carries the pre-modification definition; after this PR it carries what the canvas shows.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tested locally (`tsc -b`, `npm run build`, manual editor flows: create → modify → send, clear chat, network switch, load existing)
- [ ] Added/updated tests (frontend has no test runner configured in this repo)
- [ ] Updated relevant documentation (inline JSDoc on the new selectors documents the contract)
- [ ] Added dependencies (none)
