### PR TITLE
Add toolbox and designer reference endpoints

### DIFF
--- a/nsflow/backend/api/router.py
+++ b/nsflow/backend/api/router.py
@@ -21,6 +21,7 @@ from .v1 import agent_flows
 from .v1 import app_configs
 from .v1 import audio_endpoints
 from .v1 import cruse_endpoints
+from .v1 import designer_endpoints
 from .v1 import editor_endpoints
 from .v1 import export_endpoints
 from .v1 import fast_websocket
@@ -28,6 +29,7 @@ from .v1 import fastapi_concierge_endpoints
 from .v1 import mcp_oauth_endpoints
 from .v1 import oneshot_endpoints
 from .v1 import pdf_endpoints
+from .v1 import toolbox_endpoints
 from .v1 import vqa_endpoints
 
 NSFLOW_PLUGIN_VQA_ENDPOINT = os.getenv("NSFLOW_PLUGIN_VQA_ENDPOINT", None)
@@ -44,6 +46,8 @@ router.include_router(editor_endpoints.router, tags=["Agent Network Designer"])
 router.include_router(cruse_endpoints.router, prefix="/api/v1", tags=["CRUSE Threads"])
 router.include_router(oneshot_endpoints.router, tags=["One-Shot Chat"])
 router.include_router(pdf_endpoints.router, tags=["PDF Processing"])
+router.include_router(toolbox_endpoints.router, tags=["Toolbox"])
+router.include_router(designer_endpoints.router, tags=["Designer"])
 router.include_router(mcp_oauth_endpoints.router, tags=["MCP OAuth"])
 if NSFLOW_PLUGIN_VQA_ENDPOINT:
     router.include_router(vqa_endpoints.router, tags=["Visual Question Answering"])

--- a/nsflow/backend/api/v1/designer_endpoints.py
+++ b/nsflow/backend/api/v1/designer_endpoints.py
@@ -1,0 +1,149 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Lists what the agent network designer will accept as an external reference.
+
+This is deliberately NOT the same as what the server serves. The designer validates
+references against a curated subset, and a network the server hosts but the designer
+does not know is rejected with
+
+    Agent 'frontman' references an unrecognized URL or path tool '/basic/coffee_finder'
+
+which is not a plain error: the designer responds by invoking its LLM to repair the
+network, restructuring what the user drew and taking half a minute per edit. Offering
+the editor's palette anything outside this set therefore poisons every subsequent edit
+until the reference is removed, so the palette has to be fed from the same two sources
+the designer itself reads:
+
+* ``AGENT_NETWORK_DESIGNER_MANIFEST_FILE`` for other agent networks. Distinct from
+  ``AGENT_MANIFEST_FILE`` on purpose, so the designer's pool can be narrower than what
+  the server hosts.
+* ``MCP_SERVERS_INFO_FILE`` for MCP servers. Also distinct from the OAuth connection
+  store: a server can be connected without being offered to the designer, and vice
+  versa.
+
+Both are read through neuro-san's own restorers and manifest filters rather than by
+re-reading the files here, so manifest semantics (``include`` composition, quoted
+keys, the ``serve`` flag) cannot drift from the server's.
+"""
+
+import logging
+import os
+from typing import Any
+from typing import Dict
+from typing import List
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from leaf_common.config.config_filter_chain import ConfigFilterChain
+from neuro_san.internals.graph.persistence.manifest_dict_config_filter import ManifestDictConfigFilter
+from neuro_san.internals.graph.persistence.manifest_key_config_filter import ManifestKeyConfigFilter
+from neuro_san.internals.graph.persistence.raw_manifest_restorer import RawManifestRestorer
+from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
+from neuro_san.internals.graph.persistence.served_manifest_config_filter import ServedManifestConfigFilter
+from neuro_san.internals.run_context.langchain.mcp.mcp_servers_info_restorer import McpServersInfoRestorer
+
+router = APIRouter(prefix="/api/v1/designer")
+
+DESIGNER_MANIFEST_ENV_VAR = "AGENT_NETWORK_DESIGNER_MANIFEST_FILE"
+MCP_SERVERS_ENV_VAR = "MCP_SERVERS_INFO_FILE"
+
+# What neuro-san-studio ships as the designer's manifest when the env var is unset.
+# Only resolves for an in-repo run, which is why studio exports the resolved path.
+DEFAULT_DESIGNER_MANIFEST = os.path.join("registries", "manifest_and.hocon")
+
+
+def _designer_manifest_file() -> str:
+    """
+    :return: The manifest naming the networks the designer may reference.
+    """
+    return os.getenv(DESIGNER_MANIFEST_ENV_VAR) or DEFAULT_DESIGNER_MANIFEST
+
+
+def _referenceable_networks() -> List[str]:
+    """
+    Read the external network names the designer accepts, as "/<name>".
+
+    Mirrors the designer's own ``GetSubnetwork``: neuro-san's manifest filters strip
+    quoted keys, normalise bool entries, and drop anything not served, then its
+    registry restorer derives the external names.
+
+    :return: The names, or an empty list when the manifest is missing or unparseable.
+    """
+    manifest_file = _designer_manifest_file()
+
+    try:
+        # Missing file comes back as None rather than raising.
+        raw_manifest: Dict[str, Any] = RawManifestRestorer().restore(file_reference=manifest_file)
+        if raw_manifest is None:
+            logging.warning("Designer manifest %s not found; no networks can be referenced", manifest_file)
+            return []
+
+        # Assembled rather than using ManifestFilterChain, which keeps unserved
+        # entries and warns per entry. Here they should be dropped silently.
+        filter_chain = ConfigFilterChain()
+        filter_chain.register(ManifestKeyConfigFilter(manifest_file))
+        filter_chain.register(ManifestDictConfigFilter(manifest_file))
+        filter_chain.register(ServedManifestConfigFilter(manifest_file, warn_on_skip=False, entry_for_skipped=False))
+        one_manifest: Dict[str, Any] = filter_chain.filter_config(raw_manifest)
+
+        restorer = RegistryManifestRestorer(manifest_files=manifest_file)
+        return list(restorer.find_external_network_names(one_manifest))
+    except Exception as exc:  # pylint: disable=broad-except
+        # neuro-san re-wraps HOCON parse errors as ValueError. Whatever the cause, an
+        # unreadable manifest means "nothing to offer", not a failed request: the
+        # toolbox and MCP halves of the palette are still usable.
+        logging.warning("Could not read designer manifest %s: %s", manifest_file, exc)
+        return []
+
+
+def _referenceable_mcp_servers() -> List[str]:
+    """
+    Read the MCP server URLs the designer accepts.
+
+    :return: The URLs, or an empty list when no info file is configured or readable.
+    """
+    mcp_info_file = os.getenv(MCP_SERVERS_ENV_VAR)
+    if not mcp_info_file:
+        # No fallback path is guessed here: unlike the designer, nsflow does not know
+        # where a given project keeps its bundled copy.
+        return []
+
+    try:
+        info: Dict[str, Any] = McpServersInfoRestorer().restore(file_reference=mcp_info_file)
+        return list(info.keys()) if info else []
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.warning("Could not read %s=%s: %s", MCP_SERVERS_ENV_VAR, mcp_info_file, exc)
+        return []
+
+
+@router.get(
+    "/references",
+    summary="List what the agent network designer accepts as an external reference.",
+    responses={200: {"description": "The networks and MCP servers the designer recognises"}},
+)
+async def list_references() -> JSONResponse:
+    """
+    List the external references the editor palette may offer.
+
+    :return: ``{"networks": ["/industry/foo", ...], "mcp_servers": ["https://...", ...]}``
+    """
+    return JSONResponse(
+        content={
+            "networks": _referenceable_networks(),
+            "mcp_servers": _referenceable_mcp_servers(),
+        }
+    )

--- a/nsflow/backend/api/v1/toolbox_endpoints.py
+++ b/nsflow/backend/api/v1/toolbox_endpoints.py
@@ -1,0 +1,175 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Lists the tools available to drag onto the editor canvas.
+
+There are two different toolboxes in play, and the editor wants the narrower one:
+
+* ``AGENT_TOOLBOX_INFO_FILE`` is the *runtime* toolbox, overlaid on neuro-san's
+  built-in set. It is what a running network resolves tool names against.
+* ``AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE`` is a curated subset naming the tools
+  the agent network designer may pick from when it authors a network.
+
+Since every editor change is canonicalised by the designer, the palette offers the
+designer's subset when that is configured, and falls back to the runtime toolbox
+otherwise. This resolution deliberately mirrors the designer's own
+``GetToolbox`` coded tool so the palette and the designer agree on what exists.
+
+nsflow does not apply the designer file's directory-relative default the way
+neuro-san-studio does; that default only resolves for an in-repo studio run, and
+studio exports the resolved path into the env var, which is what is read here.
+
+Both loads come from neuro-san rather than from a list nsflow maintains, so a tool
+added to either file shows up without an nsflow change.
+"""
+
+import logging
+import os
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from fastapi import APIRouter
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from neuro_san.internals.run_context.factory.master_toolbox_factory import MasterToolboxFactory
+from neuro_san.internals.run_context.langchain.toolbox.toolbox_info_restorer import ToolboxInfoRestorer
+
+router = APIRouter(prefix="/api/v1")
+
+DESIGNER_TOOLBOX_ENV_VAR = "AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE"
+
+# Resolving and parsing HOCON is done once per process rather than per request; a
+# toolbox only changes when the server is reconfigured and restarted. Two slots:
+# "designer" holds the curated tools once that load succeeds, and "factory" holds the
+# runtime toolbox factory, whose own load() is a no-op after the first call.
+#
+# Only a successful designer load is final. Falling back is deliberately not cached,
+# so a designer file that is missing when the first palette opens is picked up on a
+# later request rather than pinning the wrong toolbox for the life of the process.
+_TOOLBOX_CACHE: Dict[str, Any] = {}
+
+
+def _load_designer_toolbox() -> Optional[Dict[str, Any]]:
+    """
+    Load the curated toolbox the agent network designer picks from.
+
+    :return: The tool infos, or None when the env var is unset or the file is
+             missing, empty, or unreadable, in which case the caller falls back to
+             the runtime toolbox.
+    """
+    path: str = os.getenv(DESIGNER_TOOLBOX_ENV_VAR)
+    if not path:
+        return None
+
+    try:
+        infos: Dict[str, Any] = ToolboxInfoRestorer().restore(path)
+    except Exception as exc:  # pylint: disable=broad-except
+        # Not fatal: the runtime toolbox is still a usable palette.
+        logging.warning("Could not read %s=%s: %s", DESIGNER_TOOLBOX_ENV_VAR, path, exc)
+        return None
+
+    if not infos:
+        logging.warning("%s=%s yielded no tools", DESIGNER_TOOLBOX_ENV_VAR, path)
+        return None
+    return infos
+
+
+def _load_runtime_toolbox() -> Dict[str, Any]:
+    """
+    Load the runtime toolbox: neuro-san's built-in set overlaid with
+    ``AGENT_TOOLBOX_INFO_FILE``.
+
+    The factory is asked for the merged view rather than the override file being read
+    directly, since reading the file alone would miss the built-in tools.
+
+    :return: The merged tool infos, keyed by tool name.
+    """
+    factory = _TOOLBOX_CACHE.get("factory")
+    if factory is None:
+        factory = MasterToolboxFactory.create_toolbox_factory({})
+        _TOOLBOX_CACHE["factory"] = factory
+    # Reusing the instance is what keeps this cheap: load() only does work on its
+    # first call, so the HOCON is parsed once per process.
+    factory.load()
+    # toolbox_infos is a public attribute on ToolboxFactory rather than part of the
+    # ContextTypeToolboxFactory interface, so it is semi-internal. It is still a far
+    # better source than a hand-maintained list, which would drift the moment
+    # neuro-san or a project ships a new tool.
+    return getattr(factory, "toolbox_infos", {}) or {}
+
+
+def _load_toolbox() -> Tuple[str, Dict[str, Any]]:
+    """
+    Return the toolbox the palette should offer, loading it on first use.
+
+    :return: A (source, tool infos) pair, where source names which toolbox won.
+    """
+    cached: Optional[Dict[str, Any]] = _TOOLBOX_CACHE.get("designer")
+    if cached:
+        return "agent_network_designer", cached
+
+    designer_infos: Optional[Dict[str, Any]] = _load_designer_toolbox()
+    if designer_infos:
+        _TOOLBOX_CACHE["designer"] = designer_infos
+        return "agent_network_designer", designer_infos
+
+    return "runtime", _load_runtime_toolbox()
+
+
+@router.get(
+    "/toolbox",
+    summary="List the tools available from neuro-san's toolbox.",
+    responses={
+        200: {"description": "The tools the configured toolbox offers"},
+        500: {"description": "The toolbox could not be loaded"},
+    },
+)
+async def list_toolbox() -> JSONResponse:
+    """
+    List the toolbox tools, for the editor palette.
+
+    Each entry carries the tool's name, its human-readable description, and whether
+    it is a coded tool or a langchain tool, which is what the palette needs to group
+    and label them.
+
+    :return: ``{"source", "tools": [{"name", "description", "class", "display_as"}]}``
+    """
+    try:
+        source, infos = _load_toolbox()
+    except Exception as exc:
+        logging.exception("Failed to load the neuro-san toolbox: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to load the neuro-san toolbox") from exc
+
+    tools: List[Dict[str, Any]] = []
+    for name, info in sorted(infos.items()):
+        entry: Dict[str, Any] = info if isinstance(info, dict) else {}
+        # A tool backed by a python class is a coded_tool; one backed by a langchain
+        # toolkit is not. display_as matches the vocabulary connectivity already uses,
+        # so a dragged tool renders like the same tool does on a generated network.
+        has_class = bool(entry.get("class"))
+        tools.append(
+            {
+                "name": name,
+                "description": entry.get("description", ""),
+                "class": entry.get("class"),
+                "display_as": "coded_tool" if has_class else "langchain_tool",
+            }
+        )
+
+    return JSONResponse(content={"source": source, "tools": tools})

--- a/tests/nsflow/test_designer_endpoints.py
+++ b/tests/nsflow/test_designer_endpoints.py
@@ -1,0 +1,112 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for GET /api/v1/designer/references, which feeds the editor palette.
+
+What matters is that the set is the DESIGNER's, not the server's. Offering a network
+the designer does not recognise makes it reject the reference and rewrite the network
+with its LLM, so every later edit breaks until that reference is removed.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nsflow.backend.api.v1 import designer_endpoints
+
+# Two entries served and one not, so the `serve` flag is exercised.
+DESIGNER_MANIFEST = """
+{
+    "industry/banking_ops.hocon": true,
+    "generated/coffee_shop.hocon": true,
+    "basic/coffee_finder.hocon": false,
+}
+"""
+
+MCP_INFO = """
+{
+    "https://mcp.example.com/mcp": {
+        "url": "https://mcp.example.com/mcp",
+    },
+}
+"""
+
+
+@pytest.fixture(name="client")
+def client_fixture() -> TestClient:
+    """An app serving only the designer router, so nothing else can interfere."""
+    app = FastAPI()
+    app.include_router(designer_endpoints.router)
+    return TestClient(app)
+
+
+def test_offers_only_the_networks_the_designer_manifest_serves(client, tmp_path, monkeypatch):
+    """
+    The designer manifest is a curated subset, and an unserved entry is not part of
+    it. Both distinctions decide whether an edit stays deterministic.
+    """
+    manifest = tmp_path / "manifest_and.hocon"
+    manifest.write_text(DESIGNER_MANIFEST, encoding="utf-8")
+    monkeypatch.setenv(designer_endpoints.DESIGNER_MANIFEST_ENV_VAR, str(manifest))
+    monkeypatch.delenv(designer_endpoints.MCP_SERVERS_ENV_VAR, raising=False)
+
+    body = client.get("/api/v1/designer/references").json()
+
+    assert sorted(body["networks"]) == ["/generated/coffee_shop", "/industry/banking_ops"]
+
+
+def test_reports_the_mcp_servers_the_designer_was_given(client, tmp_path, monkeypatch):
+    """The designer reads its servers from a file, not from the OAuth connection store."""
+    mcp_info = tmp_path / "mcp_info.hocon"
+    mcp_info.write_text(MCP_INFO, encoding="utf-8")
+    monkeypatch.setenv(designer_endpoints.MCP_SERVERS_ENV_VAR, str(mcp_info))
+    monkeypatch.delenv(designer_endpoints.DESIGNER_MANIFEST_ENV_VAR, raising=False)
+
+    body = client.get("/api/v1/designer/references").json()
+
+    assert body["mcp_servers"] == ["https://mcp.example.com/mcp"]
+
+
+@pytest.mark.parametrize("missing", ["manifest", "mcp"])
+def test_an_unreadable_source_empties_only_its_own_half(client, tmp_path, monkeypatch, missing):
+    """
+    Half the palette is better than none, and better than a 500: the toolbox section
+    is served by a different route and stays usable either way.
+    """
+    manifest = tmp_path / "manifest_and.hocon"
+    manifest.write_text(DESIGNER_MANIFEST, encoding="utf-8")
+    mcp_info = tmp_path / "mcp_info.hocon"
+    mcp_info.write_text(MCP_INFO, encoding="utf-8")
+
+    monkeypatch.setenv(
+        designer_endpoints.DESIGNER_MANIFEST_ENV_VAR,
+        "/nonexistent/manifest.hocon" if missing == "manifest" else str(manifest),
+    )
+    monkeypatch.setenv(
+        designer_endpoints.MCP_SERVERS_ENV_VAR,
+        "/nonexistent/mcp_info.hocon" if missing == "mcp" else str(mcp_info),
+    )
+
+    response = client.get("/api/v1/designer/references")
+
+    assert response.status_code == 200
+    body = response.json()
+    if missing == "manifest":
+        assert body["networks"] == []
+        assert body["mcp_servers"] != []
+    else:
+        assert body["networks"] != []
+        assert body["mcp_servers"] == []

--- a/tests/nsflow/test_toolbox_endpoints.py
+++ b/tests/nsflow/test_toolbox_endpoints.py
@@ -1,0 +1,133 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for GET /api/v1/toolbox, which feeds the editor palette.
+
+What matters is the choice between the two toolboxes: the designer's curated subset
+when AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE points somewhere usable, and the
+runtime toolbox otherwise. Offering tools the designer will not accept is invisible
+from the tool list alone, which is why the response reports its ``source``.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nsflow.backend.api.v1 import toolbox_endpoints
+
+DESIGNER_ENV_VAR = toolbox_endpoints.DESIGNER_TOOLBOX_ENV_VAR
+
+# A stand-in for the designer's toolbox info file: one entry with a class and one
+# without, so the coded_tool/langchain_tool split is exercised.
+DESIGNER_TOOLBOX = """
+{
+    "drag_me": {
+        "class": "some_module.DragMe",
+        "description": "A coded tool the designer may pick.",
+    },
+    "a_toolkit": {
+        "description": "A toolkit with no class of its own.",
+    },
+}
+"""
+
+
+@pytest.fixture(name="client")
+def client_fixture() -> TestClient:
+    """An app serving only the toolbox router, so nothing else can interfere."""
+    app = FastAPI()
+    app.include_router(toolbox_endpoints.router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_toolbox_cache():
+    """The route caches its load process-wide, so each test starts and ends clean."""
+    toolbox_endpoints._TOOLBOX_CACHE.clear()  # pylint: disable=protected-access
+    yield
+    toolbox_endpoints._TOOLBOX_CACHE.clear()  # pylint: disable=protected-access
+
+
+@pytest.fixture(name="designer_toolbox_file")
+def designer_toolbox_file_fixture(tmp_path) -> str:
+    """Write the stand-in designer toolbox to a temp file and return its path."""
+    path = tmp_path / "agent_network_designer_toolbox_info.hocon"
+    path.write_text(DESIGNER_TOOLBOX, encoding="utf-8")
+    return str(path)
+
+
+def test_serves_the_designer_toolbox_when_configured(client, designer_toolbox_file, monkeypatch):
+    """
+    The designer's curated subset wins, since the designer canonicalises every edit
+    and only knows the tools in this file. Each entry carries what the palette needs
+    to label and group it.
+    """
+    monkeypatch.setenv(DESIGNER_ENV_VAR, designer_toolbox_file)
+
+    body = client.get("/api/v1/toolbox").json()
+
+    assert body["source"] == "agent_network_designer"
+    assert body["tools"] == [
+        {
+            "name": "a_toolkit",
+            "description": "A toolkit with no class of its own.",
+            "class": None,
+            "display_as": "langchain_tool",
+        },
+        {
+            "name": "drag_me",
+            "description": "A coded tool the designer may pick.",
+            "class": "some_module.DragMe",
+            "display_as": "coded_tool",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "designer_path",
+    [
+        pytest.param(None, id="unset"),
+        pytest.param("/nonexistent/toolbox.hocon", id="missing file"),
+    ],
+)
+def test_falls_back_to_the_runtime_toolbox(client, monkeypatch, designer_path):
+    """
+    With no usable designer toolbox, the runtime toolbox is a better answer than an
+    empty palette, and a stale path should not take the palette down.
+    """
+    if designer_path is None:
+        monkeypatch.delenv(DESIGNER_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(DESIGNER_ENV_VAR, designer_path)
+
+    body = client.get("/api/v1/toolbox").json()
+
+    # Only the choice of source is asserted. Which tools neuro-san ships in its
+    # built-in toolbox is neuro-san's business and changes between releases, so
+    # naming one here would make this test fail for a reason it does not care about.
+    assert body["source"] == "runtime"
+
+
+def test_a_failed_load_is_not_cached_so_a_later_request_heals(client, designer_toolbox_file, monkeypatch):
+    """
+    The cache avoids re-parsing HOCON per request, but caching a failure would pin
+    the wrong toolbox until the server restarted.
+    """
+    monkeypatch.setenv(DESIGNER_ENV_VAR, "/nonexistent/toolbox.hocon")
+    assert client.get("/api/v1/toolbox").json()["source"] == "runtime"
+
+    monkeypatch.setenv(DESIGNER_ENV_VAR, designer_toolbox_file)
+    assert client.get("/api/v1/toolbox").json()["source"] == "agent_network_designer"


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Two read-only endpoints so the client can offer exactly what the agent network designer will accept.

`GET /api/v1/toolbox` returns the toolbox tools. It prefers the designer's curated set from `AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE` via neuro-san's `ToolboxInfoRestorer`, and falls back to the runtime toolbox when that file is absent. Only a successful designer load is cached, so a missing or late-mounted file heals on the next request instead of pinning the fallback for the process lifetime.

`GET /api/v1/designer/references` returns the other agent networks and MCP servers that can be referenced, read from `AGENT_NETWORK_DESIGNER_MANIFEST_FILE` and `MCP_SERVERS_INFO_FILE`.

Both read the same environment variables studio already sets, rather than nsflow keeping its own copy of the list.

## Impact

Motivation: the client had no way to know which references the designer accepts, so it could offer a network the designer then rejects. A rejected reference does not fail in isolation, it poisons every later edit of that network. These endpoints make the offered set and the accepted set the same set.

Additive and read-only. No existing endpoint changes. If either source file is missing, that half returns empty and the other half still works, which the tests assert directly.

## Screenshots / Logs / Examples (optional)

```
tests/nsflow/test_toolbox_endpoints.py ....                              [4 passed]
tests/nsflow/test_designer_endpoints.py ....                             [4 passed]
```

Verified against a live studio instance: `designer/references` returned exactly the 21 networks and 3 MCP servers the designer's own validation error listed, and correctly excluded the one network it rejects.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

8 new tests. Full Python suite: 194 passing. `make lint-check-source` and `lint-check-tests` both 10.00/10. No new dependencies: both endpoints use restorers neuro-san already provides.

---