### PR TITLE
Add a neuro-san-shaped agent facade

### DIFF
--- a/nsflow/backend/api/router.py
+++ b/nsflow/backend/api/router.py
@@ -31,6 +31,7 @@ from .v1 import oneshot_endpoints
 from .v1 import pdf_endpoints
 from .v1 import toolbox_endpoints
 from .v1 import vqa_endpoints
+from .v1.neuro_san import agent as neuro_san_agent
 
 NSFLOW_PLUGIN_VQA_ENDPOINT = os.getenv("NSFLOW_PLUGIN_VQA_ENDPOINT", None)
 
@@ -51,3 +52,12 @@ router.include_router(designer_endpoints.router, tags=["Designer"])
 router.include_router(mcp_oauth_endpoints.router, tags=["MCP OAuth"])
 if NSFLOW_PLUGIN_VQA_ENDPOINT:
     router.include_router(vqa_endpoints.router, tags=["Visual Question Answering"])
+
+# KEEP LAST. The neuro-san-shaped facade routes on "/api/v1/{agent_name:path}/..."
+# put a greedy path parameter where nsflow's own routes have a literal first
+# segment (e.g. "/api/v1/connectivity/{network_name}"). Starlette matches in
+# registration order, so registering this after everything else is what keeps
+# every existing endpoint winning for its own consumers. Adding a router below
+# this line, or moving this line up, will silently shadow existing endpoints.
+# tests/nsflow/test_neuro_san_facade.py asserts this ordering.
+router.include_router(neuro_san_agent.router, tags=["neuro-san API"])

--- a/nsflow/backend/api/v1/neuro_san/agent.py
+++ b/nsflow/backend/api/v1/neuro_san/agent.py
@@ -1,0 +1,180 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+neuro-san-shaped routes for per-agent operations (neuro-san's AgentService).
+
+These mirror neuro-san's own HTTP contract so the frontend speaks one vocabulary
+whether it is pointed at nsflow or at a neuro-san server, without a neuro-san API
+layer living in the browser.
+
+They are deliberately thin passthroughs. neuro-san's payloads are returned as-is,
+with no Pydantic models mirroring its schemas: those schemas are generated on
+neuro-san's side, so hand-copying them here would only create drift, and the
+frontend already gets real types from ui-common's generated client. Passing the
+payload straight through also means a field added by a future neuro-san release
+reaches the client instead of being silently dropped.
+
+TWO THINGS TO KNOW BEFORE EDITING THIS FILE
+-------------------------------------------
+1. ``{agent_name:path}`` is GREEDY on purpose. Generated networks are named
+   "<subdir>/<name>" (e.g. "generated/coffee_shop"), so a single-segment converter
+   would 404 every generated network.
+
+2. This router MUST be registered last (see ``nsflow/backend/api/router.py``).
+   ``/api/v1/{agent_name:path}/connectivity`` occupies the same position as
+   existing routes whose first segment is a literal, such as
+   ``/api/v1/connectivity/{network_name}``. First-registered wins in Starlette, so
+   registering last is what keeps every existing consumer working.
+   ``tests/nsflow/test_neuro_san_facade.py`` asserts both properties.
+"""
+
+import json
+import logging
+from typing import Any
+from typing import AsyncIterator
+from typing import Dict
+
+from fastapi import APIRouter
+from fastapi import HTTPException
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from fastapi.responses import StreamingResponse
+
+from nsflow.backend.utils.agentutils.ns_agent_client import NsAgentClient
+
+router = APIRouter(prefix="/api/v1")
+
+
+async def _ndjson_lines(client: NsAgentClient, chat_request: Dict[str, Any]) -> AsyncIterator[bytes]:
+    """
+    Serialise each neuro-san chat response as its own newline-terminated line.
+
+    Errors are logged and end the stream rather than raising: response headers have
+    already been sent by the time the first chunk is produced, so there is no status
+    code left to change. A client disconnect cancels this generator, which stops the
+    iteration at its next await.
+
+    :param client: The client for the agent network being streamed.
+    :param chat_request: The neuro-san ChatRequest to send.
+    :return: An async iterator of newline-delimited JSON lines.
+    """
+    try:
+        async for chunk in client.streaming_chat(chat_request):
+            yield (json.dumps(chunk) + "\n").encode("utf-8")
+    except Exception as exc:  # pylint: disable=broad-except  # must not escape mid-stream
+        logging.exception("streaming_chat failed for %s: %s", client.agent_name, exc)
+
+
+@router.get(
+    "/{agent_name:path}/connectivity",
+    summary="Get an agent network's connectivity, in neuro-san's own shape.",
+    responses={
+        200: {"description": "neuro-san's ConnectivityResponse verbatim: {'connectivity_info': [...]}"},
+        502: {"description": "The neuro-san server could not be reached or failed"},
+    },
+)
+async def get_connectivity(agent_name: str) -> JSONResponse:
+    """
+    Mirror of neuro-san's ``AgentService_Connectivity``.
+
+    Returns the raw ``connectivity_info`` list. For React Flow nodes and edges, use
+    nsflow's own ``/api/v1/connectivity/{network_name}`` instead.
+
+    :param agent_name: The agent network. May contain slashes.
+    :return: neuro-san's connectivity payload, unmodified.
+    """
+    try:
+        result: Dict[str, Any] = NsAgentClient(agent_name).connectivity()
+    except Exception as exc:
+        logging.exception("Failed to get connectivity for %s: %s", agent_name, exc)
+        raise HTTPException(status_code=502, detail=f"Failed to get connectivity for '{agent_name}'") from exc
+
+    return JSONResponse(content=result)
+
+
+@router.get(
+    "/{agent_name:path}/function",
+    summary="Get an agent network's function description, in neuro-san's own shape.",
+    responses={
+        200: {"description": "neuro-san's FunctionResponse verbatim: {'function': {...}}"},
+        502: {"description": "The neuro-san server could not be reached or failed"},
+    },
+)
+async def get_function(agent_name: str) -> JSONResponse:
+    """
+    Mirror of neuro-san's ``AgentService_Function``.
+
+    :param agent_name: The agent network. May contain slashes.
+    :return: neuro-san's function payload, unmodified.
+    """
+    try:
+        result: Dict[str, Any] = NsAgentClient(agent_name).function()
+    except Exception as exc:
+        logging.exception("Failed to get function for %s: %s", agent_name, exc)
+        raise HTTPException(status_code=502, detail=f"Failed to get function for '{agent_name}'") from exc
+
+    return JSONResponse(content=result)
+
+
+@router.post(
+    "/{agent_name:path}/streaming_chat",
+    summary="Stream a chat turn with an agent network, in neuro-san's own shape.",
+    responses={
+        200: {
+            "description": (
+                "Newline-delimited JSON. Each line is one neuro-san chat response, "
+                "shaped {'response': {...}}, emitted as it arrives."
+            )
+        },
+        422: {"description": "The request body was not valid JSON"},
+        502: {"description": "The neuro-san server could not be reached or failed"},
+    },
+)
+async def streaming_chat(agent_name: str, request: Request) -> StreamingResponse:
+    """
+    Mirror of neuro-san's ``AgentService_StreamingChat``.
+
+    The body is a neuro-san ChatRequest and is forwarded as-is, except that
+    ``sly_data`` goes through the same redaction-sentinel merge and MCP token
+    injection the WebSocket chat path applies, so this route cannot be used to get
+    around them.
+
+    Responses stream out as newline-delimited JSON, one neuro-san chat response per
+    line, which is what ui-common's chunk parser expects.
+
+    nsflow's WebSocket endpoints remain the richer path: they also multiplex
+    progress, logs and sly_data onto separate sockets. This route exists so the HTTP
+    surface matches neuro-san's contract.
+
+    :param agent_name: The agent network. May contain slashes.
+    :param request: The incoming request, whose JSON body is the ChatRequest.
+    :return: A newline-delimited JSON stream of neuro-san chat responses.
+    """
+    try:
+        chat_request: Dict[str, Any] = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail="Request body must be valid JSON") from exc
+
+    if not isinstance(chat_request, dict):
+        raise HTTPException(status_code=422, detail="Request body must be a JSON object")
+
+    # Mirrors what a neuro-san server sends for this operation. It carries no
+    # meaning for nsflow itself (our own consumer reads the body as text and splits
+    # lines), but a client written against neuro-san should not be able to tell the
+    # difference. Not asserted in tests: it is neuro-san's value, not ours to pin.
+    return StreamingResponse(
+        _ndjson_lines(NsAgentClient(agent_name), chat_request), media_type="application/json-lines"
+    )

--- a/nsflow/backend/utils/agentutils/ns_agent_client.py
+++ b/nsflow/backend/utils/agentutils/ns_agent_client.py
@@ -1,0 +1,119 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Typed client for neuro-san's per-agent operations.
+
+This is the backend counterpart to ui-common's ``controller/agent/Agent.ts``: the
+one place that knows how to talk to a neuro-san agent, so the routes in
+``nsflow/backend/api/v1/neuro_san/`` stay thin.
+
+It delegates session construction to :class:`NsWebsocketUtils`, which already owns
+reading the active :class:`NsConfig` and building an ``AgentSession`` via
+``AgentSessionFactory``. Reusing it keeps one implementation of that logic rather
+than a second copy that could drift on host/port/connection handling. The
+websocket argument is ``None`` because these are plain request/response calls; the
+existing ``/api/v1/connectivity/{network_name}`` endpoint already uses it this way.
+"""
+
+from typing import Any
+from typing import AsyncIterator
+from typing import Dict
+from typing import Optional
+
+from nsflow.backend.utils.agentutils.async_streaming_input_processor import AsyncStreamingInputProcessor
+from nsflow.backend.utils.agentutils.ns_websocket_utils import NsWebsocketUtils
+
+
+class NsAgentClient:
+    """Request/response calls against a single neuro-san agent network."""
+
+    def __init__(self, agent_name: str):
+        """
+        :param agent_name: The agent network to talk to. May contain slashes, since
+                           generated networks are named "<subdir>/<name>".
+        """
+        self.agent_name = agent_name
+
+    def _session(self) -> Any:
+        """
+        Build a neuro-san session for this agent.
+
+        Constructed per call rather than cached: ``NsWebsocketUtils`` reads the
+        active config at construction time, so a fresh instance picks up a
+        ``/set_ns_config`` change instead of pinning the first host it saw.
+        """
+        return NsWebsocketUtils(self.agent_name, None).session
+
+    def connectivity(self) -> Dict[str, Any]:
+        """
+        Return the agent network's connectivity exactly as neuro-san reports it.
+
+        No transformation: the caller gets ``{"connectivity_info": [...]}``. nsflow's
+        React Flow shaping lives in ``NsNetworkUtils`` and stays behind the older
+        ``/api/v1/connectivity/{network_name}`` endpoint.
+        """
+        return self._session().connectivity({})
+
+    def function(self) -> Dict[str, Any]:
+        """Return the agent network's function description as neuro-san reports it."""
+        return self._session().function({})
+
+    async def streaming_chat(self, chat_request: Dict[str, Any]) -> AsyncIterator[Dict[str, Any]]:
+        """
+        Stream a chat turn, yielding neuro-san's chat responses as they arrive.
+
+        Each yielded item is one ``{"response": {...}}`` dict, exactly as
+        ``AgentSession.streaming_chat`` produces it and exactly what a neuro-san
+        server sends on the wire, so callers can serialise them straight to
+        newline-delimited JSON.
+
+        Before dispatch this applies the same two steps the WebSocket chat path
+        applies, so the HTTP route is not a way around them:
+
+        1. The client's ``sly_data`` is merged through
+           ``_merge_user_sly_data``, which strips ``***redacted***`` sentinels. The
+           UI round-trips the last streamed sly_data, which the backend surfaces
+           with credentials masked, so a plain copy would forward those literal
+           redaction strings to the agent.
+        2. ``inject_mcp_auth_headers`` adds Authorization headers for the
+           OAuth-connected MCP servers this network declares it needs, so the agent
+           can reach them without the user pasting a token.
+
+        Unlike the WebSocket path this is stateless: there is no per-session state
+        carried between turns, so tokens are injected fresh on every request and
+        conversation continuity is the caller's job via ``chat_context`` (which is
+        how neuro-san's own HTTP endpoint behaves too).
+
+        :param chat_request: A neuro-san ChatRequest. Passed through untouched
+                             apart from the ``sly_data`` handling above.
+        :return: An async iterator of neuro-san chat response dicts.
+        """
+        utils = NsWebsocketUtils(self.agent_name, None)
+
+        incoming: Optional[Dict[str, Any]] = chat_request.get("sly_data")
+        sly_data: Dict[str, Any] = {}
+        # Reaching for the WebSocket path's own merge rather than copying its
+        # redaction-sentinel rules, which would be a second implementation to keep
+        # in step. Static and side-effect free, so there is no session coupling.
+        # pylint: disable-next=protected-access
+        utils._merge_user_sly_data(sly_data, incoming)
+        await utils.inject_mcp_auth_headers(sly_data)
+
+        outgoing: Dict[str, Any] = {**chat_request, "sly_data": sly_data}
+
+        responses = utils.session.streaming_chat(outgoing)
+        async for chunk in AsyncStreamingInputProcessor.async_wrap_iter(responses):
+            yield chunk

--- a/tests/nsflow/test_neuro_san_facade.py
+++ b/tests/nsflow/test_neuro_san_facade.py
@@ -1,0 +1,281 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for the neuro-san-shaped API facade.
+
+The load-bearing test here is `test_route_priority_matrix`. The facade's
+``/api/v1/{agent_name:path}/connectivity`` occupies the same position as existing
+routes whose FIRST segment is a literal (``/api/v1/connectivity/{network_name}``
+and friends), so route registration order is what keeps existing consumers
+working. If anyone registers the facade earlier, or makes the converter
+non-greedy, these tests fail loudly instead of the editor silently 404-ing.
+"""
+
+import json
+from typing import Any
+from typing import Dict
+from typing import List
+
+import pytest
+from fastapi.testclient import TestClient
+
+import nsflow.backend.utils.agentutils.ns_websocket_utils as nw
+from nsflow.backend.api.router import router as nsflow_router
+from nsflow.backend.api.v1.neuro_san import agent as facade_agent
+from nsflow.backend.main import app
+from nsflow.backend.utils.tools.ns_configs_registry import NsConfigsRegistry
+
+client = TestClient(app)
+
+# What a neuro-san `connectivity` call returns: a list of nodes, each naming its
+# origin and the tools reachable from it. This is the shape the facade must pass
+# through untouched.
+FAKE_CONNECTIVITY: Dict[str, Any] = {
+    "connectivity_info": [
+        {"origin": "frontman", "tools": ["barista", "loyalty"]},
+        {"origin": "barista", "tools": []},
+        {"origin": "loyalty", "tools": ["rewards_db"]},
+    ]
+}
+
+FAKE_FUNCTION: Dict[str, Any] = {
+    "function": {
+        "description": "Takes coffee orders",
+        "parameters": {"type": "object", "properties": {}},
+    }
+}
+
+
+# One turn of neuro-san's streaming chat: several {"response": {...}} dicts, which
+# is what AgentSession.streaming_chat yields and what a neuro-san server sends.
+FAKE_CHAT_CHUNKS = [
+    {"response": {"type": "AGENT_PROGRESS", "text": "thinking"}},
+    {"response": {"type": "AI", "text": "One coffee coming up"}},
+]
+
+
+class _FakeSession:
+    """Stands in for a neuro-san AgentSession."""
+
+    def __init__(self):
+        self.streaming_chat_requests: List[Dict[str, Any]] = []
+
+    def connectivity(self, _data: Dict[str, Any]) -> Dict[str, Any]:
+        """Answer a connectivity call."""
+        return FAKE_CONNECTIVITY
+
+    def function(self, _data: Dict[str, Any]) -> Dict[str, Any]:
+        """Answer a function call."""
+        return FAKE_FUNCTION
+
+    def streaming_chat(self, chat_request: Dict[str, Any]):
+        """Record what was sent, then yield a turn's worth of responses."""
+        self.streaming_chat_requests.append(chat_request)
+        yield from FAKE_CHAT_CHUNKS
+
+
+@pytest.fixture(autouse=True)
+def _fake_neuro_san(monkeypatch):
+    """
+    Give every code path a working config and a session that answers locally, so
+    these tests exercise nsflow's routing and shaping rather than a live server.
+    """
+    NsConfigsRegistry.set_current("http", "localhost", 8080)
+    monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: _FakeSession())
+
+
+def test_facade_connectivity_returns_raw_neuro_san_shape():
+    """The facade passes neuro-san's connectivity_info through untransformed."""
+    response = client.get("/api/v1/my_net/connectivity")
+    assert response.status_code == 200
+    assert response.json() == FAKE_CONNECTIVITY
+
+
+def test_facade_connectivity_supports_nested_agent_names():
+    """
+    Generated networks are named `<subdir>/<name>` (frontend toServedNetworkPath),
+    so the path converter must be greedy or every generated network 404s.
+    """
+    response = client.get("/api/v1/generated/coffee_shop/connectivity")
+    assert response.status_code == 200
+    assert response.json() == FAKE_CONNECTIVITY
+
+
+def test_facade_function_returns_raw_neuro_san_shape():
+    """The facade passes neuro-san's function description through untransformed."""
+    response = client.get("/api/v1/my_net/function")
+    assert response.status_code == 200
+    assert response.json() == FAKE_FUNCTION
+
+
+def test_existing_connectivity_endpoint_still_returns_react_flow_shape():
+    """
+    The pre-existing endpoint transforms connectivity into React Flow nodes/edges.
+    The facade must not have changed it: this is the regression guard for its
+    current consumers (AgentFlow.tsx, useAgentFlowData.ts, and tests).
+    """
+    response = client.get("/api/v1/connectivity/my_net")
+    assert response.status_code == 200
+    body = response.json()
+    assert "nodes" in body and "edges" in body
+    assert "connectivity_info" not in body
+
+
+@pytest.mark.parametrize(
+    "path,expect_facade",
+    [
+        # facade wins: the second segment is the literal operation name
+        ("/api/v1/my_net/connectivity", True),
+        ("/api/v1/generated/coffee_shop/connectivity", True),
+        # existing wins: the first segment is a literal nsflow route
+        ("/api/v1/connectivity/my_net", False),
+        ("/api/v1/connectivity/generated/coffee_shop", False),
+        # ambiguous (a network actually named "connectivity"): existing must win,
+        # because it was registered first and its consumers predate the facade
+        ("/api/v1/connectivity/connectivity", False),
+    ],
+)
+def test_route_priority_matrix(path, expect_facade):
+    """
+    `connectivity_info` in the body means the facade handled it; `nodes`/`edges`
+    means the existing endpoint did.
+    """
+    response = client.get(path)
+    assert response.status_code == 200, f"{path} returned {response.status_code}"
+    body = response.json()
+    if expect_facade:
+        assert "connectivity_info" in body, f"{path} should have hit the facade, got {sorted(body)}"
+    else:
+        assert "nodes" in body, f"{path} should have hit the existing endpoint, got {sorted(body)}"
+
+
+def test_facade_is_the_last_registered_router():
+    """
+    Guards the ordering invariant directly, so a reordering fails here with a clear
+    message rather than as a confusing 404 in one of the cases above.
+
+    Asserted against the aggregate router's own route list, which is in
+    registration order. (Not app.openapi()["paths"] -- that dict is not ordered by
+    registration, so it cannot answer this question.)
+    """
+    included = [r for r in nsflow_router.routes if type(r).__name__ == "_IncludedRouter"]
+    assert included, "expected the aggregate router to be built from included routers"
+
+    last_router = included[-1].original_router
+    assert last_router is facade_agent.router, (
+        "the neuro-san facade must be the LAST router registered in "
+        "nsflow/backend/api/router.py, otherwise its greedy "
+        "/api/v1/{agent_name:path}/... routes shadow existing endpoints"
+    )
+
+
+def test_facade_exposes_exactly_the_expected_paths():
+    """A new facade route is a deliberate act; this pins the current surface."""
+    paths = sorted(r.path for r in facade_agent.router.routes)
+    assert paths == [
+        "/api/v1/{agent_name:path}/connectivity",
+        "/api/v1/{agent_name:path}/function",
+        "/api/v1/{agent_name:path}/streaming_chat",
+    ]
+
+
+def test_streaming_chat_emits_newline_delimited_json():
+    """
+    Each line is one neuro-san chat response verbatim, which is the shape
+    ui-common's chatMessageFromChunk parses (JSON.parse(line).response).
+    """
+    response = client.post("/api/v1/my_net/streaming_chat", json={"user_message": {"text": "a coffee please"}})
+    assert response.status_code == 200
+
+    lines = [line for line in response.text.split("\n") if line.strip()]
+    assert [json.loads(line) for line in lines] == FAKE_CHAT_CHUNKS
+
+
+def test_streaming_chat_supports_nested_agent_names():
+    """Generated networks are nested paths, so streaming_chat needs the greedy converter too."""
+    response = client.post("/api/v1/generated/coffee_shop/streaming_chat", json={"user_message": {"text": "hi"}})
+    assert response.status_code == 200
+    assert json.loads(response.text.split("\n")[0]) == FAKE_CHAT_CHUNKS[0]
+
+
+def test_streaming_chat_passes_the_request_through_untouched(monkeypatch):
+    """Everything except sly_data reaches neuro-san exactly as the client sent it."""
+    captured = _FakeSession()
+    monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: captured)
+
+    sent = {
+        "user_message": {"text": "a coffee please"},
+        "chat_filter": {"chat_filter_type": "MAXIMAL"},
+        "chat_context": {"some": "context"},
+    }
+    client.post("/api/v1/my_net/streaming_chat", json=sent)
+
+    assert len(captured.streaming_chat_requests) == 1
+    forwarded = captured.streaming_chat_requests[0]
+    assert forwarded["user_message"] == sent["user_message"]
+    assert forwarded["chat_filter"] == sent["chat_filter"]
+    assert forwarded["chat_context"] == sent["chat_context"]
+
+
+def test_streaming_chat_strips_redaction_sentinels_from_sly_data(monkeypatch):
+    """
+    The UI round-trips the last streamed sly_data, which the backend surfaces with
+    credentials masked. Those literal "***redacted***" values must never be
+    forwarded to the agent as if they were real secrets.
+    """
+    captured = _FakeSession()
+    monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: captured)
+
+    client.post(
+        "/api/v1/my_net/streaming_chat",
+        json={
+            "user_message": {"text": "hi"},
+            "sly_data": {
+                "agent_network_name": "coffee_shop",
+                "http_headers": {"https://mcp.example.com": {"Authorization": nw.REDACTED_VALUE}},
+            },
+        },
+    )
+
+    forwarded_sly_data = captured.streaming_chat_requests[0]["sly_data"]
+    # Non-credential keys pass through
+    assert forwarded_sly_data["agent_network_name"] == "coffee_shop"
+    # The redaction sentinel does not
+    headers = forwarded_sly_data.get("http_headers", {}).get("https://mcp.example.com", {})
+    assert headers.get("Authorization") != nw.REDACTED_VALUE
+
+
+def test_streaming_chat_injects_mcp_auth_headers(monkeypatch):
+    """
+    The HTTP route must not be a way around the MCP token injection the WebSocket
+    path performs, or it becomes an auth bypass.
+    """
+    captured = _FakeSession()
+    monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: captured)
+
+    injected = []
+
+    async def _fake_inject(_self, sly_data):
+        injected.append(sly_data)
+        sly_data["http_headers"] = {"https://mcp.example.com": {"Authorization": "Bearer real-token"}}
+
+    monkeypatch.setattr(nw.NsWebsocketUtils, "inject_mcp_auth_headers", _fake_inject)
+
+    client.post("/api/v1/my_net/streaming_chat", json={"user_message": {"text": "hi"}})
+
+    assert injected, "inject_mcp_auth_headers was never called for the HTTP chat route"
+    forwarded = captured.streaming_chat_requests[0]["sly_data"]
+    assert forwarded["http_headers"]["https://mcp.example.com"]["Authorization"] == "Bearer real-token"


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Adds a neuro-san-shaped facade so a client can talk to nsflow using neuro-san's own HTTP contract instead of nsflow's bespoke shape.

The routes return neuro-san's payload verbatim rather than through hand-written models. Copying an external schema by hand creates drift: every field ends up optional, so it validates nothing, and it silently drops fields the moment upstream adds one.

## Impact

Additive. No existing endpoint changes shape or path.

One ordering constraint carries real risk, so it is documented in the code and asserted by a test. The facade routes on `/api/v1/{agent_name:path}/...`, a greedy path parameter where nsflow's own routes have a literal first segment such as `/api/v1/connectivity/{network_name}`. Starlette matches in registration order, so the facade must be registered last. Moving that line up, or adding a router below it, would silently shadow existing endpoints with no error. `test_neuro_san_facade.py` asserts both the registration order and a route-priority matrix, so the shadowing cannot regress unnoticed.

## Screenshots / Logs / Examples (optional)

```
tests/nsflow/test_neuro_san_facade.py::test_facade_is_the_last_registered_router PASSED
tests/nsflow/test_neuro_san_facade.py::test_facade_exposes_exactly_the_expected_paths PASSED
tests/nsflow/test_neuro_san_facade.py::test_route_priority_matrix[...] PASSED
16 passed
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

16 new tests, including the route-priority matrix that guards the registration order. Full Python suite: 194 passing. `make lint-check-source` and `lint-check-tests` both 10.00/10. No new dependencies.

---