### PR TITLE
Pin CodeQL workflow actions to exact SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,8 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      # v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -65,7 +66,8 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      # v4.37.6
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -93,6 +95,7 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      # v4.37.6
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Description

`.github/workflows/codeql.yml` was the last workflow in this repo still using floating tags (`actions/checkout@v4`, `github/codeql-action/{init,analyze}@v3`) while the other workflows pin third-party actions to an exact commit SHA. Mutable tags mean a retagged or compromised release gets picked up silently.

Pins to the SHAs already used elsewhere in the org, each with a version comment:

- `actions/checkout@de0fac2e...` (v6.0.2) - same SHA as `publish.yml` here and build-common's reusable workflows
- `github/codeql-action/init@5595ccaf...` and `analyze@5595ccaf...` (v4.37.6, published 2026-08-04)

Follow-up to cognizant-ai-lab/leaf-common#176, which surfaced this pattern while restoring that repo's deleted CodeQL workflow.

## Impact

CodeQL scanning runs against fixed action versions. This also moves codeql-action from the v3 to the v4 major; no other lines change. The pre-existing zizmor `artipacked` finding on the checkout step (no `persist-credentials: false`) is left as-is to keep this diff to the pinning change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally (YAML parse + `zizmor` on the changed workflow; the workflow itself only runs on GitHub)
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt`

Link to Devin session: https://app.devin.ai/sessions/9635ad6164be41efa8a172dd1b9c80d1
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/nsflow/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->