### PR TITLE
Add toolbox and designer reference endpoints and a neuro-san facade

### DIFF
--- a/nsflow/backend/api/router.py
+++ b/nsflow/backend/api/router.py
@@ -31,6 +31,7 @@ from .v1 import oneshot_endpoints
 from .v1 import pdf_endpoints
 from .v1 import toolbox_endpoints
 from .v1 import vqa_endpoints
+from .v1.neuro_san import agent as neuro_san_agent
 
 NSFLOW_PLUGIN_VQA_ENDPOINT = os.getenv("NSFLOW_PLUGIN_VQA_ENDPOINT", None)
 
@@ -51,3 +52,12 @@ router.include_router(designer_endpoints.router, tags=["Designer"])
 router.include_router(mcp_oauth_endpoints.router, tags=["MCP OAuth"])
 if NSFLOW_PLUGIN_VQA_ENDPOINT:
     router.include_router(vqa_endpoints.router, tags=["Visual Question Answering"])
+
+# KEEP LAST. The neuro-san-shaped facade routes on "/api/v1/{agent_name:path}/..."
+# put a greedy path parameter where nsflow's own routes have a literal first
+# segment (e.g. "/api/v1/connectivity/{network_name}"). Starlette matches in
+# registration order, so registering this after everything else is what keeps
+# every existing endpoint winning for its own consumers. Adding a router below
+# this line, or moving this line up, will silently shadow existing endpoints.
+# tests/nsflow/test_neuro_san_facade.py asserts this ordering.
+router.include_router(neuro_san_agent.router, tags=["neuro-san API"])

--- a/nsflow/backend/api/router.py
+++ b/nsflow/backend/api/router.py
@@ -21,6 +21,7 @@ from .v1 import agent_flows
 from .v1 import app_configs
 from .v1 import audio_endpoints
 from .v1 import cruse_endpoints
+from .v1 import designer_endpoints
 from .v1 import editor_endpoints
 from .v1 import export_endpoints
 from .v1 import fast_websocket
@@ -28,6 +29,7 @@ from .v1 import fastapi_concierge_endpoints
 from .v1 import mcp_oauth_endpoints
 from .v1 import oneshot_endpoints
 from .v1 import pdf_endpoints
+from .v1 import toolbox_endpoints
 from .v1 import vqa_endpoints
 
 NSFLOW_PLUGIN_VQA_ENDPOINT = os.getenv("NSFLOW_PLUGIN_VQA_ENDPOINT", None)
@@ -44,6 +46,8 @@ router.include_router(editor_endpoints.router, tags=["Agent Network Designer"])
 router.include_router(cruse_endpoints.router, prefix="/api/v1", tags=["CRUSE Threads"])
 router.include_router(oneshot_endpoints.router, tags=["One-Shot Chat"])
 router.include_router(pdf_endpoints.router, tags=["PDF Processing"])
+router.include_router(toolbox_endpoints.router, tags=["Toolbox"])
+router.include_router(designer_endpoints.router, tags=["Designer"])
 router.include_router(mcp_oauth_endpoints.router, tags=["MCP OAuth"])
 if NSFLOW_PLUGIN_VQA_ENDPOINT:
     router.include_router(vqa_endpoints.router, tags=["Visual Question Answering"])

--- a/nsflow/backend/api/v1/designer_endpoints.py
+++ b/nsflow/backend/api/v1/designer_endpoints.py
@@ -1,0 +1,149 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Lists what the agent network designer will accept as an external reference.
+
+This is deliberately NOT the same as what the server serves. The designer validates
+references against a curated subset, and a network the server hosts but the designer
+does not know is rejected with
+
+    Agent 'frontman' references an unrecognized URL or path tool '/basic/coffee_finder'
+
+which is not a plain error: the designer responds by invoking its LLM to repair the
+network, restructuring what the user drew and taking half a minute per edit. Offering
+the editor's palette anything outside this set therefore poisons every subsequent edit
+until the reference is removed, so the palette has to be fed from the same two sources
+the designer itself reads:
+
+* ``AGENT_NETWORK_DESIGNER_MANIFEST_FILE`` for other agent networks. Distinct from
+  ``AGENT_MANIFEST_FILE`` on purpose, so the designer's pool can be narrower than what
+  the server hosts.
+* ``MCP_SERVERS_INFO_FILE`` for MCP servers. Also distinct from the OAuth connection
+  store: a server can be connected without being offered to the designer, and vice
+  versa.
+
+Both are read through neuro-san's own restorers and manifest filters rather than by
+re-reading the files here, so manifest semantics (``include`` composition, quoted
+keys, the ``serve`` flag) cannot drift from the server's.
+"""
+
+import logging
+import os
+from typing import Any
+from typing import Dict
+from typing import List
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from leaf_common.config.config_filter_chain import ConfigFilterChain
+from neuro_san.internals.graph.persistence.manifest_dict_config_filter import ManifestDictConfigFilter
+from neuro_san.internals.graph.persistence.manifest_key_config_filter import ManifestKeyConfigFilter
+from neuro_san.internals.graph.persistence.raw_manifest_restorer import RawManifestRestorer
+from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
+from neuro_san.internals.graph.persistence.served_manifest_config_filter import ServedManifestConfigFilter
+from neuro_san.internals.run_context.langchain.mcp.mcp_servers_info_restorer import McpServersInfoRestorer
+
+router = APIRouter(prefix="/api/v1/designer")
+
+DESIGNER_MANIFEST_ENV_VAR = "AGENT_NETWORK_DESIGNER_MANIFEST_FILE"
+MCP_SERVERS_ENV_VAR = "MCP_SERVERS_INFO_FILE"
+
+# What neuro-san-studio ships as the designer's manifest when the env var is unset.
+# Only resolves for an in-repo run, which is why studio exports the resolved path.
+DEFAULT_DESIGNER_MANIFEST = os.path.join("registries", "manifest_and.hocon")
+
+
+def _designer_manifest_file() -> str:
+    """
+    :return: The manifest naming the networks the designer may reference.
+    """
+    return os.getenv(DESIGNER_MANIFEST_ENV_VAR) or DEFAULT_DESIGNER_MANIFEST
+
+
+def _referenceable_networks() -> List[str]:
+    """
+    Read the external network names the designer accepts, as "/<name>".
+
+    Mirrors the designer's own ``GetSubnetwork``: neuro-san's manifest filters strip
+    quoted keys, normalise bool entries, and drop anything not served, then its
+    registry restorer derives the external names.
+
+    :return: The names, or an empty list when the manifest is missing or unparseable.
+    """
+    manifest_file = _designer_manifest_file()
+
+    try:
+        # Missing file comes back as None rather than raising.
+        raw_manifest: Dict[str, Any] = RawManifestRestorer().restore(file_reference=manifest_file)
+        if raw_manifest is None:
+            logging.warning("Designer manifest %s not found; no networks can be referenced", manifest_file)
+            return []
+
+        # Assembled rather than using ManifestFilterChain, which keeps unserved
+        # entries and warns per entry. Here they should be dropped silently.
+        filter_chain = ConfigFilterChain()
+        filter_chain.register(ManifestKeyConfigFilter(manifest_file))
+        filter_chain.register(ManifestDictConfigFilter(manifest_file))
+        filter_chain.register(ServedManifestConfigFilter(manifest_file, warn_on_skip=False, entry_for_skipped=False))
+        one_manifest: Dict[str, Any] = filter_chain.filter_config(raw_manifest)
+
+        restorer = RegistryManifestRestorer(manifest_files=manifest_file)
+        return list(restorer.find_external_network_names(one_manifest))
+    except Exception as exc:  # pylint: disable=broad-except
+        # neuro-san re-wraps HOCON parse errors as ValueError. Whatever the cause, an
+        # unreadable manifest means "nothing to offer", not a failed request: the
+        # toolbox and MCP halves of the palette are still usable.
+        logging.warning("Could not read designer manifest %s: %s", manifest_file, exc)
+        return []
+
+
+def _referenceable_mcp_servers() -> List[str]:
+    """
+    Read the MCP server URLs the designer accepts.
+
+    :return: The URLs, or an empty list when no info file is configured or readable.
+    """
+    mcp_info_file = os.getenv(MCP_SERVERS_ENV_VAR)
+    if not mcp_info_file:
+        # No fallback path is guessed here: unlike the designer, nsflow does not know
+        # where a given project keeps its bundled copy.
+        return []
+
+    try:
+        info: Dict[str, Any] = McpServersInfoRestorer().restore(file_reference=mcp_info_file)
+        return list(info.keys()) if info else []
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.warning("Could not read %s=%s: %s", MCP_SERVERS_ENV_VAR, mcp_info_file, exc)
+        return []
+
+
+@router.get(
+    "/references",
+    summary="List what the agent network designer accepts as an external reference.",
+    responses={200: {"description": "The networks and MCP servers the designer recognises"}},
+)
+async def list_references() -> JSONResponse:
+    """
+    List the external references the editor palette may offer.
+
+    :return: ``{"networks": ["/industry/foo", ...], "mcp_servers": ["https://...", ...]}``
+    """
+    return JSONResponse(
+        content={
+            "networks": _referenceable_networks(),
+            "mcp_servers": _referenceable_mcp_servers(),
+        }
+    )

--- a/nsflow/backend/api/v1/designer_endpoints.py
+++ b/nsflow/backend/api/v1/designer_endpoints.py
@@ -45,6 +45,8 @@ import os
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
+from typing import Set
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
@@ -61,16 +63,43 @@ router = APIRouter(prefix="/api/v1/designer")
 DESIGNER_MANIFEST_ENV_VAR = "AGENT_NETWORK_DESIGNER_MANIFEST_FILE"
 MCP_SERVERS_ENV_VAR = "MCP_SERVERS_INFO_FILE"
 
-# What neuro-san-studio ships as the designer's manifest when the env var is unset.
-# Only resolves for an in-repo run, which is why studio exports the resolved path.
+# Where neuro-san-studio keeps the designer's manifest inside its own repo. Used only
+# when the env var is unset AND this path exists, which is true for a studio run
+# started from a clone and false for every pip installed one. Studio does not export
+# this variable yet, so removing the fallback outright would empty the list for the
+# deployments that work today. See cognizant-ai-lab/neuro-san-studio for the upstream
+# fix, after which this comes out.
 DEFAULT_DESIGNER_MANIFEST = os.path.join("registries", "manifest_and.hocon")
 
+# Already warned about, so the log does not repeat itself. The endpoint below is
+# requested every time the palette opens, and a deployment without a designer manifest
+# would otherwise print the same line hundreds of times.
+WARNED_MESSAGES: Set[str] = set()
 
-def _designer_manifest_file() -> str:
+
+def _warn_once(message: str) -> None:
     """
-    :return: The manifest naming the networks the designer may reference.
+    Log a warning the first time it comes up, then stay quiet about it.
+
+    :param message: The warning, which doubles as the key.
     """
-    return os.getenv(DESIGNER_MANIFEST_ENV_VAR) or DEFAULT_DESIGNER_MANIFEST
+    if message not in WARNED_MESSAGES:
+        WARNED_MESSAGES.add(message)
+        logging.warning(message)
+
+
+def _designer_manifest_file() -> Optional[str]:
+    """
+    :return: The manifest naming the networks the designer may reference, or None when
+             nothing configured or shipped points at one.
+    """
+    configured = os.getenv(DESIGNER_MANIFEST_ENV_VAR)
+    if configured:
+        return configured
+    # Relative, so it resolves against the server's working directory. Checking it
+    # exists is what keeps a pip installed deployment quiet rather than warning about a
+    # path it was never going to have.
+    return DEFAULT_DESIGNER_MANIFEST if os.path.isfile(DEFAULT_DESIGNER_MANIFEST) else None
 
 
 def _referenceable_networks() -> List[str]:
@@ -84,12 +113,18 @@ def _referenceable_networks() -> List[str]:
     :return: The names, or an empty list when the manifest is missing or unparseable.
     """
     manifest_file = _designer_manifest_file()
+    if manifest_file is None:
+        _warn_once(
+            f"{DESIGNER_MANIFEST_ENV_VAR} is not set and no manifest ships with this install, "
+            "so the designer has no networks to reference."
+        )
+        return []
 
     try:
         # Missing file comes back as None rather than raising.
         raw_manifest: Dict[str, Any] = RawManifestRestorer().restore(file_reference=manifest_file)
         if raw_manifest is None:
-            logging.warning("Designer manifest %s not found; no networks can be referenced", manifest_file)
+            _warn_once(f"Designer manifest {manifest_file} not found; no networks can be referenced")
             return []
 
         # Assembled rather than using ManifestFilterChain, which keeps unserved

--- a/nsflow/backend/api/v1/neuro_san/agent.py
+++ b/nsflow/backend/api/v1/neuro_san/agent.py
@@ -1,0 +1,180 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+neuro-san-shaped routes for per-agent operations (neuro-san's AgentService).
+
+These mirror neuro-san's own HTTP contract so the frontend speaks one vocabulary
+whether it is pointed at nsflow or at a neuro-san server, without a neuro-san API
+layer living in the browser.
+
+They are deliberately thin passthroughs. neuro-san's payloads are returned as-is,
+with no Pydantic models mirroring its schemas: those schemas are generated on
+neuro-san's side, so hand-copying them here would only create drift, and the
+frontend already gets real types from ui-common's generated client. Passing the
+payload straight through also means a field added by a future neuro-san release
+reaches the client instead of being silently dropped.
+
+TWO THINGS TO KNOW BEFORE EDITING THIS FILE
+-------------------------------------------
+1. ``{agent_name:path}`` is GREEDY on purpose. Generated networks are named
+   "<subdir>/<name>" (e.g. "generated/coffee_shop"), so a single-segment converter
+   would 404 every generated network.
+
+2. This router MUST be registered last (see ``nsflow/backend/api/router.py``).
+   ``/api/v1/{agent_name:path}/connectivity`` occupies the same position as
+   existing routes whose first segment is a literal, such as
+   ``/api/v1/connectivity/{network_name}``. First-registered wins in Starlette, so
+   registering last is what keeps every existing consumer working.
+   ``tests/nsflow/test_neuro_san_facade.py`` asserts both properties.
+"""
+
+import json
+import logging
+from typing import Any
+from typing import AsyncIterator
+from typing import Dict
+
+from fastapi import APIRouter
+from fastapi import HTTPException
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from fastapi.responses import StreamingResponse
+
+from nsflow.backend.utils.agentutils.ns_agent_client import NsAgentClient
+
+router = APIRouter(prefix="/api/v1")
+
+
+async def _ndjson_lines(client: NsAgentClient, chat_request: Dict[str, Any]) -> AsyncIterator[bytes]:
+    """
+    Serialise each neuro-san chat response as its own newline-terminated line.
+
+    Errors are logged and end the stream rather than raising: response headers have
+    already been sent by the time the first chunk is produced, so there is no status
+    code left to change. A client disconnect cancels this generator, which stops the
+    iteration at its next await.
+
+    :param client: The client for the agent network being streamed.
+    :param chat_request: The neuro-san ChatRequest to send.
+    :return: An async iterator of newline-delimited JSON lines.
+    """
+    try:
+        async for chunk in client.streaming_chat(chat_request):
+            yield (json.dumps(chunk) + "\n").encode("utf-8")
+    except Exception as exc:  # pylint: disable=broad-except  # must not escape mid-stream
+        logging.exception("streaming_chat failed for %s: %s", client.agent_name, exc)
+
+
+@router.get(
+    "/{agent_name:path}/connectivity",
+    summary="Get an agent network's connectivity, in neuro-san's own shape.",
+    responses={
+        200: {"description": "neuro-san's ConnectivityResponse verbatim: {'connectivity_info': [...]}"},
+        502: {"description": "The neuro-san server could not be reached or failed"},
+    },
+)
+async def get_connectivity(agent_name: str) -> JSONResponse:
+    """
+    Mirror of neuro-san's ``AgentService_Connectivity``.
+
+    Returns the raw ``connectivity_info`` list. For React Flow nodes and edges, use
+    nsflow's own ``/api/v1/connectivity/{network_name}`` instead.
+
+    :param agent_name: The agent network. May contain slashes.
+    :return: neuro-san's connectivity payload, unmodified.
+    """
+    try:
+        result: Dict[str, Any] = NsAgentClient(agent_name).connectivity()
+    except Exception as exc:
+        logging.exception("Failed to get connectivity for %s: %s", agent_name, exc)
+        raise HTTPException(status_code=502, detail=f"Failed to get connectivity for '{agent_name}'") from exc
+
+    return JSONResponse(content=result)
+
+
+@router.get(
+    "/{agent_name:path}/function",
+    summary="Get an agent network's function description, in neuro-san's own shape.",
+    responses={
+        200: {"description": "neuro-san's FunctionResponse verbatim: {'function': {...}}"},
+        502: {"description": "The neuro-san server could not be reached or failed"},
+    },
+)
+async def get_function(agent_name: str) -> JSONResponse:
+    """
+    Mirror of neuro-san's ``AgentService_Function``.
+
+    :param agent_name: The agent network. May contain slashes.
+    :return: neuro-san's function payload, unmodified.
+    """
+    try:
+        result: Dict[str, Any] = NsAgentClient(agent_name).function()
+    except Exception as exc:
+        logging.exception("Failed to get function for %s: %s", agent_name, exc)
+        raise HTTPException(status_code=502, detail=f"Failed to get function for '{agent_name}'") from exc
+
+    return JSONResponse(content=result)
+
+
+@router.post(
+    "/{agent_name:path}/streaming_chat",
+    summary="Stream a chat turn with an agent network, in neuro-san's own shape.",
+    responses={
+        200: {
+            "description": (
+                "Newline-delimited JSON. Each line is one neuro-san chat response, "
+                "shaped {'response': {...}}, emitted as it arrives."
+            )
+        },
+        422: {"description": "The request body was not valid JSON"},
+        502: {"description": "The neuro-san server could not be reached or failed"},
+    },
+)
+async def streaming_chat(agent_name: str, request: Request) -> StreamingResponse:
+    """
+    Mirror of neuro-san's ``AgentService_StreamingChat``.
+
+    The body is a neuro-san ChatRequest and is forwarded as-is, except that
+    ``sly_data`` goes through the same redaction-sentinel merge and MCP token
+    injection the WebSocket chat path applies, so this route cannot be used to get
+    around them.
+
+    Responses stream out as newline-delimited JSON, one neuro-san chat response per
+    line, which is what ui-common's chunk parser expects.
+
+    nsflow's WebSocket endpoints remain the richer path: they also multiplex
+    progress, logs and sly_data onto separate sockets. This route exists so the HTTP
+    surface matches neuro-san's contract.
+
+    :param agent_name: The agent network. May contain slashes.
+    :param request: The incoming request, whose JSON body is the ChatRequest.
+    :return: A newline-delimited JSON stream of neuro-san chat responses.
+    """
+    try:
+        chat_request: Dict[str, Any] = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail="Request body must be valid JSON") from exc
+
+    if not isinstance(chat_request, dict):
+        raise HTTPException(status_code=422, detail="Request body must be a JSON object")
+
+    # Mirrors what a neuro-san server sends for this operation. It carries no
+    # meaning for nsflow itself (our own consumer reads the body as text and splits
+    # lines), but a client written against neuro-san should not be able to tell the
+    # difference. Not asserted in tests: it is neuro-san's value, not ours to pin.
+    return StreamingResponse(
+        _ndjson_lines(NsAgentClient(agent_name), chat_request), media_type="application/json-lines"
+    )

--- a/nsflow/backend/api/v1/toolbox_endpoints.py
+++ b/nsflow/backend/api/v1/toolbox_endpoints.py
@@ -1,0 +1,175 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Lists the tools available to drag onto the editor canvas.
+
+There are two different toolboxes in play, and the editor wants the narrower one:
+
+* ``AGENT_TOOLBOX_INFO_FILE`` is the *runtime* toolbox, overlaid on neuro-san's
+  built-in set. It is what a running network resolves tool names against.
+* ``AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE`` is a curated subset naming the tools
+  the agent network designer may pick from when it authors a network.
+
+Since every editor change is canonicalised by the designer, the palette offers the
+designer's subset when that is configured, and falls back to the runtime toolbox
+otherwise. This resolution deliberately mirrors the designer's own
+``GetToolbox`` coded tool so the palette and the designer agree on what exists.
+
+nsflow does not apply the designer file's directory-relative default the way
+neuro-san-studio does; that default only resolves for an in-repo studio run, and
+studio exports the resolved path into the env var, which is what is read here.
+
+Both loads come from neuro-san rather than from a list nsflow maintains, so a tool
+added to either file shows up without an nsflow change.
+"""
+
+import logging
+import os
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from fastapi import APIRouter
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from neuro_san.internals.run_context.factory.master_toolbox_factory import MasterToolboxFactory
+from neuro_san.internals.run_context.langchain.toolbox.toolbox_info_restorer import ToolboxInfoRestorer
+
+router = APIRouter(prefix="/api/v1")
+
+DESIGNER_TOOLBOX_ENV_VAR = "AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE"
+
+# Resolving and parsing HOCON is done once per process rather than per request; a
+# toolbox only changes when the server is reconfigured and restarted. Two slots:
+# "designer" holds the curated tools once that load succeeds, and "factory" holds the
+# runtime toolbox factory, whose own load() is a no-op after the first call.
+#
+# Only a successful designer load is final. Falling back is deliberately not cached,
+# so a designer file that is missing when the first palette opens is picked up on a
+# later request rather than pinning the wrong toolbox for the life of the process.
+_TOOLBOX_CACHE: Dict[str, Any] = {}
+
+
+def _load_designer_toolbox() -> Optional[Dict[str, Any]]:
+    """
+    Load the curated toolbox the agent network designer picks from.
+
+    :return: The tool infos, or None when the env var is unset or the file is
+             missing, empty, or unreadable, in which case the caller falls back to
+             the runtime toolbox.
+    """
+    path: str = os.getenv(DESIGNER_TOOLBOX_ENV_VAR)
+    if not path:
+        return None
+
+    try:
+        infos: Dict[str, Any] = ToolboxInfoRestorer().restore(path)
+    except Exception as exc:  # pylint: disable=broad-except
+        # Not fatal: the runtime toolbox is still a usable palette.
+        logging.warning("Could not read %s=%s: %s", DESIGNER_TOOLBOX_ENV_VAR, path, exc)
+        return None
+
+    if not infos:
+        logging.warning("%s=%s yielded no tools", DESIGNER_TOOLBOX_ENV_VAR, path)
+        return None
+    return infos
+
+
+def _load_runtime_toolbox() -> Dict[str, Any]:
+    """
+    Load the runtime toolbox: neuro-san's built-in set overlaid with
+    ``AGENT_TOOLBOX_INFO_FILE``.
+
+    The factory is asked for the merged view rather than the override file being read
+    directly, since reading the file alone would miss the built-in tools.
+
+    :return: The merged tool infos, keyed by tool name.
+    """
+    factory = _TOOLBOX_CACHE.get("factory")
+    if factory is None:
+        factory = MasterToolboxFactory.create_toolbox_factory({})
+        _TOOLBOX_CACHE["factory"] = factory
+    # Reusing the instance is what keeps this cheap: load() only does work on its
+    # first call, so the HOCON is parsed once per process.
+    factory.load()
+    # toolbox_infos is a public attribute on ToolboxFactory rather than part of the
+    # ContextTypeToolboxFactory interface, so it is semi-internal. It is still a far
+    # better source than a hand-maintained list, which would drift the moment
+    # neuro-san or a project ships a new tool.
+    return getattr(factory, "toolbox_infos", {}) or {}
+
+
+def _load_toolbox() -> Tuple[str, Dict[str, Any]]:
+    """
+    Return the toolbox the palette should offer, loading it on first use.
+
+    :return: A (source, tool infos) pair, where source names which toolbox won.
+    """
+    cached: Optional[Dict[str, Any]] = _TOOLBOX_CACHE.get("designer")
+    if cached:
+        return "agent_network_designer", cached
+
+    designer_infos: Optional[Dict[str, Any]] = _load_designer_toolbox()
+    if designer_infos:
+        _TOOLBOX_CACHE["designer"] = designer_infos
+        return "agent_network_designer", designer_infos
+
+    return "runtime", _load_runtime_toolbox()
+
+
+@router.get(
+    "/toolbox",
+    summary="List the tools available from neuro-san's toolbox.",
+    responses={
+        200: {"description": "The tools the configured toolbox offers"},
+        500: {"description": "The toolbox could not be loaded"},
+    },
+)
+async def list_toolbox() -> JSONResponse:
+    """
+    List the toolbox tools, for the editor palette.
+
+    Each entry carries the tool's name, its human-readable description, and whether
+    it is a coded tool or a langchain tool, which is what the palette needs to group
+    and label them.
+
+    :return: ``{"source", "tools": [{"name", "description", "class", "display_as"}]}``
+    """
+    try:
+        source, infos = _load_toolbox()
+    except Exception as exc:
+        logging.exception("Failed to load the neuro-san toolbox: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to load the neuro-san toolbox") from exc
+
+    tools: List[Dict[str, Any]] = []
+    for name, info in sorted(infos.items()):
+        entry: Dict[str, Any] = info if isinstance(info, dict) else {}
+        # A tool backed by a python class is a coded_tool; one backed by a langchain
+        # toolkit is not. display_as matches the vocabulary connectivity already uses,
+        # so a dragged tool renders like the same tool does on a generated network.
+        has_class = bool(entry.get("class"))
+        tools.append(
+            {
+                "name": name,
+                "description": entry.get("description", ""),
+                "class": entry.get("class"),
+                "display_as": "coded_tool" if has_class else "langchain_tool",
+            }
+        )
+
+    return JSONResponse(content={"source": source, "tools": tools})

--- a/nsflow/backend/utils/agentutils/ns_agent_client.py
+++ b/nsflow/backend/utils/agentutils/ns_agent_client.py
@@ -1,0 +1,119 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Typed client for neuro-san's per-agent operations.
+
+This is the backend counterpart to ui-common's ``controller/agent/Agent.ts``: the
+one place that knows how to talk to a neuro-san agent, so the routes in
+``nsflow/backend/api/v1/neuro_san/`` stay thin.
+
+It delegates session construction to :class:`NsWebsocketUtils`, which already owns
+reading the active :class:`NsConfig` and building an ``AgentSession`` via
+``AgentSessionFactory``. Reusing it keeps one implementation of that logic rather
+than a second copy that could drift on host/port/connection handling. The
+websocket argument is ``None`` because these are plain request/response calls; the
+existing ``/api/v1/connectivity/{network_name}`` endpoint already uses it this way.
+"""
+
+from typing import Any
+from typing import AsyncIterator
+from typing import Dict
+from typing import Optional
+
+from nsflow.backend.utils.agentutils.async_streaming_input_processor import AsyncStreamingInputProcessor
+from nsflow.backend.utils.agentutils.ns_websocket_utils import NsWebsocketUtils
+
+
+class NsAgentClient:
+    """Request/response calls against a single neuro-san agent network."""
+
+    def __init__(self, agent_name: str):
+        """
+        :param agent_name: The agent network to talk to. May contain slashes, since
+                           generated networks are named "<subdir>/<name>".
+        """
+        self.agent_name = agent_name
+
+    def _session(self) -> Any:
+        """
+        Build a neuro-san session for this agent.
+
+        Constructed per call rather than cached: ``NsWebsocketUtils`` reads the
+        active config at construction time, so a fresh instance picks up a
+        ``/set_ns_config`` change instead of pinning the first host it saw.
+        """
+        return NsWebsocketUtils(self.agent_name, None).session
+
+    def connectivity(self) -> Dict[str, Any]:
+        """
+        Return the agent network's connectivity exactly as neuro-san reports it.
+
+        No transformation: the caller gets ``{"connectivity_info": [...]}``. nsflow's
+        React Flow shaping lives in ``NsNetworkUtils`` and stays behind the older
+        ``/api/v1/connectivity/{network_name}`` endpoint.
+        """
+        return self._session().connectivity({})
+
+    def function(self) -> Dict[str, Any]:
+        """Return the agent network's function description as neuro-san reports it."""
+        return self._session().function({})
+
+    async def streaming_chat(self, chat_request: Dict[str, Any]) -> AsyncIterator[Dict[str, Any]]:
+        """
+        Stream a chat turn, yielding neuro-san's chat responses as they arrive.
+
+        Each yielded item is one ``{"response": {...}}`` dict, exactly as
+        ``AgentSession.streaming_chat`` produces it and exactly what a neuro-san
+        server sends on the wire, so callers can serialise them straight to
+        newline-delimited JSON.
+
+        Before dispatch this applies the same two steps the WebSocket chat path
+        applies, so the HTTP route is not a way around them:
+
+        1. The client's ``sly_data`` is merged through
+           ``_merge_user_sly_data``, which strips ``***redacted***`` sentinels. The
+           UI round-trips the last streamed sly_data, which the backend surfaces
+           with credentials masked, so a plain copy would forward those literal
+           redaction strings to the agent.
+        2. ``inject_mcp_auth_headers`` adds Authorization headers for the
+           OAuth-connected MCP servers this network declares it needs, so the agent
+           can reach them without the user pasting a token.
+
+        Unlike the WebSocket path this is stateless: there is no per-session state
+        carried between turns, so tokens are injected fresh on every request and
+        conversation continuity is the caller's job via ``chat_context`` (which is
+        how neuro-san's own HTTP endpoint behaves too).
+
+        :param chat_request: A neuro-san ChatRequest. Passed through untouched
+                             apart from the ``sly_data`` handling above.
+        :return: An async iterator of neuro-san chat response dicts.
+        """
+        utils = NsWebsocketUtils(self.agent_name, None)
+
+        incoming: Optional[Dict[str, Any]] = chat_request.get("sly_data")
+        sly_data: Dict[str, Any] = {}
+        # Reaching for the WebSocket path's own merge rather than copying its
+        # redaction-sentinel rules, which would be a second implementation to keep
+        # in step. Static and side-effect free, so there is no session coupling.
+        # pylint: disable-next=protected-access
+        utils._merge_user_sly_data(sly_data, incoming)
+        await utils.inject_mcp_auth_headers(sly_data)
+
+        outgoing: Dict[str, Any] = {**chat_request, "sly_data": sly_data}
+
+        responses = utils.session.streaming_chat(outgoing)
+        async for chunk in AsyncStreamingInputProcessor.async_wrap_iter(responses):
+            yield chunk

--- a/tests/nsflow/test_designer_endpoints.py
+++ b/tests/nsflow/test_designer_endpoints.py
@@ -21,6 +21,8 @@ the designer does not recognise makes it reject the reference and rewrite the ne
 with its LLM, so every later edit breaks until that reference is removed.
 """
 
+import logging
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -110,3 +112,43 @@ def test_an_unreadable_source_empties_only_its_own_half(client, tmp_path, monkey
     else:
         assert body["networks"] != []
         assert body["mcp_servers"] == []
+
+
+def test_no_configured_manifest_and_none_shipped_offers_nothing(client, tmp_path, monkeypatch, caplog):
+    """
+    A pip installed neuro-san-studio has no `registries/` beside the server, so the
+    relative default resolves to nothing. Reporting an empty list is honest; trying to
+    read the path anyway warned on every request for a file that was never coming.
+    """
+    monkeypatch.delenv(designer_endpoints.DESIGNER_MANIFEST_ENV_VAR, raising=False)
+    monkeypatch.delenv(designer_endpoints.MCP_SERVERS_ENV_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)
+    designer_endpoints.WARNED_MESSAGES.clear()
+
+    with caplog.at_level(logging.WARNING):
+        first = client.get("/api/v1/designer/references").json()
+        second = client.get("/api/v1/designer/references").json()
+
+    assert first["networks"] == []
+    assert second["networks"] == []
+    # The palette asks for this every time it opens, so the same line repeating is the
+    # part worth pinning down, not just the empty list.
+    manifest_warnings = [record for record in caplog.records if "designer" in record.message.lower()]
+    assert len(manifest_warnings) == 1
+
+
+def test_falls_back_to_the_shipped_manifest_when_it_is_actually_there(client, tmp_path, monkeypatch):
+    """
+    studio's run.py does not export the manifest variable yet, so an in-repo run has
+    the file and no variable. That deployment works today and has to keep working.
+    """
+    monkeypatch.delenv(designer_endpoints.DESIGNER_MANIFEST_ENV_VAR, raising=False)
+    monkeypatch.delenv(designer_endpoints.MCP_SERVERS_ENV_VAR, raising=False)
+    registries = tmp_path / "registries"
+    registries.mkdir()
+    (registries / "manifest_and.hocon").write_text(DESIGNER_MANIFEST, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    body = client.get("/api/v1/designer/references").json()
+
+    assert sorted(body["networks"]) == ["/generated/coffee_shop", "/industry/banking_ops"]

--- a/tests/nsflow/test_designer_endpoints.py
+++ b/tests/nsflow/test_designer_endpoints.py
@@ -1,0 +1,112 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for GET /api/v1/designer/references, which feeds the editor palette.
+
+What matters is that the set is the DESIGNER's, not the server's. Offering a network
+the designer does not recognise makes it reject the reference and rewrite the network
+with its LLM, so every later edit breaks until that reference is removed.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nsflow.backend.api.v1 import designer_endpoints
+
+# Two entries served and one not, so the `serve` flag is exercised.
+DESIGNER_MANIFEST = """
+{
+    "industry/banking_ops.hocon": true,
+    "generated/coffee_shop.hocon": true,
+    "basic/coffee_finder.hocon": false,
+}
+"""
+
+MCP_INFO = """
+{
+    "https://mcp.example.com/mcp": {
+        "url": "https://mcp.example.com/mcp",
+    },
+}
+"""
+
+
+@pytest.fixture(name="client")
+def client_fixture() -> TestClient:
+    """An app serving only the designer router, so nothing else can interfere."""
+    app = FastAPI()
+    app.include_router(designer_endpoints.router)
+    return TestClient(app)
+
+
+def test_offers_only_the_networks_the_designer_manifest_serves(client, tmp_path, monkeypatch):
+    """
+    The designer manifest is a curated subset, and an unserved entry is not part of
+    it. Both distinctions decide whether an edit stays deterministic.
+    """
+    manifest = tmp_path / "manifest_and.hocon"
+    manifest.write_text(DESIGNER_MANIFEST, encoding="utf-8")
+    monkeypatch.setenv(designer_endpoints.DESIGNER_MANIFEST_ENV_VAR, str(manifest))
+    monkeypatch.delenv(designer_endpoints.MCP_SERVERS_ENV_VAR, raising=False)
+
+    body = client.get("/api/v1/designer/references").json()
+
+    assert sorted(body["networks"]) == ["/generated/coffee_shop", "/industry/banking_ops"]
+
+
+def test_reports_the_mcp_servers_the_designer_was_given(client, tmp_path, monkeypatch):
+    """The designer reads its servers from a file, not from the OAuth connection store."""
+    mcp_info = tmp_path / "mcp_info.hocon"
+    mcp_info.write_text(MCP_INFO, encoding="utf-8")
+    monkeypatch.setenv(designer_endpoints.MCP_SERVERS_ENV_VAR, str(mcp_info))
+    monkeypatch.delenv(designer_endpoints.DESIGNER_MANIFEST_ENV_VAR, raising=False)
+
+    body = client.get("/api/v1/designer/references").json()
+
+    assert body["mcp_servers"] == ["https://mcp.example.com/mcp"]
+
+
+@pytest.mark.parametrize("missing", ["manifest", "mcp"])
+def test_an_unreadable_source_empties_only_its_own_half(client, tmp_path, monkeypatch, missing):
+    """
+    Half the palette is better than none, and better than a 500: the toolbox section
+    is served by a different route and stays usable either way.
+    """
+    manifest = tmp_path / "manifest_and.hocon"
+    manifest.write_text(DESIGNER_MANIFEST, encoding="utf-8")
+    mcp_info = tmp_path / "mcp_info.hocon"
+    mcp_info.write_text(MCP_INFO, encoding="utf-8")
+
+    monkeypatch.setenv(
+        designer_endpoints.DESIGNER_MANIFEST_ENV_VAR,
+        "/nonexistent/manifest.hocon" if missing == "manifest" else str(manifest),
+    )
+    monkeypatch.setenv(
+        designer_endpoints.MCP_SERVERS_ENV_VAR,
+        "/nonexistent/mcp_info.hocon" if missing == "mcp" else str(mcp_info),
+    )
+
+    response = client.get("/api/v1/designer/references")
+
+    assert response.status_code == 200
+    body = response.json()
+    if missing == "manifest":
+        assert body["networks"] == []
+        assert body["mcp_servers"] != []
+    else:
+        assert body["networks"] != []
+        assert body["mcp_servers"] == []

--- a/tests/nsflow/test_neuro_san_facade.py
+++ b/tests/nsflow/test_neuro_san_facade.py
@@ -1,0 +1,281 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for the neuro-san-shaped API facade.
+
+The load-bearing test here is `test_route_priority_matrix`. The facade's
+``/api/v1/{agent_name:path}/connectivity`` occupies the same position as existing
+routes whose FIRST segment is a literal (``/api/v1/connectivity/{network_name}``
+and friends), so route registration order is what keeps existing consumers
+working. If anyone registers the facade earlier, or makes the converter
+non-greedy, these tests fail loudly instead of the editor silently 404-ing.
+"""
+
+import json
+from typing import Any
+from typing import Dict
+from typing import List
+
+import pytest
+from fastapi.testclient import TestClient
+
+import nsflow.backend.utils.agentutils.ns_websocket_utils as nw
+from nsflow.backend.api.router import router as nsflow_router
+from nsflow.backend.api.v1.neuro_san import agent as facade_agent
+from nsflow.backend.main import app
+from nsflow.backend.utils.tools.ns_configs_registry import NsConfigsRegistry
+
+client = TestClient(app)
+
+# What a neuro-san `connectivity` call returns: a list of nodes, each naming its
+# origin and the tools reachable from it. This is the shape the facade must pass
+# through untouched.
+FAKE_CONNECTIVITY: Dict[str, Any] = {
+    "connectivity_info": [
+        {"origin": "frontman", "tools": ["barista", "loyalty"]},
+        {"origin": "barista", "tools": []},
+        {"origin": "loyalty", "tools": ["rewards_db"]},
+    ]
+}
+
+FAKE_FUNCTION: Dict[str, Any] = {
+    "function": {
+        "description": "Takes coffee orders",
+        "parameters": {"type": "object", "properties": {}},
+    }
+}
+
+
+# One turn of neuro-san's streaming chat: several {"response": {...}} dicts, which
+# is what AgentSession.streaming_chat yields and what a neuro-san server sends.
+FAKE_CHAT_CHUNKS = [
+    {"response": {"type": "AGENT_PROGRESS", "text": "thinking"}},
+    {"response": {"type": "AI", "text": "One coffee coming up"}},
+]
+
+
+class _FakeSession:
+    """Stands in for a neuro-san AgentSession."""
+
+    def __init__(self):
+        self.streaming_chat_requests: List[Dict[str, Any]] = []
+
+    def connectivity(self, _data: Dict[str, Any]) -> Dict[str, Any]:
+        """Answer a connectivity call."""
+        return FAKE_CONNECTIVITY
+
+    def function(self, _data: Dict[str, Any]) -> Dict[str, Any]:
+        """Answer a function call."""
+        return FAKE_FUNCTION
+
+    def streaming_chat(self, chat_request: Dict[str, Any]):
+        """Record what was sent, then yield a turn's worth of responses."""
+        self.streaming_chat_requests.append(chat_request)
+        yield from FAKE_CHAT_CHUNKS
+
+
+@pytest.fixture(autouse=True)
+def _fake_neuro_san(monkeypatch):
+    """
+    Give every code path a working config and a session that answers locally, so
+    these tests exercise nsflow's routing and shaping rather than a live server.
+    """
+    NsConfigsRegistry.set_current("http", "localhost", 8080)
+    monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: _FakeSession())
+
+
+def test_facade_connectivity_returns_raw_neuro_san_shape():
+    """The facade passes neuro-san's connectivity_info through untransformed."""
+    response = client.get("/api/v1/my_net/connectivity")
+    assert response.status_code == 200
+    assert response.json() == FAKE_CONNECTIVITY
+
+
+def test_facade_connectivity_supports_nested_agent_names():
+    """
+    Generated networks are named `<subdir>/<name>` (frontend toServedNetworkPath),
+    so the path converter must be greedy or every generated network 404s.
+    """
+    response = client.get("/api/v1/generated/coffee_shop/connectivity")
+    assert response.status_code == 200
+    assert response.json() == FAKE_CONNECTIVITY
+
+
+def test_facade_function_returns_raw_neuro_san_shape():
+    """The facade passes neuro-san's function description through untransformed."""
+    response = client.get("/api/v1/my_net/function")
+    assert response.status_code == 200
+    assert response.json() == FAKE_FUNCTION
+
+
+def test_existing_connectivity_endpoint_still_returns_react_flow_shape():
+    """
+    The pre-existing endpoint transforms connectivity into React Flow nodes/edges.
+    The facade must not have changed it: this is the regression guard for its
+    current consumers (AgentFlow.tsx, useAgentFlowData.ts, and tests).
+    """
+    response = client.get("/api/v1/connectivity/my_net")
+    assert response.status_code == 200
+    body = response.json()
+    assert "nodes" in body and "edges" in body
+    assert "connectivity_info" not in body
+
+
+@pytest.mark.parametrize(
+    "path,expect_facade",
+    [
+        # facade wins: the second segment is the literal operation name
+        ("/api/v1/my_net/connectivity", True),
+        ("/api/v1/generated/coffee_shop/connectivity", True),
+        # existing wins: the first segment is a literal nsflow route
+        ("/api/v1/connectivity/my_net", False),
+        ("/api/v1/connectivity/generated/coffee_shop", False),
+        # ambiguous (a network actually named "connectivity"): existing must win,
+        # because it was registered first and its consumers predate the facade
+        ("/api/v1/connectivity/connectivity", False),
+    ],
+)
+def test_route_priority_matrix(path, expect_facade):
+    """
+    `connectivity_info` in the body means the facade handled it; `nodes`/`edges`
+    means the existing endpoint did.
+    """
+    response = client.get(path)
+    assert response.status_code == 200, f"{path} returned {response.status_code}"
+    body = response.json()
+    if expect_facade:
+        assert "connectivity_info" in body, f"{path} should have hit the facade, got {sorted(body)}"
+    else:
+        assert "nodes" in body, f"{path} should have hit the existing endpoint, got {sorted(body)}"
+
+
+def test_facade_is_the_last_registered_router():
+    """
+    Guards the ordering invariant directly, so a reordering fails here with a clear
+    message rather than as a confusing 404 in one of the cases above.
+
+    Asserted against the aggregate router's own route list, which is in
+    registration order. (Not app.openapi()["paths"] -- that dict is not ordered by
+    registration, so it cannot answer this question.)
+    """
+    included = [r for r in nsflow_router.routes if type(r).__name__ == "_IncludedRouter"]
+    assert included, "expected the aggregate router to be built from included routers"
+
+    last_router = included[-1].original_router
+    assert last_router is facade_agent.router, (
+        "the neuro-san facade must be the LAST router registered in "
+        "nsflow/backend/api/router.py, otherwise its greedy "
+        "/api/v1/{agent_name:path}/... routes shadow existing endpoints"
+    )
+
+
+def test_facade_exposes_exactly_the_expected_paths():
+    """A new facade route is a deliberate act; this pins the current surface."""
+    paths = sorted(r.path for r in facade_agent.router.routes)
+    assert paths == [
+        "/api/v1/{agent_name:path}/connectivity",
+        "/api/v1/{agent_name:path}/function",
+        "/api/v1/{agent_name:path}/streaming_chat",
+    ]
+
+
+def test_streaming_chat_emits_newline_delimited_json():
+    """
+    Each line is one neuro-san chat response verbatim, which is the shape
+    ui-common's chatMessageFromChunk parses (JSON.parse(line).response).
+    """
+    response = client.post("/api/v1/my_net/streaming_chat", json={"user_message": {"text": "a coffee please"}})
+    assert response.status_code == 200
+
+    lines = [line for line in response.text.split("\n") if line.strip()]
+    assert [json.loads(line) for line in lines] == FAKE_CHAT_CHUNKS
+
+
+def test_streaming_chat_supports_nested_agent_names():
+    """Generated networks are nested paths, so streaming_chat needs the greedy converter too."""
+    response = client.post("/api/v1/generated/coffee_shop/streaming_chat", json={"user_message": {"text": "hi"}})
+    assert response.status_code == 200
+    assert json.loads(response.text.split("\n")[0]) == FAKE_CHAT_CHUNKS[0]
+
+
+def test_streaming_chat_passes_the_request_through_untouched(monkeypatch):
+    """Everything except sly_data reaches neuro-san exactly as the client sent it."""
+    captured = _FakeSession()
+    monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: captured)
+
+    sent = {
+        "user_message": {"text": "a coffee please"},
+        "chat_filter": {"chat_filter_type": "MAXIMAL"},
+        "chat_context": {"some": "context"},
+    }
+    client.post("/api/v1/my_net/streaming_chat", json=sent)
+
+    assert len(captured.streaming_chat_requests) == 1
+    forwarded = captured.streaming_chat_requests[0]
+    assert forwarded["user_message"] == sent["user_message"]
+    assert forwarded["chat_filter"] == sent["chat_filter"]
+    assert forwarded["chat_context"] == sent["chat_context"]
+
+
+def test_streaming_chat_strips_redaction_sentinels_from_sly_data(monkeypatch):
+    """
+    The UI round-trips the last streamed sly_data, which the backend surfaces with
+    credentials masked. Those literal "***redacted***" values must never be
+    forwarded to the agent as if they were real secrets.
+    """
+    captured = _FakeSession()
+    monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: captured)
+
+    client.post(
+        "/api/v1/my_net/streaming_chat",
+        json={
+            "user_message": {"text": "hi"},
+            "sly_data": {
+                "agent_network_name": "coffee_shop",
+                "http_headers": {"https://mcp.example.com": {"Authorization": nw.REDACTED_VALUE}},
+            },
+        },
+    )
+
+    forwarded_sly_data = captured.streaming_chat_requests[0]["sly_data"]
+    # Non-credential keys pass through
+    assert forwarded_sly_data["agent_network_name"] == "coffee_shop"
+    # The redaction sentinel does not
+    headers = forwarded_sly_data.get("http_headers", {}).get("https://mcp.example.com", {})
+    assert headers.get("Authorization") != nw.REDACTED_VALUE
+
+
+def test_streaming_chat_injects_mcp_auth_headers(monkeypatch):
+    """
+    The HTTP route must not be a way around the MCP token injection the WebSocket
+    path performs, or it becomes an auth bypass.
+    """
+    captured = _FakeSession()
+    monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: captured)
+
+    injected = []
+
+    async def _fake_inject(_self, sly_data):
+        injected.append(sly_data)
+        sly_data["http_headers"] = {"https://mcp.example.com": {"Authorization": "Bearer real-token"}}
+
+    monkeypatch.setattr(nw.NsWebsocketUtils, "inject_mcp_auth_headers", _fake_inject)
+
+    client.post("/api/v1/my_net/streaming_chat", json={"user_message": {"text": "hi"}})
+
+    assert injected, "inject_mcp_auth_headers was never called for the HTTP chat route"
+    forwarded = captured.streaming_chat_requests[0]["sly_data"]
+    assert forwarded["http_headers"]["https://mcp.example.com"]["Authorization"] == "Bearer real-token"

--- a/tests/nsflow/test_neuro_san_facade.py
+++ b/tests/nsflow/test_neuro_san_facade.py
@@ -95,6 +95,11 @@ def _fake_neuro_san(monkeypatch):
     """
     NsConfigsRegistry.set_current("http", "localhost", 8080)
     monkeypatch.setattr(nw.NsWebsocketUtils, "create_agent_session", lambda self: _FakeSession())
+    yield
+    # The registry holds its config on the class, so without this the config set here
+    # outlives the module and whichever test file runs next inherits it. Reset puts it
+    # back to how it starts the process, which is what the rest of the suite expects.
+    NsConfigsRegistry.reset()
 
 
 def test_facade_connectivity_returns_raw_neuro_san_shape():

--- a/tests/nsflow/test_toolbox_endpoints.py
+++ b/tests/nsflow/test_toolbox_endpoints.py
@@ -1,0 +1,133 @@
+# Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for GET /api/v1/toolbox, which feeds the editor palette.
+
+What matters is the choice between the two toolboxes: the designer's curated subset
+when AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE points somewhere usable, and the
+runtime toolbox otherwise. Offering tools the designer will not accept is invisible
+from the tool list alone, which is why the response reports its ``source``.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nsflow.backend.api.v1 import toolbox_endpoints
+
+DESIGNER_ENV_VAR = toolbox_endpoints.DESIGNER_TOOLBOX_ENV_VAR
+
+# A stand-in for the designer's toolbox info file: one entry with a class and one
+# without, so the coded_tool/langchain_tool split is exercised.
+DESIGNER_TOOLBOX = """
+{
+    "drag_me": {
+        "class": "some_module.DragMe",
+        "description": "A coded tool the designer may pick.",
+    },
+    "a_toolkit": {
+        "description": "A toolkit with no class of its own.",
+    },
+}
+"""
+
+
+@pytest.fixture(name="client")
+def client_fixture() -> TestClient:
+    """An app serving only the toolbox router, so nothing else can interfere."""
+    app = FastAPI()
+    app.include_router(toolbox_endpoints.router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_toolbox_cache():
+    """The route caches its load process-wide, so each test starts and ends clean."""
+    toolbox_endpoints._TOOLBOX_CACHE.clear()  # pylint: disable=protected-access
+    yield
+    toolbox_endpoints._TOOLBOX_CACHE.clear()  # pylint: disable=protected-access
+
+
+@pytest.fixture(name="designer_toolbox_file")
+def designer_toolbox_file_fixture(tmp_path) -> str:
+    """Write the stand-in designer toolbox to a temp file and return its path."""
+    path = tmp_path / "agent_network_designer_toolbox_info.hocon"
+    path.write_text(DESIGNER_TOOLBOX, encoding="utf-8")
+    return str(path)
+
+
+def test_serves_the_designer_toolbox_when_configured(client, designer_toolbox_file, monkeypatch):
+    """
+    The designer's curated subset wins, since the designer canonicalises every edit
+    and only knows the tools in this file. Each entry carries what the palette needs
+    to label and group it.
+    """
+    monkeypatch.setenv(DESIGNER_ENV_VAR, designer_toolbox_file)
+
+    body = client.get("/api/v1/toolbox").json()
+
+    assert body["source"] == "agent_network_designer"
+    assert body["tools"] == [
+        {
+            "name": "a_toolkit",
+            "description": "A toolkit with no class of its own.",
+            "class": None,
+            "display_as": "langchain_tool",
+        },
+        {
+            "name": "drag_me",
+            "description": "A coded tool the designer may pick.",
+            "class": "some_module.DragMe",
+            "display_as": "coded_tool",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "designer_path",
+    [
+        pytest.param(None, id="unset"),
+        pytest.param("/nonexistent/toolbox.hocon", id="missing file"),
+    ],
+)
+def test_falls_back_to_the_runtime_toolbox(client, monkeypatch, designer_path):
+    """
+    With no usable designer toolbox, the runtime toolbox is a better answer than an
+    empty palette, and a stale path should not take the palette down.
+    """
+    if designer_path is None:
+        monkeypatch.delenv(DESIGNER_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(DESIGNER_ENV_VAR, designer_path)
+
+    body = client.get("/api/v1/toolbox").json()
+
+    # Only the choice of source is asserted. Which tools neuro-san ships in its
+    # built-in toolbox is neuro-san's business and changes between releases, so
+    # naming one here would make this test fail for a reason it does not care about.
+    assert body["source"] == "runtime"
+
+
+def test_a_failed_load_is_not_cached_so_a_later_request_heals(client, designer_toolbox_file, monkeypatch):
+    """
+    The cache avoids re-parsing HOCON per request, but caching a failure would pin
+    the wrong toolbox until the server restarted.
+    """
+    monkeypatch.setenv(DESIGNER_ENV_VAR, "/nonexistent/toolbox.hocon")
+    assert client.get("/api/v1/toolbox").json()["source"] == "runtime"
+
+    monkeypatch.setenv(DESIGNER_ENV_VAR, designer_toolbox_file)
+    assert client.get("/api/v1/toolbox").json()["source"] == "agent_network_designer"


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Three additive backend changes.

**`GET /api/v1/toolbox`** returns the toolbox tools, preferring the designer's curated set from `AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE` via neuro-san's `ToolboxInfoRestorer`, and falling back to the runtime toolbox when that file is absent. Only a successful designer load is cached, so a missing or late-mounted file heals on the next request instead of pinning the fallback for the process lifetime.

**`GET /api/v1/designer/references`** returns the other agent networks and MCP servers that can be referenced, read from `AGENT_NETWORK_DESIGNER_MANIFEST_FILE` and `MCP_SERVERS_INFO_FILE`.

Both read the environment variables studio already sets rather than nsflow keeping its own copy of the list. Studio's `run.py` exports `AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE` and `MCP_SERVERS_INFO_FILE` but not `AGENT_NETWORK_DESIGNER_MANIFEST_FILE`, so the manifest keeps one fallback to the path studio ships in its own repo, used only when that file is actually there. Raised upstream as cognizant-ai-lab/neuro-san-studio#1402 so the fallback can come out.

**A neuro-san-shaped agent facade**, so a client can use neuro-san's own HTTP contract. The routes return neuro-san's payload verbatim rather than through hand-written models: copying an external schema by hand makes every field optional, so it validates nothing, and it silently drops fields the moment upstream adds one.

## Impact

Additive. No existing endpoint changes path or shape.

One ordering constraint carries real risk, so it is documented in code and asserted by a test. The facade routes on `/api/v1/{agent_name:path}/...`, a greedy path parameter where nsflow's own routes have a literal first segment such as `/api/v1/connectivity/{network_name}`. Starlette matches in registration order, so the facade must be registered last. Moving that line up, or adding a router below it, would silently shadow existing endpoints with no error at all.

Why the reference endpoints matter: the client had no way to know which references the designer accepts, so it could offer one the designer then rejects. A rejected reference does not fail in isolation, it poisons every later edit of that network.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

24 new tests, including a route-priority matrix guarding the registration order. Full Python suite 194 passing. Both quality gates 10.00/10. No new dependencies: everything uses restorers neuro-san already provides.

Verified against a live studio instance: `designer/references` returned exactly the 21 networks and 3 MCP servers the designer's own validation error listed, and excluded the one it rejects.

Stacked on #287.

---