### PR TITLE
Run unit tests on Python 3.12, 3.13 and 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,13 @@ permissions:
 jobs:
   test:
     if: github.repository == 'cognizant-ai-lab/nsflow'
-    # 1.0.11
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
+    # 1.0.12
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3f4cdab31b6ac10382c99452b720eb0b8b2dab8f
     with:
-      # 1.0.11
-      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
+      # 1.0.12
+      build-common-ref: '3f4cdab31b6ac10382c99452b720eb0b8b2dab8f'
       python-version: '3.12'
+      test-python-versions: '["3.12", "3.13", "3.14"]'
       lint-command-override: |
         set -e
         VIRTUAL_ENV=system make lint-check


### PR DESCRIPTION
## Description

Bumps the quality gate (and its `build-common-ref`) to build-common 1.0.12 and sets the new `test-python-versions` input (cognizant-ai-lab/build-common#36), so `make test` runs once per interpreter in `Unit tests (3.12|3.13|3.14)` jobs while `make lint-check` and the README check stay on 3.12 in `quality-gate`. Same change as leaf-common#191 and neuro-san-studio#1388.

## Impact

Python unit tests now run on 3.12, 3.13 and 3.14; a single Slack notification reports the combined result. The `frontend` job is unchanged.

## Type of Change

- [x] Refactoring / Improvement

## Checklist

- [x] Tested locally (`actionlint` clean)
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---


Link to Devin session: https://app.devin.ai/sessions/25fc14ae7bdc496f98837871f43ed0ea
Open in Devin Desktop: https://app.devin.ai/desktop/session/25fc14ae7bdc496f98837871f43ed0ea?variant=devin
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/nsflow/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->