### PR TITLE
Rebuild the editor on a browser data layer

### DIFF
--- a/nsflow/frontend/src/components/AgentContextMenu.tsx
+++ b/nsflow/frontend/src/components/AgentContextMenu.tsx
@@ -14,8 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect, useRef } from "react";
-import { FaEdit, FaTrash, FaPlus, FaCopy, FaEye } from "react-icons/fa";
+/**
+ * Right-click actions for an agent on the editor canvas.
+ *
+ * Styled from the MUI theme rather than with fixed colours. It used to hardcode dark
+ * Tailwind greys and white text, which is unreadable under the light theme.
+ */
+
+import { useEffect, useRef } from "react";
+import {
+  Box,
+  Divider,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+  MenuList,
+  Paper,
+  Typography,
+  alpha,
+  useTheme,
+} from "@mui/material";
+import DuplicateIcon from "@mui/icons-material/ContentCopy";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import AddChildIcon from "@mui/icons-material/Add";
+
+/** Roughly the menu's own size, used to keep it inside the viewport. */
+const MENU_WIDTH = 200;
+const MENU_HEIGHT = 210;
 
 interface AgentContextMenuProps {
   visible: boolean;
@@ -27,10 +53,26 @@ interface AgentContextMenuProps {
   onDuplicate: (nodeId: string) => void;
   onAddChild: (nodeId: string) => void;
   onClose: () => void;
-  enableEditing?: boolean;
+  /**
+   * Whether this agent may be given a down-chain agent. False for a toolbox tool or
+   * an external reference, which cannot have children: such a network fails
+   * validation and the designer LLM is summoned to repair it, so hiding the action is
+   * what keeps a new user from building that by accident.
+   */
+  canAddChild?: boolean;
+  /**
+   * Whether this agent may be duplicated. False for the frontman: a copy inherits the
+   * original's parents, and the frontman has none, so the copy would be a second root.
+   */
+  canDuplicate?: boolean;
+  /**
+   * Whether this agent may be deleted. False for the frontman, which is the network's
+   * entry point and has no parent to promote its children to.
+   */
+  canDelete?: boolean;
 }
 
-const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
+const AgentContextMenu = ({
   visible,
   x,
   y,
@@ -40,10 +82,12 @@ const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   onDuplicate,
   onAddChild,
   onClose,
-  enableEditing = false,
-}) => {
+  canAddChild = true,
+  canDuplicate = true,
+  canDelete = true,
+}: AgentContextMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
-  const canEdit = !!enableEditing;
+  const theme = useTheme();
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -79,93 +123,108 @@ const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
 
   if (!visible) return null;
 
-  // Adjust position to keep menu within viewport
-  const adjustedX = Math.min(x, window.innerWidth - 200);
-  const adjustedY = Math.min(y, window.innerHeight - 200);
+  // The frontman is checked first: it is the more specific case, and saying "cannot
+  // have down-chain agents" about it would be wrong as well as unhelpful.
+  const hint = !canDelete
+    ? "The frontman is the network's entry point, so it cannot be removed or copied."
+    : !canAddChild
+      ? "This agent cannot have down-chain agents."
+      : undefined;
 
-  // Build menu items based on flag
-  const menuItems = canEdit
-    ? [
-        {
-          icon: FaEdit,
-          label: "Edit Agent",
-          onClick: () => onEdit(nodeId),
-          className: "hover:bg-blue-600",
-        },
-        {
-          icon: FaCopy,
-          label: "Duplicate",
-          onClick: () => onDuplicate(nodeId),
-          className: "hover:bg-green-600",
-        },
-        {
-          icon: FaPlus,
-          label: "Add Child Agent",
-          onClick: () => onAddChild(nodeId),
-          className: "hover:bg-purple-600",
-        },
-        {
-          icon: FaTrash,
-          label: "Delete Agent",
-          onClick: () => onDelete(nodeId),
-          className: "hover:bg-red-600 text-red-300",
-          divider: true,
-        },
-      ]
-    : [
-        {
-          icon: FaEye,
-          label: "View Agent",
-          onClick: () => onEdit(nodeId),    // opens panel in read-only (since enableEditing=false there)
-          className: "hover:bg-gray-700",
-        },
-      ];
+  // Keep the menu within the viewport
+  const adjustedX = Math.min(x, window.innerWidth - MENU_WIDTH);
+  const adjustedY = Math.min(y, window.innerHeight - MENU_HEIGHT);
+
+  const actions = [
+    { icon: <EditIcon fontSize="small" />, label: "Edit Agent", onClick: () => onEdit(nodeId) },
+    ...(canDuplicate
+      ? [
+          {
+            icon: <DuplicateIcon fontSize="small" />,
+            label: "Duplicate",
+            onClick: () => onDuplicate(nodeId),
+          },
+        ]
+      : []),
+    ...(canAddChild
+      ? [
+          {
+            icon: <AddChildIcon fontSize="small" />,
+            label: "Add Child Agent",
+            onClick: () => onAddChild(nodeId),
+          },
+        ]
+      : []),
+  ];
 
   return (
-    <div
+    <Paper
       ref={menuRef}
-      className="fixed z-50 bg-gray-800 border border-gray-600 rounded-lg shadow-xl min-w-[160px]"
-      style={{
+      elevation={8}
+      sx={{
+        position: "fixed",
         left: adjustedX,
         top: adjustedY,
+        zIndex: theme.zIndex.tooltip,
+        minWidth: MENU_WIDTH,
+        borderRadius: 2,
+        border: `1px solid ${theme.palette.divider}`,
+        overflow: "hidden",
       }}
     >
-      {/* Header */}
-      <div className="px-3 py-2 border-b border-gray-600 bg-gray-750">
-        <div className="text-xs text-gray-300 font-medium">Agent Actions</div>
+      <Box
+        sx={{
+          px: 1.5,
+          py: 1,
+          borderBottom: `1px solid ${theme.palette.divider}`,
+          backgroundColor: alpha(theme.palette.primary.main, 0.08),
+        }}
+      >
+        <Typography variant="caption" sx={{ fontWeight: 600, display: "block" }}>
+          Agent Actions
+        </Typography>
         {nodeId && (
-          <div className="text-xs text-gray-400 truncate">{nodeId}</div>
+          <Typography variant="caption" color="text.secondary" noWrap sx={{ display: "block" }}>
+            {nodeId}
+          </Typography>
         )}
-      </div>
+      </Box>
 
-      {/* Menu Items */}
-      <div className="py-1">
-        {menuItems.map((item, index) => (
-          <React.Fragment key={index}>
-            {item.divider && (
-              <div className="border-t border-gray-600 my-1" />
-            )}
-            <button
-              onClick={item.onClick}
-              className={`
-                w-full flex items-center px-3 py-2 text-sm text-white transition-colors
-                ${item.className || "hover:bg-gray-700"}
-              `}
-            >
-              <item.icon className="mr-3 text-sm" />
-              {item.label}
-            </button>
-          </React.Fragment>
+      <MenuList dense disablePadding sx={{ py: 0.5 }}>
+        {actions.map((action) => (
+          <MenuItem key={action.label} onClick={action.onClick}>
+            <ListItemIcon sx={{ color: theme.palette.text.secondary }}>{action.icon}</ListItemIcon>
+            <ListItemText primary={action.label} />
+          </MenuItem>
         ))}
-      </div>
 
-      {/* Footer tip */}
-      <div className="px-3 py-2 border-t border-gray-600 bg-gray-750">
-        <div className="text-xs text-gray-400">
-          Right-click for context menu
-        </div>
-      </div>
-    </div>
+        {canDelete && (
+          <>
+            <Divider sx={{ my: 0.5 }} />
+            <MenuItem
+              onClick={() => onDelete(nodeId)}
+              sx={{
+                color: theme.palette.error.main,
+                "&:hover": { backgroundColor: alpha(theme.palette.error.main, 0.12) },
+              }}
+            >
+              <ListItemIcon sx={{ color: theme.palette.error.main }}>
+                <DeleteIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary="Delete Agent" />
+            </MenuItem>
+          </>
+        )}
+      </MenuList>
+
+      {hint && (
+        <Box sx={{ px: 1.5, py: 1, borderTop: `1px solid ${theme.palette.divider}` }}>
+          <Typography variant="caption" color="text.secondary">
+            {hint}
+          </Typography>
+        </Box>
+      )}
+    </Paper>
   );
 };
 

--- a/nsflow/frontend/src/components/ChatPanel.tsx
+++ b/nsflow/frontend/src/components/ChatPanel.tsx
@@ -65,18 +65,24 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
   const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
   const [chatHandoffHighlight, setChatHandoffHighlight] = useState(false);
 
-  useEffect(
-    () =>
-      onChatFocusRequested(() => {
-        messageInputRef.current?.focus();
-        messageInputRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-        // A brief ring, because focus alone is easy to miss when the user's eyes are
-        // still on the dialog that just closed.
-        setChatHandoffHighlight(true);
-        setTimeout(() => setChatHandoffHighlight(false), 1600);
-      }),
-    []
-  );
+  useEffect(() => {
+    let ringTimer: number | undefined;
+    const unsubscribe = onChatFocusRequested(() => {
+      messageInputRef.current?.focus();
+      messageInputRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      // A brief ring, because focus alone is easy to miss when the user's eyes are
+      // still on the dialog that just closed.
+      setChatHandoffHighlight(true);
+      window.clearTimeout(ringTimer);
+      ringTimer = window.setTimeout(() => setChatHandoffHighlight(false), 1600);
+    });
+    return () => {
+      // Cleared as well as unsubscribed, so a panel that unmounts inside the ring's
+      // 1.6s does not leave a timer running against a component that is gone.
+      window.clearTimeout(ringTimer);
+      unsubscribe();
+    };
+  }, []);
 
   const { apiUrl } = useApiPort();
   const { theme } = useTheme();

--- a/nsflow/frontend/src/components/ChatPanel.tsx
+++ b/nsflow/frontend/src/components/ChatPanel.tsx
@@ -47,6 +47,7 @@ import {
   InsertDriveFile as FileIcon,
 } from "@mui/icons-material";
 import { useApiPort } from "../context/ApiPortContext";
+import { onChatFocusRequested } from "../utils/focusChat";
 import { useChatControls } from "../hooks/useChatControls";
 import { useChatContext } from "../context/ChatContext";
 import { getFeatureFlags } from "../utils/config";
@@ -59,6 +60,24 @@ import { Mp3Encoder } from "@breezystack/lamejs";
 import { useSlyDataCache } from "../hooks/useSlyDataCache";
 
 const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
+  // Focused when the editor hands over ("describe it in chat instead"). The input
+  // already autoFocuses on load; this is for the handover, which happens later.
+  const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const [chatHandoffHighlight, setChatHandoffHighlight] = useState(false);
+
+  useEffect(
+    () =>
+      onChatFocusRequested(() => {
+        messageInputRef.current?.focus();
+        messageInputRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        // A brief ring, because focus alone is easy to miss when the user's eyes are
+        // still on the dialog that just closed.
+        setChatHandoffHighlight(true);
+        setTimeout(() => setChatHandoffHighlight(false), 1600);
+      }),
+    []
+  );
+
   const { apiUrl } = useApiPort();
   const { theme } = useTheme();
   const { viteUseSpeech } = getFeatureFlags();
@@ -966,9 +985,21 @@ const ChatPanel = ({ title = "Chat" }: { title?: string }) => {
             {/* Message input */}
             <Box sx={{ display: "flex", gap: 2, alignItems: "flex-end" }}>
               {/* Message box wrapper with anchored attach icon */}
-              <Box sx={{ flexGrow: 1, position: "relative" }}>
+              <Box
+                sx={{
+                  flexGrow: 1,
+                  position: "relative",
+                  borderRadius: 1,
+                  transition: "box-shadow 300ms",
+                  // Set briefly when the editor hands over, so the eye follows.
+                  ...(chatHandoffHighlight && {
+                    boxShadow: (theme) => `0 0 0 3px ${alpha(theme.palette.primary.main, 0.55)}`,
+                  }),
+                }}
+              >
                 <TextField
                   autoFocus
+                  inputRef={messageInputRef}
                   multiline
                   minRows={3}
                   placeholder="Type a message..."

--- a/nsflow/frontend/src/components/EdgeContextMenu.tsx
+++ b/nsflow/frontend/src/components/EdgeContextMenu.tsx
@@ -1,0 +1,131 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Right-click actions for a connection between two agents.
+ *
+ * Deleting a connection is how a network gets rearranged, so it needs to be as
+ * reachable as deleting an agent. This is separate from the node menu because the
+ * two share no actions.
+ */
+
+import { useEffect, useRef } from "react";
+import {
+  Box,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+  MenuList,
+  Paper,
+  Typography,
+  alpha,
+  useTheme,
+} from "@mui/material";
+import DisconnectIcon from "@mui/icons-material/LinkOff";
+
+const MENU_WIDTH = 220;
+const MENU_HEIGHT = 120;
+
+interface EdgeContextMenuProps {
+  visible: boolean;
+  x: number;
+  y: number;
+  source: string;
+  target: string;
+  onDelete: (source: string, target: string) => void;
+  onClose: () => void;
+}
+
+const EdgeContextMenu = ({
+  visible,
+  x,
+  y,
+  source,
+  target,
+  onDelete,
+  onClose,
+}: EdgeContextMenuProps) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (!visible) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) onClose();
+    };
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscapeKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscapeKey);
+    };
+  }, [visible, onClose]);
+
+  if (!visible) return null;
+
+  return (
+    <Paper
+      ref={menuRef}
+      elevation={8}
+      sx={{
+        position: "fixed",
+        left: Math.min(x, window.innerWidth - MENU_WIDTH),
+        top: Math.min(y, window.innerHeight - MENU_HEIGHT),
+        zIndex: theme.zIndex.tooltip,
+        minWidth: MENU_WIDTH,
+        borderRadius: 2,
+        border: `1px solid ${theme.palette.divider}`,
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        sx={{
+          px: 1.5,
+          py: 1,
+          borderBottom: `1px solid ${theme.palette.divider}`,
+          backgroundColor: alpha(theme.palette.primary.main, 0.08),
+        }}
+      >
+        <Typography variant="caption" sx={{ fontWeight: 600, display: "block" }}>
+          Connection
+        </Typography>
+        <Typography variant="caption" color="text.secondary" noWrap sx={{ display: "block" }}>
+          {source} → {target}
+        </Typography>
+      </Box>
+
+      <MenuList dense disablePadding sx={{ py: 0.5 }}>
+        <MenuItem
+          onClick={() => onDelete(source, target)}
+          sx={{
+            color: theme.palette.error.main,
+            "&:hover": { backgroundColor: alpha(theme.palette.error.main, 0.12) },
+          }}
+        >
+          <ListItemIcon sx={{ color: theme.palette.error.main }}>
+            <DisconnectIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText primary="Delete connection" />
+        </MenuItem>
+      </MenuList>
+    </Paper>
+  );
+};
+
+export default EdgeContextMenu;

--- a/nsflow/frontend/src/components/EditableAgentNode.tsx
+++ b/nsflow/frontend/src/components/EditableAgentNode.tsx
@@ -16,6 +16,7 @@ limitations under the License.
 
 import React from "react";
 import { Handle, Position, NodeProps, Node } from "@xyflow/react";
+import { alpha, useTheme } from "@mui/material/styles";
 import { FaRobot, FaCog, FaQuestionCircle } from "react-icons/fa";
 
 // The index signature is what @xyflow/react 12 requires of a node's data
@@ -25,6 +26,8 @@ interface EditableAgentNodeData extends Record<string, unknown> {
   instructions?: string;
   is_defined?: boolean;
   selected?: boolean;
+  /** True while a drag is over this agent, so a drop would attach to it. */
+  is_drop_target?: boolean;
   network_name?: string;
   depth?: number;
 }
@@ -33,60 +36,101 @@ interface EditableAgentNodeData extends Record<string, unknown> {
 const EditableAgentNode: React.FC<NodeProps<Node<EditableAgentNodeData>>> = ({ data, selected }) => {
   const isSelected = data.selected || selected;
   const isDefined = data.is_defined !== false; // Default to true if not specified
+  // Set while something from the palette is being dragged over this agent. It has to
+  // outrank the selected styling: during a drag, what the drop will attach to is the
+  // only thing the user is looking for.
+  const isDropTarget = data.is_drop_target === true;
+  const theme = useTheme();
+
+  // Colours come from the theme rather than fixed Tailwind greys. The card used to be
+  // dark-only — bg-gray-800 with text-white — and the selected state tinted it with a
+  // near-transparent blue, so under the light theme a selected agent was white text
+  // on a white canvas.
+  const borderColor = isDropTarget
+    ? theme.palette.success.main
+    : !isDefined
+      ? theme.palette.warning.main
+      : isSelected
+        ? theme.palette.primary.main
+        : theme.palette.divider;
+  const backgroundColor = isDropTarget
+    ? alpha(theme.palette.success.main, 0.18)
+    : !isDefined
+      ? alpha(theme.palette.warning.main, 0.14)
+      : isSelected
+        ? alpha(theme.palette.primary.main, 0.14)
+        : theme.palette.background.paper;
 
   return (
     <div 
       className={`
         relative px-4 py-3 rounded-lg shadow-lg border-2 transition-all duration-200
-        ${isSelected 
-          ? 'border-blue-400 bg-blue-900/20 shadow-blue-400/50' 
-          : 'border-gray-600 bg-gray-800 hover:border-gray-500'
-        }
-        ${isDefined ? '' : 'border-orange-500 bg-orange-900/20'}
+        ${isDropTarget ? 'scale-105' : ''}
         min-w-[150px] max-w-[250px]
       `}
+      style={{ borderColor, backgroundColor, color: theme.palette.text.primary }}
     >
-      {/* Selection indicator */}
-      {isSelected && (
-        <div className="absolute -inset-1 bg-blue-400/20 rounded-lg animate-pulse" />
-      )}
+      {/* Drop target indicator, and selection when nothing is being dragged */}
+      {isDropTarget ? (
+        <div className="absolute -inset-1.5 rounded-lg ring-2 ring-emerald-400 bg-emerald-400/20 animate-pulse" />
+      ) : isSelected ? (
+        <div
+          className="absolute -inset-1 rounded-lg animate-pulse"
+          style={{ backgroundColor: alpha(theme.palette.primary.main, 0.2) }}
+        />
+      ) : null}
 
       {/* Node content */}
       <div className="relative z-10">
         {/* Header */}
         <div className="flex items-center space-x-2 mb-2">
           {isDefined ? (
-            <FaRobot className="text-blue-400 flex-shrink-0" size={16} />
+            <FaRobot className="flex-shrink-0" size={16} style={{ color: theme.palette.primary.main }} />
           ) : (
-            <FaQuestionCircle className="text-orange-400 flex-shrink-0" size={16} />
+            <FaQuestionCircle className="flex-shrink-0" size={16} style={{ color: theme.palette.warning.main }} />
           )}
-          <h3 className="text-white font-medium text-sm truncate flex-1">
+          <h3
+            className="font-medium text-sm truncate flex-1"
+            style={{ color: theme.palette.text.primary }}
+          >
             {data.label}
           </h3>
           {!isDefined && (
-            <FaCog className="text-orange-400 flex-shrink-0" size={12} />
+            <FaCog className="flex-shrink-0" size={12} style={{ color: theme.palette.warning.main }} />
           )}
         </div>
 
         {/* Instructions */}
         {data.instructions && (
-          <p className="text-gray-300 text-xs leading-relaxed line-clamp-3">
+          <p
+            className="text-xs leading-relaxed line-clamp-3"
+            style={{ color: theme.palette.text.secondary }}
+          >
             {data.instructions}
           </p>
         )}
 
         {/* Status indicators */}
         <div className="flex items-center justify-between mt-2">
-          <span className={`text-xs px-2 py-1 rounded ${
-            isDefined 
-              ? 'bg-green-600/20 text-green-300 border border-green-600/30' 
-              : 'bg-orange-600/20 text-orange-300 border border-orange-600/30'
-          }`}>
+          <span
+            className="text-xs px-2 py-1 rounded border"
+            style={{
+              backgroundColor: alpha(
+                isDefined ? theme.palette.success.main : theme.palette.warning.main,
+                0.18
+              ),
+              borderColor: alpha(
+                isDefined ? theme.palette.success.main : theme.palette.warning.main,
+                0.35
+              ),
+              color: isDefined ? theme.palette.success.main : theme.palette.warning.main,
+            }}
+          >
             {isDefined ? 'Defined' : 'Referenced'}
           </span>
           
           {data.depth !== undefined && (
-            <span className="text-xs text-gray-400">
+            <span className="text-xs" style={{ color: theme.palette.text.secondary }}>
               L{data.depth}
             </span>
           )}

--- a/nsflow/frontend/src/components/EditorAgentFlow.test.tsx
+++ b/nsflow/frontend/src/components/EditorAgentFlow.test.tsx
@@ -1,0 +1,197 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Does adding an agent from the palette actually reach the canvas?
+ *
+ * Reported symptom: an agent added by click or drop only appeared after a page
+ * reload, while the same agent added via right-click "Add Child" appeared at once.
+ * Both go through the same store write, so this mounts the real component and
+ * inspects what React Flow is handed, rather than reasoning about which of the two
+ * paths differs.
+ */
+
+import { ReactFlowProvider } from "@xyflow/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Captures the nodes React Flow is asked to render on each pass. */
+const renderedNodeIds: string[][] = [];
+
+vi.mock("@xyflow/react", async () => {
+  const actual = await vi.importActual<typeof import("@xyflow/react")>("@xyflow/react");
+  return {
+    ...actual,
+    ReactFlow: ({ nodes, children }: { nodes: { id: string }[]; children?: React.ReactNode }) => {
+      renderedNodeIds.push(nodes.map((node) => node.id));
+      return (
+        <div data-testid="rf">
+          {nodes.map((node) => (
+            <div key={node.id} data-testid={`node-${node.id}`} />
+          ))}
+          {children}
+        </div>
+      );
+    },
+    Background: () => null,
+    Controls: () => null,
+  };
+});
+
+vi.mock("../context/ApiPortContext", () => ({
+  useApiPort: () => ({ apiUrl: "http://api", isReady: true }),
+}));
+
+vi.mock("../context/ChatContext", () => ({
+  useChatContext: () => ({
+    getLatestNetworkPayload: () => undefined,
+    getLastProgressMessage: () => undefined,
+    getLastSlyDataMessage: () => undefined,
+    progressTick: 0,
+    slyDataTick: 0,
+    lastProgressAt: 0,
+    lastSlyDataAt: 0,
+    waitingForAgent: false,
+    targetNetwork: "",
+  }),
+}));
+
+// The agent editor panel pulls in the app's json-editor theming, which is not what
+// is under test here.
+vi.mock("./NetworkAgentEditorPanel", () => ({ default: () => null }));
+
+vi.mock("../utils/config", () => ({
+  getFeatureFlags: () => ({ pluginCruse: false }),
+  toServedNetworkPath: (name: string) => name,
+  getManifestUpdatePeriodMs: () => 1000,
+}));
+
+import EditorAgentFlow from "./EditorAgentFlow";
+import { useEditorNetworkStore } from "../state/editorNetworkStore";
+import type { AgentNetworkDefinitionEntry } from "../uiCommon";
+
+const NETWORK = "coffee_shop";
+
+const mount = () =>
+  render(
+    <ReactFlowProvider>
+      <EditorAgentFlow selectedNetwork={NETWORK} />
+    </ReactFlowProvider>
+  );
+
+describe("adding an agent from the palette", () => {
+  beforeEach(() => {
+    renderedNodeIds.length = 0;
+    localStorage.clear();
+    useEditorNetworkStore.getState().reset(NETWORK);
+    // A network with a frontman, so an added agent has something to attach to.
+    const seed: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: [], instructions: "Greet.", description: "Front" },
+    ];
+    useEditorNetworkStore.getState().applyEdit(NETWORK, seed);
+    // The round-trip is deliberately left broken (no body, so sendEditorUpdate
+    // throws and logs). The canvas must update from the optimistic local apply
+    // whatever the designer does, so a failing round-trip should not hide the edit.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, body: null, status: 200, statusText: "OK", json: async () => ({}) }))
+    );
+  });
+
+  it("renders the new agent without waiting for a reload", async () => {
+    mount();
+
+    await waitFor(() => expect(screen.getByTestId("node-frontman")).toBeTruthy());
+
+    // The palette notch adds an agent in one click; the seeded network already has
+    // a frontman, so the add button offers a plain agent.
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Add agent"));
+    });
+
+    // The store is the authority, so confirm the edit landed there first: if it did
+    // not, the failure is in the operation, not in the rendering.
+    await waitFor(() =>
+      expect(
+        useEditorNetworkStore.getState().entries[NETWORK]?.definition.map((entry) => entry.origin)
+      ).toContain("agent")
+    );
+
+    // ...and then that React Flow was actually handed it.
+    await waitFor(() => expect(screen.getByTestId("node-agent")).toBeTruthy());
+
+    // And that it STAYS. waitFor succeeds on a transient appearance, which is
+    // exactly what the bug looked like: renderFromStore added the node and a
+    // relayout scheduled in a requestAnimationFrame then wrote back a stale node
+    // list that no longer contained it. So let every queued frame and timer run,
+    // and check the last thing React Flow was actually given.
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 150)));
+    });
+
+    expect(renderedNodeIds[renderedNodeIds.length - 1]).toContain("agent");
+    expect(screen.getByTestId("node-agent")).toBeTruthy();
+  });
+
+  it("asks for a name before the first agent, then adds it", async () => {
+    // A hand-built network has no name until someone gives it one, and the designer
+    // drops any edit that arrives without agent_network_name. Asking up front is what
+    // stops that first edit being applied locally and silently lost server-side.
+    useEditorNetworkStore.getState().reset(NETWORK);
+    render(
+      <ReactFlowProvider>
+        <EditorAgentFlow selectedNetwork="" />
+      </ReactFlowProvider>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Add frontman"));
+    });
+
+    // Nothing added yet: the dialog is asking first.
+    expect(screen.getByText("Name this agent network")).toBeTruthy();
+    expect(screen.queryByTestId("node-frontman")).toBeNull();
+
+    // Typed with spaces and capitals on purpose: the name is sanitised on save.
+    const nameField = screen.getByPlaceholderText("Name this network");
+    await act(async () => {
+      fireEvent.change(nameField, { target: { value: "Car Wash" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Save network name"));
+    });
+
+    // The frontman is named after the network rather than being called "frontman",
+    // which says nothing about what it does once it reaches the HOCON or the chat.
+    await waitFor(() => expect(screen.getByTestId("node-car_wash_agent")).toBeTruthy());
+  });
+
+  it("offers nothing but the frontman while the canvas is empty", async () => {
+    // Referencing a network or a tool before there is an agent to attach it to would
+    // leave it unattached, which is the state the whole editor is built to avoid.
+    useEditorNetworkStore.getState().reset(NETWORK);
+    render(
+      <ReactFlowProvider>
+        <EditorAgentFlow selectedNetwork="" />
+      </ReactFlowProvider>
+    );
+
+    expect(screen.getByLabelText("Add frontman")).not.toHaveProperty("disabled", true);
+    for (const source of ["Agent Networks", "Toolbox", "MCP Servers"]) {
+      expect(screen.getByLabelText(source)).toHaveProperty("disabled", true);
+    }
+  });
+});

--- a/nsflow/frontend/src/components/EditorAgentFlow.tsx
+++ b/nsflow/frontend/src/components/EditorAgentFlow.tsx
@@ -14,26 +14,53 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { ReactFlow, Background, Controls, useEdgesState, useNodesState, useReactFlow, 
-  Node, Edge, EdgeMarkerType, addEdge, Connection, NodeMouseHandler } from "@xyflow/react";
+  Node, Edge, EdgeMarkerType, Connection, NodeChange, NodeMouseHandler } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { Box, Typography, Paper, useTheme, IconButton, Tooltip, Slider, alpha, Button, ButtonGroup, ClickAwayListener, Grow, Popper, MenuList, MenuItem } from "@mui/material";
+import { Box, Typography, Paper, useTheme, IconButton, Tooltip, Slider, alpha, Button, ButtonGroup, ClickAwayListener, Dialog, DialogActions, DialogContent, DialogTitle, Grow, Popper, MenuList, MenuItem } from "@mui/material";
 import EditableAgentNode from "./EditableAgentNode";
 import FloatingEdge from "./FloatingEdge";
 import AgentContextMenu from "./AgentContextMenu";
+import EdgeContextMenu from "./EdgeContextMenu";
 import EditorPalette from "./EditorPalette";
 import NetworkAgentEditorPanel from "./NetworkAgentEditorPanel";
+import NetworkNameField from "./NetworkNameField";
 import { useApiPort } from "../context/ApiPortContext";
 import { createLayoutManager } from "../utils/agentLayoutManager";
-import {
-  AccountTree as LayoutIcon,
-  RocketLaunchTwoTone as LaunchIcon,
-  ArrowDropDown as ArrowDropDownIcon,
-  Home as HomeIcon
-} from "@mui/icons-material";
+import LayoutIcon from "@mui/icons-material/AccountTree";
+import LaunchIcon from "@mui/icons-material/RocketLaunchTwoTone";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import HelpIcon from "@mui/icons-material/HelpOutlined";
+import RenameIcon from "@mui/icons-material/DriveFileRenameOutline";
+import NewDraftIcon from "@mui/icons-material/EditNote";
+import ChatIcon from "@mui/icons-material/ChatBubbleOutlined";
+import HomeIcon from "@mui/icons-material/Home";
 import { useChatContext } from "../context/ChatContext";
 import { getFeatureFlags, toServedNetworkPath, getManifestUpdatePeriodMs } from "../utils/config";
+import { selectEntry, useEditorNetworkStore } from "../state/editorNetworkStore";
+import { isDraftKey, useEditorDraftSession } from "../state/editorSession";
+import { buildEditorGraph } from "../state/editorGraph";
+import { sendEditorUpdate } from "../state/editorRoundTrip";
+import type { ChatMessage } from "../uiCommon";
+import { useEditorProgressBridge } from "../state/progressBridge";
+import type { ConnectivityInfo } from "../uiCommon";
+import {
+  addAgent as addAgentToDefinition,
+  definitionIssues,
+  deleteAgent as deleteAgentFromDefinition,
+  disconnectAgents as disconnectAgentsInDefinition,
+  reparentAgent as reparentAgentInDefinition,
+  duplicateAgent as duplicateAgentInDefinition,
+  canDelete,
+  canDuplicate,
+  canHaveChildren,
+  connectAgents as connectAgentsInDefinition,
+  newAgentAttributes,
+  uniqueAgentName,
+} from "../state/editorOperations";
+import { FRONTMAN_ITEM, PALETTE_DRAG_TYPE, type PaletteItem } from "../state/paletteSources";
+import { requestChatFocus } from "../utils/focusChat";
 
 export const nodeTypes = Object.freeze({
   agent: EditableAgentNode,
@@ -45,50 +72,77 @@ export const edgeTypes = Object.freeze({
   floating: FloatingEdge,
 });
 
-interface StateConnectivityResponse {
-  nodes: Node[];
-  edges: Edge[];
-  network_name: string;
-  connected_components: number;
-  total_agents: number;
-  defined_agents: number;
-  undefined_agents: number;
-}
+/**
+ * What the editor will and will not let you do, and why.
+ *
+ * Every line here corresponds to a rule enforced in `editorOperations`, so a greyed
+ * out action always has an explanation the user can find.
+ */
+const EDITING_RULES: string[] = [
+  "Adding an agent attaches it to the selected agent, or to the frontman when nothing is selected.",
+  "The frontman is the network's entry point: it cannot be deleted or duplicated. Edit its instructions instead, or start a new draft.",
+  "A toolbox tool or another network cannot have down-chain agents, so nothing can be attached to it.",
+  "Right-click a connection to delete it, or drag its end onto another agent to move the child.",
+  "A change that leaves an agent with no parent is kept on the canvas but not saved until you reconnect it.",
+];
 
-const EditorAgentFlow = ({ 
-  selectedNetwork, 
-  selectedDesignId,
-  onNetworkCreated, 
-  onNetworkSelected 
-}: { 
-  selectedNetwork: string;
-  selectedDesignId: string;
-  onNetworkCreated: () => void;
-  onNetworkSelected: (networkName: string) => void;
-}) => {
-  // console.log('EditorAgentFlow: Received props:', { selectedNetwork, selectedDesignId });
+const EditorAgentFlow = ({ selectedNetwork }: { selectedNetwork: string }) => {
   const { apiUrl } = useApiPort();
   // v12 needs the node/edge type explicitly: an untyped useNodesState([]) infers never[].
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
-  const { fitView, setViewport } = useReactFlow();
+  const { fitView, setViewport, getNodes, getEdges } = useReactFlow();
   const theme = useTheme();
+
+  // Where a manual edit goes when the user has not picked a network: building a
+  // network from scratch has to work before it has a name, so edits land in a draft
+  // and the designer names it on the first round-trip. Without this the editor is
+  // dead on a blank canvas, since every edit path needs a store key.
+  //
+  // The draft is scoped to this editing session, so arriving at the Editor gives a
+  // clean canvas rather than reopening whatever was drawn days ago.
+  const { draftKey, startNewSession } = useEditorDraftSession();
+  const networkId = selectedNetwork || draftKey;
+
+  // The store is the authority for the definition; the canvas renders from it.
+  const entry = useEditorNetworkStore((state) => selectEntry(state, networkId));
+  const applyEdit = useEditorNetworkStore((state) => state.applyEdit);
+  const reconcileFromServer = useEditorNetworkStore((state) => state.reconcileFromServer);
+
+  // Naming is offered for a draft only. Renaming a network that was selected from
+  // the sidebar would save a second copy under the new name and leave the original
+  // behind, which needs designer-side cleanup this cannot do from the browser.
+  const isDraft = isDraftKey(networkId);
+  const networkLabel = selectedNetwork || entry?.networkName || "";
+  // Shown until the draft has a name, and reopened by the pencil after that.
+  const [isNamingNetwork, setIsNamingNetwork] = useState(false);
+  const showNameField = Boolean(entry) && (isDraft ? !entry?.networkName || isNamingNetwork : isNamingNetwork);
+  // Chat-driven changes arrive on the progress/slydata sockets and land in the same
+  // store, so the canvas does not care whether a change came from chat or a manual
+  // edit. Keyed on networkId rather than selectedNetwork so that the handover works
+  // in both directions: a user who builds a network by hand and then asks the chat to
+  // reword its instructions sees the result on the same canvas, instead of the frames
+  // being dropped because no network is formally "selected".
+  useEditorProgressBridge(networkId);
+
 
   // Layout control state (similar to AgentFlow)
   const [baseRadius, setBaseRadius] = useState(30);
   const [levelSpacing, setLevelSpacing] = useState(80);
   const [tempBaseRadius, setTempBaseRadius] = useState(baseRadius);
   const [tempLevelSpacing, setTempLevelSpacing] = useState(levelSpacing);
-  const { pluginManualEditor, pluginCruse } = getFeatureFlags();
-  const canEdit = !!pluginManualEditor;
+  const { pluginCruse } = getFeatureFlags();
   const shouldForceLayoutRef = useRef(false);
+  // The network whose viewport has already been pinned, so switching networks
+  // re-frames the canvas but ordinary edits and selections do not.
+  const pinnedViewportForRef = useRef<string | null>(null);
   const lastSeenNameRef = useRef<string | null>(null);
   const [showLaunchButton, setShowLaunchButton] = useState(false);
   const [launchMenuOpen, setLaunchMenuOpen] = useState(false);
   const launchAnchorRef = useRef<HTMLDivElement>(null);
 
   // We'll read the latest agent_network_definition from logs in view-mode
-  const { getLatestNetworkPayload,
+  const { getLatestNetworkPayload, addSlyDataMessage, targetNetwork,
     progressTick, slyDataTick, waitingForAgent } = useChatContext();
 
   // The launch button becomes visible as soon as the designer reports a network name,
@@ -116,12 +170,21 @@ const EditorAgentFlow = ({
     }
   }, [waitingForAgent]);
 
-  const launchDisabled = waitingForAgent || registryReloadPending;
+  // What the launch buttons will open. A chat-generated network is named by the
+  // designer; a hand-built one carries the name the user gave it, which is also the
+  // name it was saved under.
+  const launchableNetworkName =
+    getLatestNetworkPayload()?.agent_network_name || entry?.networkName || selectedNetwork || "";
 
-  // latest definition for view-mode
-  const getViewDefinition = useCallback(() => {
-    return getLatestNetworkPayload()?.agent_network_definition as Record<string, any> | undefined;
-  }, [getLatestNetworkPayload]);
+  // Visible as soon as the canvas holds a network, rather than waiting for the
+  // designer to announce a name: a network built by hand never produces that
+  // announcement, so the button used to stay hidden however complete the network was.
+  const hasNetworkToLaunch = (entry?.definition?.length ?? 0) > 0;
+
+  // A network with no name has not been persisted, so there is nothing on the server
+  // to launch yet. Showing the button but disabling it says that much more clearly
+  // than hiding it.
+  const launchDisabled = waitingForAgent || registryReloadPending || !launchableNetworkName;
 
   // Latest agent network name for the launch button — same selector as the canvas
   // and outgoing sly_data, so all three always name the same network.
@@ -130,10 +193,14 @@ const EditorAgentFlow = ({
   }, [getLatestNetworkPayload]);
 
   // Layout manager for position caching and intelligent layout
-  const layoutManager = selectedNetwork ? createLayoutManager(selectedNetwork, {
-    baseRadius,
-    levelSpacing
-  }) : null;
+  // Memoised deliberately. renderFromStore depends on this, and the effect that
+  // renders depends on renderFromStore, so an unmemoised layout manager would give
+  // renderFromStore a new identity on every render, re-run the effect, call
+  // setNodes/setEdges, and loop until React throws "maximum update depth exceeded".
+  const layoutManager = useMemo(
+    () => createLayoutManager(networkId, { baseRadius, levelSpacing }),
+    [networkId, baseRadius, levelSpacing]
+  );
   
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{
@@ -145,96 +212,106 @@ const EditorAgentFlow = ({
 
   // Selected node state
   const [selectedNodeId, setSelectedNodeId] = useState<string>("");
+  /** The agent a drop would attach to, or "" over empty canvas. */
+  const [dropTargetId, setDropTargetId] = useState("");
+  /** Held while the naming dialog is up, and added once the network has a name. */
+  const [pendingFirstItem, setPendingFirstItem] = useState<PaletteItem | null>(null);
   
   // Agent editor state
   const [selectedAgentName, setSelectedAgentName] = useState<string | null>(null);
   const [autoExpandPanel, setAutoExpandPanel] = useState(false);
   const isPanelOpenRef = useRef(false);
 
-  // Fetch network connectivity data
-  const fetchNetworkData = async (definitionOverride?: Record<string, any>) => {
-    // console.log('fetchNetworkData called with:', { selectedNetwork, selectedDesignId, apiUrl });
-    if (!selectedNetwork || !apiUrl) {
-      console.log('Missing selectedNetwork or apiUrl, skipping fetch');
+  // Render the canvas from the store.
+  //
+  // This replaces the old fetch: edit mode used to GET /andeditor/state/connectivity
+  // and view mode used to POST /connectivity/from_json just to turn a definition
+  // into nodes and edges. Both are now done in the browser by buildEditorGraph,
+  // which is verified to produce the same graph the backend did.
+  const renderFromStore = useCallback(() => {
+    const definition = entry?.definition ?? [];
+    if (definition.length === 0) {
+      setNodes([]);
+      setEdges([]);
       return;
     }
 
-    try {
-      let response: Response;
-      if (canEdit && selectedDesignId) {
-        // EDIT MODE: unchanged
-        response = await fetch(`${apiUrl}/api/v1/andeditor/state/connectivity/${selectedNetwork}`);
-      } else {
-        // VIEW MODE: get the definition from logs (or override)
-        const definition = definitionOverride ?? getViewDefinition();
-        if (!definition) {
-          console.warn("View-mode: no agent_network_definition available yet.");
-          return;
-        }
-        response = await fetch(`${apiUrl}/api/v1/connectivity/from_json`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agent_network_definition: definition }),
-        });
+    const graph = buildEditorGraph(definition, entry?.networkName ?? networkId);
+
+    const rawNodes = graph.nodes.map((node) => ({
+      ...node,
+      // `selected` is React Flow's own flag and decides what the Delete key removes;
+      // `data.selected` is what our node component styles from. Only the latter was
+      // being set, and since this rebuilds every node object it also wiped whatever
+      // selection React Flow had made on click — so Delete had nothing to act on.
+      selected: node.id === selectedNodeId,
+      data: { ...node.data, selected: node.id === selectedNodeId },
+    }));
+
+    const transformedEdges = graph.edges.map((edge) => ({
+      ...edge,
+      markerEnd: "arrowclosed" as EdgeMarkerType,
+      style: { stroke: theme.palette.divider, strokeWidth: 2 },
+      type: "floating",
+    }));
+
+    // Annotated as Node[] so the layout manager's return value is assignable
+    // (rawNodes alone infers a narrower literal type under @xyflow/react 12).
+    let finalNodes: Node[] = rawNodes;
+    if (layoutManager && rawNodes.length > 0) {
+      try {
+        finalNodes = layoutManager.applyLayout(rawNodes, transformedEdges).nodes;
+      } catch (error) {
+        console.warn("Failed to apply layout, using raw positions:", error);
       }
-      if (!response.ok) {
-        console.error(`Failed to fetch network data: ${response.statusText}`);
-        return;
-      }
-
-      const data: StateConnectivityResponse = await response.json();
-      // Transform nodes to include selection state
-      const rawNodes = data.nodes.map((node: Node) => ({
-        ...node,
-        data: { ...node.data, selected: node.id === selectedNodeId },
-      }));
-
-      // Transform edges to include arrows
-      const transformedEdges = data.edges.map((edge: Edge) => ({
-        ...edge,
-        markerEnd: "arrowclosed" as EdgeMarkerType,
-        style: { stroke: theme.palette.divider, strokeWidth: 2 },
-        type: "floating",
-      }));
-
-      // Apply intelligent layout with position caching. Annotated as Node[] so the
-      // layout manager's return value is assignable (rawNodes alone infers a narrower
-      // literal type under @xyflow/react 12's generics).
-      let finalNodes: Node[] = rawNodes;
-
-      if (layoutManager && rawNodes.length > 0) {
-        try {
-          const layoutResult = layoutManager.applyLayout(rawNodes, transformedEdges);
-          finalNodes = layoutResult.nodes;
-          // console.log(`Applied layout for ${selectedNetwork}: ${finalNodes.length} nodes, cached: ${layoutManager.hasCachedPositions()}`);
-        } catch (error) {
-          console.warn('Failed to apply layout, using raw positions:', error);
-          finalNodes = rawNodes;
-        }
-      }
-
-      setNodes(finalNodes);
-      setEdges(transformedEdges);
-      // Only setViewport here, deliberately. @xyflow/react 12 no longer runs
-      // fitView synchronously: it sets fitViewQueued and executes once the fresh
-      // nodes are measured, i.e. AFTER setViewport's animation has started, so a
-      // fitView() on this line would interrupt and override the pinned viewport
-      // (and this runs on every designer progress frame in view mode). Under v11
-      // fitView was a no-op against unmeasured nodes and setViewport always won,
-      // so dropping it preserves the pre-upgrade behaviour exactly.
-      setViewport({ x: -70, y: 100, zoom: 0.5 }, { duration: 800 });
-
-    } catch (error) {
-      console.error("Error fetching network data:", error);
     }
-  };
+
+    setNodes(finalNodes);
+    setEdges(transformedEdges);
+
+    // Pin the viewport only when arriving at a different network. This used to run on
+    // every call, and selectedNodeId is one of this callback's dependencies, so
+    // merely clicking an agent snapped the canvas back to zoom 0.5 and the user lost
+    // whatever they had zoomed in to. Panning and zooming are the user's to keep
+    // until they switch networks or press one of the view controls.
+    if (pinnedViewportForRef.current !== networkId) {
+      pinnedViewportForRef.current = networkId;
+      // Only setViewport here, deliberately. @xyflow/react 12 no longer runs fitView
+      // synchronously: it sets fitViewQueued and executes once the fresh nodes are
+      // measured, i.e. AFTER setViewport's animation has started, so a fitView() on
+      // this line would interrupt and override the pinned viewport.
+      setViewport({ x: -70, y: 100, zoom: 0.5 }, { duration: 800 });
+    }
+  }, [networkId, entry?.definition, entry?.networkName, selectedNodeId, layoutManager, theme, setNodes, setEdges, setViewport]);
+
+  // Mark the drop target on the nodes already on the canvas.
+  //
+  // Deliberately not part of renderFromStore: that rebuilds the graph and runs the
+  // layout, which on every dragover tick would thrash the canvas. This only rewrites
+  // the one flag on the nodes whose value actually changed.
+  useEffect(() => {
+    setNodes((current) => {
+      let changed = false;
+      const next = current.map((node) => {
+        const isTarget = node.id === dropTargetId;
+        if (Boolean(node.data.is_drop_target) === isTarget) return node;
+        changed = true;
+        return { ...node, data: { ...node.data, is_drop_target: isTarget } };
+      });
+      return changed ? next : current;
+    });
+  }, [dropTargetId, setNodes]);
 
   // Handle node click — always populate panel data, but don't auto-expand
   const onNodeClick: NodeMouseHandler = useCallback((_, node) => {
+    // Selecting an agent and editing it are different intents. A single click only
+    // selects — it decides what the palette attaches to and what Delete removes —
+    // while the editor panel is opened deliberately, by double-click or by
+    // right-click "Edit Agent". Loading the agent here as well meant the panel
+    // followed every click around the canvas.
     setSelectedNodeId(node.id);
     setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" });
-    setAutoExpandPanel(false);
-    setSelectedAgentName(node.id);
+    closeEdgeMenu();
 
     // Update nodes to show selection
     setNodes((nds) =>
@@ -255,6 +332,30 @@ const EditorAgentFlow = ({
     isPanelOpenRef.current = true;
   }, []);
 
+  const [edgeMenu, setEdgeMenu] = useState<{
+    visible: boolean;
+    x: number;
+    y: number;
+    source: string;
+    target: string;
+  }>({ visible: false, x: 0, y: 0, source: "", target: "" });
+
+  const closeEdgeMenu = useCallback(
+    () => setEdgeMenu({ visible: false, x: 0, y: 0, source: "", target: "" }),
+    []
+  );
+
+  const onEdgeContextMenu = useCallback((event: React.MouseEvent, edge: Edge) => {
+    event.preventDefault();
+    setEdgeMenu({
+      visible: true,
+      x: event.clientX,
+      y: event.clientY,
+      source: edge.source,
+      target: edge.target,
+    });
+  }, []);
+
   // Handle node context menu (right-click)
   const onNodeContextMenu = useCallback((event: React.MouseEvent, node: Node) => {
     event.preventDefault();
@@ -267,28 +368,11 @@ const EditorAgentFlow = ({
     });
   }, []);
 
-  // Handle edge connection
-  const onConnect = useCallback(
-    (params: Connection) => {
-      const newEdge: Edge = {
-        ...params,
-        id: `edge-${params.source}-${params.target}`,
-        markerEnd: "arrowclosed" as EdgeMarkerType,
-        style: {
-          stroke: theme.palette.divider,
-          strokeWidth: 2,
-        },
-        type: "floating",
-      };
-      setEdges((eds) => addEdge(newEdge, eds));
-    },
-    [setEdges]
-  );
-
   // Handle canvas click (deselect)
   const onPaneClick = useCallback(() => {
     setSelectedNodeId("");
     setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" });
+    closeEdgeMenu();
     
     // Update nodes to remove selection
     setNodes((nds) => 
@@ -300,10 +384,10 @@ const EditorAgentFlow = ({
         },
       }))
     );
-  }, [setNodes]);
+  }, [setNodes, closeEdgeMenu]);
 
   // Handle nodes change (including position updates)
-  const handleNodesChange = useCallback((changes: any[]) => {
+  const handleNodesChange = useCallback((changes: NodeChange<Node>[]) => {
     onNodesChange(changes);
     
     // Save positions when nodes are moved (simplified approach)
@@ -319,23 +403,119 @@ const EditorAgentFlow = ({
     }
   }, [onNodesChange, layoutManager, setNodes]);
 
-  // Force layout recalculation
+  // Force layout recalculation.
+  //
+  // Reads the live nodes and edges through getNodes/getEdges rather than closing over
+  // the `nodes` and `edges` state. This is called from a requestAnimationFrame, by
+  // which point the render that scheduled it has been replaced: with a closure it ran
+  // against the node list from BEFORE the edit and wrote that back, so an agent that
+  // renderFromStore had just added was silently removed again. The symptom was an
+  // added agent appearing only after some other interaction — a pane click or a
+  // reload — re-ran renderFromStore with nothing left to overwrite it.
   const handleForceLayout = useCallback(() => {
-    if (layoutManager && nodes.length > 0) {
-      try {
-        const layoutResult = layoutManager.forceLayout(nodes, edges);
-        setNodes(layoutResult.nodes);
-        // Keep existing edges as they are already transformed
-        
-        // Fit view after layout
-        setTimeout(() => {
-          fitView({ padding: 0.1, duration: 800 });
-        }, 100);
-      } catch (error) {
-        console.warn('Failed to force layout:', error);
-      }
+    if (!layoutManager) return;
+    try {
+      const currentNodes = getNodes();
+      if (currentNodes.length === 0) return;
+      // Edges are already transformed, so only the nodes are replaced.
+      setNodes(layoutManager.forceLayout(currentNodes, getEdges()).nodes);
+      setTimeout(() => {
+        fitView({ padding: 0.1, duration: 800 });
+      }, 100);
+    } catch (error) {
+      console.warn('Failed to force layout:', error);
     }
-  }, [layoutManager, nodes, edges, setNodes, fitView]);
+  }, [layoutManager, getNodes, getEdges, setNodes, fitView]);
+
+  // Apply an edit locally, then let the designer canonicalise it. The optimistic
+  // apply is what makes editing feel immediate; the round-trip is what persists it.
+  //
+  // A newer edit supersedes an older one still in flight. Every edit sends the WHOLE
+  // definition, so the newest send already contains everything the older one did and
+  // the last write wins server-side regardless. What the abort prevents is the older
+  // response arriving afterwards and reconciling a definition that is now stale,
+  // which would undo the newer edit on the canvas. It also stops a queue building up
+  // when a user adds several agents in quick succession.
+  const inFlightEditRef = useRef<AbortController | null>(null);
+
+  // Manual edits go over HTTP, so nothing about them reaches the sly_data websocket
+  // the Sly Data panel listens to, and the panel sat on whatever the last chat turn
+  // left there. Feeding the designer's echoed sly_data into the same stream a chat
+  // turn writes to keeps one source for the panel rather than teaching it a second.
+  const publishSlyData = useCallback(
+    (frame: ChatMessage) => {
+      const slyData = (frame as ChatMessage & { sly_data?: Record<string, unknown> }).sly_data;
+      if (!slyData || !targetNetwork) return;
+      // Only a frame carrying a definition is a complete picture of the network. The
+      // same rule parseEchoedPayload applies, and for the same reason: a partial blob
+      // would become the base for the next chat turn's sly_data, which round-trips
+      // non-definition keys unchanged.
+      if (!slyData.agent_network_definition) return;
+      addSlyDataMessage({
+        sender: targetNetwork,
+        // Same markdown-fenced JSON the chat path posts, so the panel's parsing does
+        // not have to know where the frame came from.
+        text: `\`\`\`json\n${JSON.stringify(slyData, null, 2)}\n\`\`\``,
+        network: targetNetwork,
+      });
+    },
+    [addSlyDataMessage, targetNetwork]
+  );
+
+  const applyAndSync = useCallback(
+    async (next: ConnectivityInfo[], agentName: string, message?: string) => {
+      if (!apiUrl) return;
+      applyEdit(networkId, next);
+
+      // Hold a half-finished rearrangement locally rather than sending it. An
+      // invalid definition is not rejected by the designer, it is REPAIRED by its
+      // LLM, which restructures the network and discards the edit in progress. The
+      // canvas still shows the change; the next valid edit persists everything.
+      if (definitionIssues(next).length > 0) return;
+
+      inFlightEditRef.current?.abort();
+      const controller = new AbortController();
+      inFlightEditRef.current = controller;
+
+      try {
+        await sendEditorUpdate({
+          apiUrl,
+          networkId,
+          agentName,
+          definition: next,
+          message,
+          signal: controller.signal,
+          onFrame: publishSlyData,
+        });
+      } catch (error) {
+        // An abort is this function superseding itself, not a failure.
+        if ((error as Error)?.name !== "AbortError") {
+          console.error(`Failed to persist edit for ${agentName}:`, error);
+        }
+      } finally {
+        if (inFlightEditRef.current === controller) inFlightEditRef.current = null;
+      }
+    },
+    [networkId, apiUrl, applyEdit, publishSlyData]
+  );
+
+  // Handle edge connection.
+  //
+  // Drawing an edge is how a free agent gets wired up, so it has to change the
+  // definition. It used to only call setEdges, which meant the edge vanished the next
+  // time the canvas rendered from the store and never reached the network. There is
+  // no local setEdges here at all now: the store is the authority, and the render
+  // effect draws the edge once the definition holds it.
+  const onConnect = useCallback(
+    (params: Connection) => {
+      const definition = entry?.definition ?? [];
+      const next = connectAgentsInDefinition(definition, params.source ?? "", params.target ?? "");
+      // Unchanged means the edge was refused: a toolbox tool or external reference
+      // cannot have down-chains, and a duplicate or self-edge is nothing to do.
+      if (next !== definition) void applyAndSync(next, params.source ?? "");
+    },
+    [entry?.definition, applyAndSync]
+  );
 
   // Context menu actions
   const handleEditAgent = (nodeId: string) => {
@@ -346,76 +526,285 @@ const EditorAgentFlow = ({
   };
 
   const handleDeleteAgent = async (nodeId: string) => {
-    // console.log("Delete agent:", nodeId, "selectedDesignId:", selectedDesignId);
-    
-    if (!selectedDesignId) {
-      console.error("Cannot delete agent: no design_id available. Current selectedDesignId:", selectedDesignId);
-      setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" });
-      return;
-    }
-    
-    const success = await deleteAgent(nodeId);
-    if (success) {
-      // Refresh the network data to reflect changes
-      await fetchNetworkData();
-    }
-    
+    const next = deleteAgentFromDefinition(entry?.definition ?? [], nodeId);
     setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" });
     setSelectedNodeId("");
+    // deleteAgent returns the same array when nothing matched, so nothing to send.
+    if (next !== (entry?.definition ?? [])) await applyAndSync(next, nodeId);
   };
 
   const handleDuplicateAgent = async (nodeId: string) => {
-    // console.log("Duplicate agent:", nodeId, "selectedDesignId:", selectedDesignId);
-    
-    if (!selectedDesignId) {
-      console.error("Cannot duplicate agent: no design_id available. Current selectedDesignId:", selectedDesignId);
-      setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" });
-      return;
-    }
-    
-    // Generate a new name for the duplicated agent
-    const newAgentName = `${nodeId}_copy`;
-    
-    const success = await duplicateAgent(nodeId, newAgentName);
-    if (success) {
-      // Refresh the network data to reflect changes
-      await fetchNetworkData();
-    }
-    
+    const definition = entry?.definition ?? [];
+    // Uniquified, or a second copy would collide with the first and addAgent's
+    // duplicate-name guard would silently make the action do nothing.
+    const newAgentName = uniqueAgentName(definition, `${nodeId}_copy`);
+    const next = duplicateAgentInDefinition(definition, nodeId, newAgentName);
     setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" });
+    if (next !== definition) await applyAndSync(next, newAgentName);
   };
 
   const handleAddChildAgent = async (nodeId: string) => {
-    // console.log("Add child agent to:", nodeId, "selectedDesignId:", selectedDesignId);
-    
-    if (!selectedDesignId) {
-      console.error("Cannot add child agent: no design_id available. Current selectedDesignId:", selectedDesignId);
-      setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" });
-      return;
-    }
-    
-    // Generate a name for the child agent
-    const childAgentName = `${nodeId}_child`;
-    
-    // Use current agent as parent (one level down)
-    const success = await createAgent(childAgentName, nodeId);
-    if (success) {
-      // Refresh the network data to reflect changes
-      await fetchNetworkData();
-    }
-    
+    const definition = entry?.definition ?? [];
+    // Uniquified for the same reason as duplicate: a fixed "<parent>_child" meant an
+    // agent could be given exactly one child, and every attempt after the first was
+    // rejected as a duplicate name with nothing to show for it.
+    const childAgentName = uniqueAgentName(definition, `${nodeId}_child`);
+    const next = addAgentToDefinition(
+      definition,
+      childAgentName,
+      nodeId,
+      newAgentAttributes(childAgentName)
+    );
     setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" });
+    if (next !== definition) await applyAndSync(next, childAgentName);
   };
+
+  // One path for putting a palette item on the canvas, whether it was clicked or
+  // dropped, so both persist exactly like a chat-generated agent does.
+  //
+  // With no explicit target `addAgent` attaches to the frontman, so nothing added
+  // here can ever float free.
+  const addPaletteItem = useCallback(
+    async (item: PaletteItem, parentName?: string) => {
+      if (!item?.agentName) return;
+
+      // Read the entry live rather than from the render closure. This is called
+      // straight after naming the network, and a captured `entry` would still be the
+      // unnamed one, so the naming gate below would fire a second time and the agent
+      // would never be added.
+      const current = useEditorNetworkStore.getState().entries[networkId];
+      const definition = current?.definition ?? [];
+
+      // A network built by hand has no name until someone gives it one, and the
+      // designer refuses to persist anything without `agent_network_name`. So the
+      // first edit of an unnamed network would apply to the canvas and be silently
+      // dropped server-side. Chat mode never hits this because the designer names
+      // what it generates; manual mode has to ask. Asking once, before the first
+      // agent exists, means every edit from then on persists.
+      if (definition.length === 0 && !current?.networkName && networkId === draftKey) {
+        setPendingFirstItem(item);
+        return;
+      }
+      // Only a blank agent gets renamed to dodge a collision; a tool or a network
+      // names something specific, so a second drop of it has to be a no-op.
+      const agentName = item.uniquifyName
+        ? uniqueAgentName(definition, item.agentName)
+        : item.agentName;
+      // An LLM agent needs instructions and a description; a toolbox tool must have
+      // neither, since that absence is what marks it as a tool. addAgent refuses a
+      // parent that cannot take children, so dropping onto a tool does nothing
+      // rather than quietly attaching the agent somewhere else.
+      const next = addAgentToDefinition(
+        definition,
+        agentName,
+        parentName,
+        item.isLlmAgent ? newAgentAttributes(agentName) : undefined
+      );
+      // addAgent returns the same array when the name is taken, which is what makes
+      // adding the same tool twice a no-op rather than an error.
+      if (next !== definition) await applyAndSync(next, agentName);
+    },
+    [entry?.definition, applyAndSync]
+  );
+
+  // Delete one connection, leaving both agents in place. The agent that loses its
+  // parent stays on the canvas so it can be reconnected; applyAndSync holds that
+  // state locally until it is valid again.
+  const handleDeleteConnection = useCallback(
+    async (source: string, target: string) => {
+      closeEdgeMenu();
+      const definition = entry?.definition ?? [];
+      const next = disconnectAgentsInDefinition(definition, source, target);
+      if (next !== definition) await applyAndSync(next, source, `Disconnect "${target}" from "${source}"`);
+    },
+    [entry?.definition, applyAndSync, closeEdgeMenu]
+  );
+
+  // Dragging an edge's endpoint onto another agent moves the child in ONE edit, so
+  // the definition never passes through the rootless state that delete-then-connect
+  // would produce.
+  const onReconnect = useCallback(
+    (oldEdge: Edge, connection: Connection) => {
+      const definition = entry?.definition ?? [];
+      // Only the parent end is meaningful here: the child keeps its identity, and
+      // what changes is which agent chains down to it.
+      const next = reparentAgentInDefinition(
+        definition,
+        oldEdge.target,
+        oldEdge.source,
+        connection.source ?? ""
+      );
+      if (next !== definition) {
+        void applyAndSync(next, connection.source ?? "", `Move "${oldEdge.target}" under "${connection.source}"`);
+      }
+    },
+    [entry?.definition, applyAndSync]
+  );
+
+  // Selecting an agent and pressing Delete removes it, through the same path as the
+  // context menu so the frontman guard and the child promotion apply either way.
+  // React Flow raises this for any node it considers deleted; refusing one simply
+  // leaves the definition unchanged.
+  const onNodesDelete = useCallback(
+    (deleted: Node[]) => {
+      for (const node of deleted) void handleDeleteAgent(node.id);
+    },
+    // handleDeleteAgent is a plain function redeclared each render, so it is read
+    // through the ref-free closure here; the definition it reads comes from `entry`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [entry?.definition, applyAndSync]
+  );
+
+  // Selecting an edge and pressing Delete goes through the same path, so the keyboard
+  // and the context menu cannot drift apart.
+  const onEdgesDelete = useCallback(
+    (deleted: Edge[]) => {
+      for (const edge of deleted) void handleDeleteConnection(edge.source, edge.target);
+    },
+    [handleDeleteConnection]
+  );
+
+  // Clicking a palette item attaches it to whichever agent is selected, falling back
+  // to the frontman when nothing is.
+  const handlePaletteAdd = useCallback(
+    (item: PaletteItem) => addPaletteItem(item, selectedNodeId || undefined),
+    [addPaletteItem, selectedNodeId]
+  );
+
+  // Why the canvas is not being saved, if it is not. Derived from the definition
+  // rather than remembered from the last edit, so it survives a reload: the store is
+  // persisted, so an unsaved rearrangement outlives the page that made it, and a
+  // warning that disappeared on refresh would read as "saved".
+  const pendingIssues = useMemo(() => {
+    const definition = entry?.definition ?? [];
+    // An empty canvas is not an unsaved change, it is a starting point.
+    return definition.length === 0 ? [] : definitionIssues(definition);
+  }, [entry?.definition]);
+
+  // A click adds under the selected agent, so a selection that cannot take children
+  // disables the palette rather than having the click land somewhere unexpected.
+  const paletteDisabledReason =
+    selectedNodeId && !canHaveChildren(entry?.definition ?? [], selectedNodeId)
+      ? `"${selectedNodeId}" cannot have down-chain agents. Deselect it to add elsewhere.`
+      : undefined;
+
+  // Name a network that is still a draft.
+  //
+  // The name is what decides persistence: verified against a live designer, an edit
+  // sent without `agent_network_name` is canonicalised and echoed but never saved,
+  // while one sent with a name is assembled and saved under it. So naming a draft is
+  // also the moment it starts being persisted.
+  //
+  // Offered for a first name only. Renaming an already-saved network would save it
+  // again under the new name and leave the old registry entry behind, which needs
+  // designer-side cleanup this cannot do from here.
+  const handleNameNetwork = useCallback(
+    async (proposedName: string) => {
+      const name = proposedName.trim();
+      if (!name || !apiUrl) return;
+
+      // Live, for the same reason addPaletteItem reads live: this runs from a dialog
+      // whose callback was created before the current definition existed.
+      const definition = useEditorNetworkStore.getState().entries[networkId]?.definition ?? [];
+      // Record it locally first, so the panel and the next edit's outgoing sly_data
+      // agree on the name even before the echo comes back. reconcileFromServer is
+      // the right door: a name is not an edit, so it must not create an undo step.
+      reconcileFromServer(networkId, { definition, networkName: name });
+
+      // Nothing to persist for a network with no agents yet. The name is recorded
+      // locally and the first agent added carries it, which is what makes that first
+      // edit persist instead of being dropped for a missing agent_network_name.
+      if (definition.length === 0) return;
+
+      // Supersede any in-flight edit, for the same reason applyAndSync does: this
+      // send carries the whole definition, and an older response landing afterwards
+      // would reconcile a definition that predates the name.
+      inFlightEditRef.current?.abort();
+      const controller = new AbortController();
+      inFlightEditRef.current = controller;
+
+      try {
+        await sendEditorUpdate({
+          apiUrl,
+          networkId,
+          agentName: definition[0]?.origin ?? "frontman",
+          definition,
+          networkName: name,
+          message: `Name this agent network "${name}"`,
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if ((error as Error)?.name !== "AbortError") {
+          console.error(`Failed to name the network ${name}:`, error);
+        }
+      } finally {
+        if (inFlightEditRef.current === controller) inFlightEditRef.current = null;
+      }
+    },
+    [apiUrl, networkId, reconcileFromServer]
+  );
+
+  /** The agent under the cursor during a drag, if any. */
+  const nodeUnderCursor = (event: React.DragEvent | React.MouseEvent): string =>
+    (event.target as HTMLElement | null)?.closest(".react-flow__node")?.getAttribute("data-id") ?? "";
+
+  const onDragOver = useCallback(
+    (event: React.DragEvent) => {
+      // Without preventDefault the browser refuses the drop entirely.
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+
+      // Highlight what the drop would attach to. A tool cannot take children, so
+      // hovering one highlights nothing rather than promising a connection that
+      // would be refused.
+      const hovered = nodeUnderCursor(event);
+      const attachable = hovered && canHaveChildren(entry?.definition ?? [], hovered) ? hovered : "";
+      setDropTargetId((current) => (current === attachable ? current : attachable));
+    },
+    [entry?.definition]
+  );
+
+  const onDragLeave = useCallback((event: React.DragEvent) => {
+    // Leaving for a child element is not leaving the canvas, so only a move outside
+    // the whole pane clears the highlight.
+    const leavingTo = event.relatedTarget as globalThis.Node | null;
+    if (leavingTo && event.currentTarget.contains(leavingTo)) return;
+    setDropTargetId("");
+  }, []);
+
+  const onDrop = useCallback(
+    async (event: React.DragEvent) => {
+      event.preventDefault();
+      const payload = event.dataTransfer.getData(PALETTE_DRAG_TYPE);
+      if (!payload) return;
+
+      let item: PaletteItem;
+      try {
+        item = JSON.parse(payload) as PaletteItem;
+      } catch {
+        return;
+      }
+
+      // What was dropped ON decides the parent; dropping on empty canvas falls back
+      // to the frontman. The drop POSITION is deliberately ignored, unlike Flowise's
+      // free-form canvas: this graph is laid out as a hierarchy, so the layout
+      // manager would immediately overwrite any position taken from the cursor.
+      const droppedOnNodeId = nodeUnderCursor(event);
+      setDropTargetId("");
+      await addPaletteItem(item, droppedOnNodeId || undefined);
+    },
+    [addPaletteItem]
+  );
 
   // Handle agent update from editor panel
   const handleAgentUpdated = async () => {
-    // console.log("Agent updated, refreshing network data");
-    await fetchNetworkData();
+    // Nothing to refetch: the panel writes through the store, which re-renders the
+    // canvas on its own.
   };
 
   // Handle launch to Cruse (default)
   const handleLaunchCruse = useCallback(() => {
-    const agentNetworkName = getLatestAgentNetworkName();
+    const agentNetworkName = launchableNetworkName;
     if (agentNetworkName) {
       // The designer reports the raw name (e.g. "foo"); neuro-san serves generated
       // networks under the configured subdirectory (e.g. "generated/foo"), which is
@@ -424,18 +813,18 @@ const EditorAgentFlow = ({
       const cruseUrl = `${window.location.origin}/cruse?network=${encodeURIComponent(servedName)}`;
       window.open(cruseUrl, '_blank');
     }
-  }, [getLatestAgentNetworkName]);
+  }, [launchableNetworkName]);
 
   // Handle launch to Home (dropdown option)
   const handleLaunchHome = useCallback(() => {
-    const agentNetworkName = getLatestAgentNetworkName();
+    const agentNetworkName = launchableNetworkName;
     if (agentNetworkName) {
       const servedName = toServedNetworkPath(agentNetworkName);
       const homeUrl = `${window.location.origin}/home?network=${encodeURIComponent(servedName)}`;
       window.open(homeUrl, '_blank');
     }
     setLaunchMenuOpen(false);
-  }, [getLatestAgentNetworkName]);
+  }, [launchableNetworkName]);
 
   // Toggle launch menu
   const handleToggleLaunchMenu = () => {
@@ -452,109 +841,21 @@ const EditorAgentFlow = ({
     setLaunchMenuOpen(false);
   };
 
-  // API functions for agent operations
-  const createAgent = async (agentName: string, parentName?: string) => {
-    if (!selectedDesignId || !apiUrl) {
-      console.error("Missing design_id or apiUrl for createAgent:", { selectedDesignId, apiUrl });
-      return false;
-    }
-
-    try {
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks/${selectedDesignId}/agents`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: agentName,
-          parent_name: parentName,
-          instructions: `Agent ${agentName}`,
-          agent_type: 'standard'
-        })
-      });
-
-      if (!response.ok) {
-        const error = await response.text();
-        console.error('Failed to create agent:', error);
-        return false;
-      }
-
-      const result = await response.json();
-      console.log('Agent created successfully:', result);
-      return true;
-    } catch (error) {
-      console.error('Error creating agent:', error);
-      return false;
-    }
-  };
-
-  const duplicateAgent = async (agentName: string, newAgentName: string) => {
-    if (!selectedDesignId || !apiUrl) {
-      console.error("Missing design_id or apiUrl");
-      return false;
-    }
-
-    try {
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks/${selectedDesignId}/agents/${agentName}/duplicate`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          new_name: newAgentName
-        })
-      });
-
-      if (!response.ok) {
-        const error = await response.text();
-        console.error('Failed to duplicate agent:', error);
-        return false;
-      }
-
-      const result = await response.json();
-      console.log('Agent duplicated successfully:', result);
-      return true;
-    } catch (error) {
-      console.error('Error duplicating agent:', error);
-      return false;
-    }
-  };
-
-  const deleteAgent = async (agentName: string) => {
-    if (!selectedDesignId || !apiUrl) {
-      console.error("Missing design_id or apiUrl");
-      return false;
-    }
-
-    try {
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks/${selectedDesignId}/agents/${agentName}`, {
-        method: 'DELETE'
-      });
-
-      if (!response.ok) {
-        const error = await response.text();
-        console.error('Failed to delete agent:', error);
-        return false;
-      }
-
-      const result = await response.json();
-      console.log('Agent deleted successfully:', result);
-      return true;
-    } catch (error) {
-      console.error('Error deleting agent:', error);
-      return false;
-    }
-  };
-
   // Effects
   // Load data when network changes or layout parameters change (similar to AgentFlow)
+  //
+  // Gated on the store entry rather than on selectedNetwork, so a draft built by
+  // dragging renders even though no network has been chosen.
   useEffect(() => {
-    // console.log('useEffect triggered with:', { selectedNetwork, selectedDesignId });
-    if (selectedNetwork) {
-      fetchNetworkData();
+    if (entry) {
+      renderFromStore();
     } else {
       setNodes([]);
       setEdges([]);
       setShowLaunchButton(false);
       lastSeenNameRef.current = null;
     }
-  }, [selectedNetwork, selectedDesignId, baseRadius, levelSpacing]);
+  }, [entry, entry?.definition, baseRadius, levelSpacing, renderFromStore]);
 
   // Update temp values when actual values change
   useEffect(() => {
@@ -565,24 +866,38 @@ const EditorAgentFlow = ({
     setTempLevelSpacing(levelSpacing);
   }, [levelSpacing]);
 
-  // refetch when new progress/slydata ticks arrive (view-mode only)
+  // Relayout after the progress stream changes the definition. The bridge already
+  // wrote it to the store, so there is nothing to refetch; this only latches an
+  // animated relayout so the graph settles into its new shape.
   useEffect(() => {
-    if (!canEdit && selectedNetwork) {
-      const timeout = setTimeout(() => {
-        shouldForceLayoutRef.current = true;
-        const def = getViewDefinition();
-        if (def) fetchNetworkData(def);  // pass override so we POST exactly what just arrived
-        else fetchNetworkData();  // fallback: still try; fetchNetworkData() will call getViewDefinition() internally
-      }, 200); // slight debounce
-
-      return () => clearTimeout(timeout);
+    if (entry) {
+      shouldForceLayoutRef.current = true;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [progressTick, slyDataTick, selectedNetwork, canEdit]);
+  }, [progressTick, slyDataTick, entry]);
+
+  // The same settle for a manual edit. Chat ticks used to be the only thing that
+  // latched a relayout, so an agent added by hand stayed wherever the first layout
+  // put it and the graph only tidied itself up later, when some unrelated chat frame
+  // arrived. Keyed on the topology, so renaming instructions does not reshuffle the
+  // canvas while the user is reading it.
+  const topologySignature = useMemo(
+    () =>
+      (entry?.definition ?? [])
+        .map((agent) => `${agent.origin}>${[...(agent.tools ?? [])].sort().join(",")}`)
+        .sort()
+        .join("|"),
+    [entry?.definition]
+  );
+  const previousTopologyRef = useRef(topologySignature);
+  useEffect(() => {
+    if (previousTopologyRef.current === topologySignature) return;
+    previousTopologyRef.current = topologySignature;
+    shouldForceLayoutRef.current = true;
+  }, [topologySignature]);
 
   // After nodes/edges update, run animated relayout once
   useEffect(() => {
-    if (!canEdit && selectedNetwork && shouldForceLayoutRef.current) {
+    if (entry && shouldForceLayoutRef.current) {
       // reset the latch before invoking to avoid loops
       shouldForceLayoutRef.current = false;
 
@@ -591,18 +906,18 @@ const EditorAgentFlow = ({
         handleForceLayout();
       });
     }
-  }, [nodes, edges, canEdit, selectedNetwork, handleForceLayout]);
+  }, [nodes, edges, entry, handleForceLayout]);
 
   // Monitor for agent network name changes to show launch button
   useEffect(() => {
-    if (!canEdit && selectedNetwork) {
+    if (selectedNetwork) {
       const currentName = getLatestAgentNetworkName();
       if (currentName && currentName !== lastSeenNameRef.current) {
         lastSeenNameRef.current = currentName;
         setShowLaunchButton(true);
       }
     }
-  }, [progressTick, slyDataTick, selectedNetwork, canEdit, getLatestAgentNetworkName]);
+  }, [progressTick, slyDataTick, selectedNetwork, getLatestAgentNetworkName]);
 
 
   return (
@@ -612,20 +927,23 @@ const EditorAgentFlow = ({
       position: 'relative',
       display: 'flex'
     }}>
-      {/* Editor Palette */}
-      {canEdit &&
-        <EditorPalette 
-          onNetworkCreated={onNetworkCreated}
-          onNetworkSelected={onNetworkSelected}
-        />
-      }
-      
       {/* Main Flow Area */}
       <Box sx={{ 
         flexGrow: 1, 
         position: 'relative',
         backgroundColor: theme.palette.background.default
       }}>
+        {/*
+          Inside the flow area, not beside it: the palette is a notch floating over
+          the canvas now, so it must be positioned against the canvas rather than
+          taking a column of its own out of the row.
+        */}
+        <EditorPalette
+          selectedNetwork={selectedNetwork}
+          needsFrontman={(entry?.definition?.length ?? 0) === 0}
+          disabledReason={paletteDisabledReason}
+          onAddItem={handlePaletteAdd}
+        />
         <ReactFlow
         nodes={nodes}
         // @xyflow/react 12 defaults --xy-controls-button-color-default to
@@ -642,7 +960,19 @@ const EditorAgentFlow = ({
         onNodeClick={onNodeClick}
         onNodeDoubleClick={onNodeDoubleClick}
         onNodeContextMenu={onNodeContextMenu}
+        onEdgeContextMenu={onEdgeContextMenu}
+        onNodesDelete={onNodesDelete}
+        onEdgesDelete={onEdgesDelete}
+        // Both, because the key a user calls "delete" differs by keyboard: the Mac
+        // key labelled delete reports "Backspace", while "Delete" is a PC delete or
+        // Mac fn+delete. xyflow binds only Backspace by default.
+        deleteKeyCode={["Delete", "Backspace"]}
+        onReconnect={onReconnect}
+        edgesReconnectable
         onPaneClick={onPaneClick}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         defaultEdgeOptions={{
@@ -677,11 +1007,74 @@ const EditorAgentFlow = ({
         onDuplicate={handleDuplicateAgent}
         onAddChild={handleAddChildAgent}
         onClose={() => setContextMenu({ visible: false, x: 0, y: 0, nodeId: "" })}
-        enableEditing={pluginManualEditor} 
+        canAddChild={canHaveChildren(entry?.definition ?? [], contextMenu.nodeId)}
+        canDuplicate={canDuplicate(entry?.definition ?? [], contextMenu.nodeId)}
+        canDelete={canDelete(entry?.definition ?? [], contextMenu.nodeId)}
+      />
+
+      {/* Name the network before its first agent exists */}
+      <Dialog
+        open={Boolean(pendingFirstItem)}
+        onClose={() => setPendingFirstItem(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ pb: 1 }}>Name this agent network</DialogTitle>
+        <DialogContent sx={{ pb: 1 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            A network needs a name before it can be saved, so this is asked once, up
+            front. Everything you build after this is saved as you go.
+          </Typography>
+          <NetworkNameField
+            onSubmit={async (name) => {
+              const item = pendingFirstItem;
+              setPendingFirstItem(null);
+              if (!item) return;
+              await handleNameNetwork(name);
+              // Name the frontman after the network rather than leaving every network
+              // with an agent called "frontman": the name shows up in the generated
+              // HOCON and in the chat, where "frontman" says nothing about what it
+              // does. Renameable afterwards from the agent panel.
+              await addPaletteItem(
+                item === FRONTMAN_ITEM ? { ...item, agentName: `${name}_agent` } : item
+              );
+            }}
+            onCancel={() => setPendingFirstItem(null)}
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2, pt: 0, justifyContent: 'flex-start' }}>
+          {/*
+            Building by hand is one way in, not the only one. Offering the other here
+            costs a line and saves a user who opened this dialog without realising
+            they could simply describe what they want.
+          */}
+          <Button
+            size="small"
+            startIcon={<ChatIcon fontSize="small" />}
+            onClick={() => {
+              setPendingFirstItem(null);
+              requestChatFocus();
+            }}
+            sx={{ textTransform: 'none' }}
+          >
+            Describe it in chat instead
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Connection Context Menu */}
+      <EdgeContextMenu
+        visible={edgeMenu.visible}
+        x={edgeMenu.x}
+        y={edgeMenu.y}
+        source={edgeMenu.source}
+        target={edgeMenu.target}
+        onDelete={handleDeleteConnection}
+        onClose={closeEdgeMenu}
       />
 
       {/* Network Info Panel */}
-      {selectedNetwork && (
+      {entry && (
         <Paper
           elevation={3}
           sx={{
@@ -695,65 +1088,116 @@ const EditorAgentFlow = ({
             minWidth: 200
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-            <Typography variant="subtitle1" sx={{ 
-              fontWeight: 600, 
-              color: theme.palette.text.primary
-            }}>
-              Editing: {selectedNetwork}
-            </Typography>
-            <Tooltip title="Reorganize Layout">
-              <span style={{ display: 'inline-flex' }}>
-                <IconButton
-                  size="small"
-                  onClick={handleForceLayout}
-                  disabled={nodes.length === 0}
-                  sx={{
-                    color: theme.palette.primary.main,
-                    '&:hover': {
-                      backgroundColor: theme.palette.primary.main + '20'
-                    }
-                  }}
-                >
-                  <LayoutIcon fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
-          </Box>
-          
-          <Box sx={{ color: theme.palette.text.secondary }}>
-            <Typography variant="body2" sx={{ color: theme.palette.text.primary }}>
-              Nodes: {nodes.length}
-            </Typography>
-            <Typography variant="body2" sx={{ color: theme.palette.text.primary }}>
-              Edges: {edges.length}
-            </Typography>
-            {selectedNodeId && (
-              <Box sx={{ 
-                mt: 1, 
-                pt: 1, 
-                borderTop: `1px solid ${theme.palette.divider}` 
-              }}>
-                <Typography variant="body2" sx={{ 
-                  color: theme.palette.primary.main,
-                  fontWeight: 500
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+            {showNameField ? (
+              <NetworkNameField
+                initialName={entry?.networkName ?? ''}
+                onSubmit={(name) => { setIsNamingNetwork(false); void handleNameNetwork(name); }}
+                onCancel={entry?.networkName ? () => setIsNamingNetwork(false) : undefined}
+              />
+            ) : (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                <Typography variant="subtitle1" noWrap sx={{
+                  fontWeight: 600,
+                  color: theme.palette.text.primary
                 }}>
-                  Selected: {selectedNodeId}
+                  Editing: {networkLabel}
                 </Typography>
+                {/*
+                  Was gated on isDraft, which turns false the moment the network is
+                  named and selected — so the rename affordance disappeared exactly
+                  when the user had a name to change. Renaming saves the network again
+                  under the new name and leaves the old entry in the registry, which
+                  the field's own helper text says.
+                */}
+                <Tooltip title="Rename this network">
+                  <IconButton size="small" onClick={() => setIsNamingNetwork(true)}>
+                    <RenameIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
               </Box>
             )}
+            <Box sx={{ display: 'flex', gap: 0.5 }}>
+              {/*
+                The editor refuses a few things on purpose, and a refusal the user
+                cannot explain reads as a bug. The rules live here so they are
+                discoverable before something is greyed out, not only after.
+              */}
+              <Tooltip
+                arrow
+                placement="right"
+                title={
+                  <Box sx={{ p: 0.5 }}>
+                    <Typography variant="caption" sx={{ fontWeight: 700, display: 'block', mb: 0.5 }}>
+                      How Manual Editing Works
+                    </Typography>
+                    {EDITING_RULES.map((rule) => (
+                      <Typography key={rule} variant="caption" sx={{ display: 'block', mb: 0.25 }}>
+                        • {rule}
+                      </Typography>
+                    ))}
+                  </Box>
+                }
+              >
+                <IconButton size="small" sx={{ color: theme.palette.text.secondary }}>
+                  <HelpIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Reorganize Layout">
+                <span style={{ display: 'inline-flex' }}>
+                  <IconButton
+                    size="small"
+                    onClick={handleForceLayout}
+                    disabled={nodes.length === 0}
+                    sx={{
+                      color: theme.palette.primary.main,
+                      '&:hover': {
+                        backgroundColor: theme.palette.primary.main + '20'
+                      }
+                    }}
+                  >
+                    <LayoutIcon fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Box>
           </Box>
+          
+          {/*
+            Node and edge counts used to live here. The graph is on screen and the
+            sidebar already lists the agents, so they were a second and third place to
+            read the same thing while making this panel three lines tall.
+          */}
+          {pendingIssues.length > 0 && (
+            // Not saved, and why. Silence here would look like a save that worked.
+            <Box sx={{ mt: 1, pt: 1, borderTop: `1px solid ${theme.palette.divider}`, maxWidth: 300 }}>
+              <Typography variant="caption" sx={{ color: theme.palette.warning.main, fontWeight: 600 }}>
+                Not saved yet
+              </Typography>
+              {pendingIssues.map((issue) => (
+                <Typography key={issue} variant="caption" sx={{ display: 'block', color: theme.palette.text.secondary }}>
+                  {issue}
+                </Typography>
+              ))}
+            </Box>
+          )}
         </Paper>
       )}
 
-      {/* Launch Button with Dropdown */}
-      {showLaunchButton && (
+      {/* Launch Button with Dropdown, and starting over */}
+      {(showLaunchButton || hasNetworkToLaunch) && (
         <Box
           sx={{
             position: 'absolute',
-            top: 16,
-            right: 180, // Position to the left of Layout Controls
+            top: 76,
+            // Below the layout controls rather than beside them. Those became a
+            // single wide row and were sitting on top of these buttons; stacking is
+            // what keeps both readable whatever the canvas width.
+            right: 60,
             zIndex: 20,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
           }}
         >
           {pluginCruse ? (
@@ -907,6 +1351,40 @@ const EditorAgentFlow = ({
               </span>
             </Tooltip>
           )}
+
+          {/*
+            Always available, not only while a draft is open: once a chat turn names
+            the network this stopped being a draft and the button vanished, which is
+            exactly when a user is most likely to want to start another one.
+          */}
+          <Tooltip title={`${isDraft ? "Start a new draft, discarding this one." : "Start a new agent network."} You can always describe a network in the chat instead of building it by hand.`}>
+              <span style={{ display: 'inline-flex' }}>
+                <IconButton
+                  onClick={() => {
+                    // Start over the same way the Editor starts: ask for a name, then
+                    // put the frontman down. A draft therefore always has both, and
+                    // nothing can be added before the network's entry point exists.
+                    startNewSession();
+                    setPendingFirstItem(FRONTMAN_ITEM);
+                  }}
+                  sx={{
+                    width: 56,
+                    height: 56,
+                    backgroundColor: alpha(theme.palette.background.paper, 0.95),
+                    backdropFilter: 'blur(8px)',
+                    border: `1px solid ${theme.palette.divider}`,
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+                    color: theme.palette.text.secondary,
+                    '&:hover': {
+                      backgroundColor: theme.palette.action.hover,
+                      color: theme.palette.primary.main,
+                    },
+                  }}
+                >
+                <NewDraftIcon />
+              </IconButton>
+            </span>
+          </Tooltip>
         </Box>
       )}
 
@@ -919,29 +1397,25 @@ const EditorAgentFlow = ({
             top: 16,
             right: 60, // Move left to avoid ReactFlow controls
             zIndex: 20,
-            p: 1,
+            px: 1.25,
+            py: 0.5,
+            borderRadius: 2,
             backgroundColor: alpha(theme.palette.background.paper, 0.95),
             backdropFilter: 'blur(8px)',
-            minWidth: 80,
-            maxWidth: 140
+            // Each control is one row of label-then-slider rather than a stacked
+            // block, which is what made this taller than the canvas needed.
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
           }}
         >
-          <Typography variant="caption" sx={{ 
-            fontWeight: 600, 
-            color: theme.palette.text.secondary,
-            display: 'block',
-            mb: 0.1,
-            fontSize: '0.6rem'
-          }}>
-            Layout Controls
-          </Typography>
-          
-          <Box sx={{ mb: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
             <Typography variant="caption" sx={{ 
-              color: theme.palette.text.primary,
-              fontSize: '0.6rem'
+              color: theme.palette.text.secondary,
+              fontSize: '0.6rem',
+              whiteSpace: 'nowrap'
             }}>
-              Radius: {tempBaseRadius}
+              Radius {tempBaseRadius}
             </Typography>
             <Slider
               size="small"
@@ -963,17 +1437,19 @@ const EditorAgentFlow = ({
                 },
                 '& .MuiSlider-rail': {
                   height: 2
-                }
+                },
+                width: 64,
               }}
             />
           </Box>
           
-          <Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
             <Typography variant="caption" sx={{ 
-              color: theme.palette.text.primary,
-              fontSize: '0.6rem'
+              color: theme.palette.text.secondary,
+              fontSize: '0.6rem',
+              whiteSpace: 'nowrap'
             }}>
-              Spacing: {tempLevelSpacing}
+              Spacing {tempLevelSpacing}
             </Typography>
             <Slider
               size="small"
@@ -995,28 +1471,35 @@ const EditorAgentFlow = ({
                 },
                 '& .MuiSlider-rail': {
                   height: 2
-                }
+                },
+                width: 64,
               }}
             />
           </Box>
         </Paper>
       )}
 
-        {!selectedNetwork && (
+        {nodes.length === 0 && (
           <Box sx={{
             position: 'absolute',
             inset: 0,
             display: 'flex',
             alignItems: 'center',
-            justifyContent: 'center'
+            justifyContent: 'center',
+            // Must not intercept drags. This overlay covers the whole canvas, and as
+            // a sibling of <ReactFlow> anything dropped on it never reaches the
+            // canvas handler, so dropping onto an empty canvas silently did nothing.
+            pointerEvents: 'none'
           }}>
-            <Typography variant="h6" sx={{ 
+            <Typography variant="h6" sx={{
               color: theme.palette.text.secondary,
-              textAlign: 'center'
+              textAlign: 'center',
+              // Broken deliberately rather than left to wrap: the two halves are the
+              // two ways in, so the line break carries meaning.
+              whiteSpace: 'pre-line',
+              lineHeight: 1.6
             }}>
-              {canEdit
-                ? "Select a network from the sidebar to start editing"
-                : "Awaiting Agent design..."}
+              {'Click or Drag an agent from the palette,\nselect a network from the sidebar, or describe one in the chat'}
             </Typography>
           </Box>
         )}
@@ -1024,12 +1507,17 @@ const EditorAgentFlow = ({
 
       {/* Network Agent Editor Panel */}
       <NetworkAgentEditorPanel
-        selectedDesignId={selectedDesignId}
+        networkId={networkId}
         selectedAgentName={selectedAgentName}
         onAgentUpdated={handleAgentUpdated}
+        onAgentRenamed={(newName) => {
+          // Follow the agent so the panel and the canvas selection do not stay on a
+          // name that no longer exists.
+          setSelectedAgentName(newName);
+          setSelectedNodeId(newName);
+        }}
         onClose={() => { setSelectedAgentName(null); setAutoExpandPanel(false); isPanelOpenRef.current = false; }}
         autoExpand={autoExpandPanel}
-        enableEditing={pluginManualEditor}
       />
     </Box>
   );

--- a/nsflow/frontend/src/components/EditorLogsPanel.tsx
+++ b/nsflow/frontend/src/components/EditorLogsPanel.tsx
@@ -25,14 +25,12 @@ import {
   alpha,
   Collapse 
 } from "@mui/material";
-import { 
-  ExpandLess as ChevronUpIcon,
-  ExpandMore as ChevronDownIcon,
-  Terminal as TerminalIcon,
-  Clear as ClearIcon,
-  PushPin as PinIcon,
-  PushPinOutlined as UnpinIcon
-} from "@mui/icons-material";
+import ChevronUpIcon from "@mui/icons-material/ExpandLess";
+import ChevronDownIcon from "@mui/icons-material/ExpandMore";
+import TerminalIcon from "@mui/icons-material/Terminal";
+import ClearIcon from "@mui/icons-material/Clear";
+import PinIcon from "@mui/icons-material/PushPin";
+import UnpinIcon from "@mui/icons-material/PushPinOutlined";
 import LogsPanel from "./LogsPanel";
 
 export interface EditorLogsPanelProps {

--- a/nsflow/frontend/src/components/EditorPalette.tsx
+++ b/nsflow/frontend/src/components/EditorPalette.tsx
@@ -14,534 +14,473 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useState, useEffect } from 'react';
+/**
+ * The editor's node library, as a floating notch on the edge of the canvas.
+ *
+ * It used to be a permanent drawer holding a fixed slice of the width whether or not
+ * anyone was using it. Here it is a small vertical pill of icons: one to add an
+ * agent, and one per source of things to reference. Each source opens a short
+ * searchable list beside its icon and closes again on a click anywhere else, so the
+ * canvas keeps the space.
+ *
+ * Everything can be clicked or dragged. A click is quicker and is the only way in
+ * when the canvas is empty and there is nothing to drop onto; a drag lets the user
+ * pick the parent. The canvas owns the mutation either way.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 import {
   Box,
-  Drawer,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  IconButton,
-  Typography,
+  Chip,
+  ClickAwayListener,
   Divider,
-  Collapse,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  TextField,
-  Button,
+  Grow,
+  IconButton,
+  InputAdornment,
+  List,
+  ListItemButton,
+  ListItemText,
   Paper,
-  useTheme,
+  Popper,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
   alpha,
-  Autocomplete
-} from '@mui/material';
+  useTheme,
+} from "@mui/material";
+import NetworkIcon from "@mui/icons-material/AccountTree";
+import AddIcon from "@mui/icons-material/Add";
+import ClearIcon from "@mui/icons-material/Clear";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import ToolboxIcon from "@mui/icons-material/Handyman";
+import McpIcon from "@mui/icons-material/Hub";
+import SearchIcon from "@mui/icons-material/Search";
+
+import { useApiPort } from "../context/ApiPortContext";
 import {
-  ChevronLeft as ChevronLeftIcon,
-  ChevronRight as ChevronRightIcon,
-  Palette as PaletteIcon,
-  CloudDownload as EditFromRegistryIcon,
-  Add as CreateNewIcon,
-  ViewModule as TemplateIcon,
-  ExpandLess,
-  ExpandMore,
-  AccountTree as HierarchicalIcon,
-  LinearScale as SequentialIcon,
-  Person as SingleAgentIcon
-} from '@mui/icons-material';
-import { useApiPort } from '../context/ApiPortContext';
+  FRONTMAN_ITEM,
+  NEW_AGENT_ITEM,
+  PALETTE_DRAG_TYPE,
+  type PaletteCategory,
+  type PaletteItem,
+  fetchPaletteItems,
+  groupByCategory,
+  rankPaletteItems,
+} from "../state/paletteSources";
 
-const drawerWidth = 280;
+/** The three sources that open a list, in the order they appear on the notch. */
+/**
+ * One entry per source, with a colour of its own.
+ *
+ * Fixed pastels rather than palette roles: the rail is dark in both themes, so a
+ * theme-derived colour would either wash out on it or change meaning between modes.
+ * These are light enough to read on the dark rail and distinct enough to tell the
+ * three sources apart at a glance.
+ */
+const SOURCES: Array<{
+  category: PaletteCategory;
+  icon: ReactElement;
+  empty: string;
+  color: string;
+}> = [
+  {
+    category: "Agent Networks",
+    icon: <NetworkIcon />,
+    empty: "No other agent networks to reference yet.",
+    color: "#8ec5ff",
+  },
+  {
+    category: "Toolbox",
+    icon: <ToolboxIcon />,
+    empty: "No toolbox tools configured.",
+    color: "#ffd28a",
+  },
+  {
+    category: "MCP Servers",
+    icon: <McpIcon />,
+    empty: "No MCP servers connected.",
+    color: "#c3b1f5",
+  },
+];
 
-interface TemplateParams {
-  type: 'single_agent' | 'hierarchical' | 'sequential';
-  levels?: number;
-  agents_per_level?: number[];
-  sequence_length?: number;
-  agent_name?: string;
-}
+/**
+ * How tall an open list may be.
+ *
+ * Deliberately close to the height of the notch itself, so the list reads as
+ * belonging to it rather than as a panel that has taken over the canvas.
+ */
+const LIST_MAX_HEIGHT = 240;
+const LIST_WIDTH = 270;
+const NOTCH_BUTTON_SIZE = 44;
 
 interface EditorPaletteProps {
-  onNetworkCreated: () => void; // Callback to refresh sidebar
-  onNetworkSelected: (networkName: string) => void; // Callback to select network in sidebar
+  /** The network being edited, excluded from the draggable networks list. */
+  selectedNetwork?: string;
+  /**
+   * True while the canvas has no frontman. The add button then offers the frontman,
+   * since a network has exactly one and it has to come first.
+   */
+  needsFrontman: boolean;
+  /**
+   * Why nothing can be added right now, or undefined when it can. Set when the
+   * selected agent cannot take a down-chain agent, which is true of a toolbox tool
+   * and of an external reference.
+   */
+  disabledReason?: string;
+  /** Put an item on the canvas. The canvas decides what it attaches to. */
+  onAddItem: (item: PaletteItem) => void;
 }
 
-const EditorPalette = ({ onNetworkCreated, onNetworkSelected }: EditorPaletteProps) => {
+const EditorPalette = ({
+  selectedNetwork,
+  needsFrontman,
+  disabledReason,
+  onAddItem,
+}: EditorPaletteProps) => {
   const theme = useTheme();
   const { apiUrl, isReady } = useApiPort();
-  
-  const [open, setOpen] = useState(false);
-  const [registryNetworks, setRegistryNetworks] = useState<string[]>([]);
-  const [selectedRegistryNetwork, setSelectedRegistryNetwork] = useState<string>('');
-  const [templateMenuOpen, setTemplateMenuOpen] = useState(false);
-  const [templateParams, setTemplateParams] = useState<TemplateParams>({
-    type: 'single_agent',
-    levels: 2,
-    agents_per_level: [1, 2],
-    sequence_length: 3,
-    agent_name: 'frontman'
-  });
-  const [loading, setLoading] = useState(false);
 
-  // Fetch registry networks
-  const fetchRegistryNetworks = async () => {
-    if (!isReady || !apiUrl) return;
+  const [loaded, setLoaded] = useState<PaletteItem[]>([]);
+  const [openCategory, setOpenCategory] = useState<PaletteCategory | null>(null);
+  const [query, setQuery] = useState("");
+  const anchors = useRef<Partial<Record<PaletteCategory, HTMLElement | null>>>({});
 
-    try {
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks`);
-      if (!response.ok) return;
+  // The add button offers the frontman on a blank canvas and a plain agent after
+  // that, which is the only thing about it that changes.
+  const addItem = needsFrontman ? FRONTMAN_ITEM : NEW_AGENT_ITEM;
 
-      const data = await response.json();
-      setRegistryNetworks(data.registry_networks || []);
-    } catch (err) {
-      console.error('Error fetching registry networks:', err);
-    }
-  };
-
+  // Loaded on first use rather than on mount, and refreshed whenever a list opens, so
+  // a network generated since the last look shows up.
   useEffect(() => {
-    if (open) {
-      fetchRegistryNetworks();
-    }
-  }, [open, isReady, apiUrl]);
+    if (!openCategory || !isReady || !apiUrl) return;
+    let cancelled = false;
+    fetchPaletteItems(apiUrl, selectedNetwork).then((items) => {
+      if (!cancelled) setLoaded(items);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [openCategory, isReady, apiUrl, selectedNetwork]);
 
-  const handleDrawerToggle = () => {
-    setOpen(!open);
-  };
+  const grouped = useMemo(() => groupByCategory(rankPaletteItems(loaded, query)), [loaded, query]);
 
+  const closeList = useCallback(() => {
+    setOpenCategory(null);
+    setQuery("");
+  }, []);
 
-  // Action 1: Edit from Registry
-  const handleEditFromRegistry = async () => {
-    if (!selectedRegistryNetwork || !apiUrl) return;
+  // A list left open when the last agent goes must not stay open over a canvas that
+  // can no longer accept anything from it.
+  useEffect(() => {
+    if (needsFrontman && openCategory) closeList();
+  }, [needsFrontman, openCategory, closeList]);
 
-    setLoading(true);
-    try {
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks/load/${selectedRegistryNetwork}`, {
-        method: 'POST'
-      });
+  const toggleList = useCallback((category: PaletteCategory) => {
+    setQuery("");
+    setOpenCategory((current) => (current === category ? null : category));
+  }, []);
 
-      if (response.ok) {
-        const result = await response.json();
-        console.log('Network loaded from registry:', result);
-        
-        // Refresh sidebar and select the new network
-        onNetworkCreated();
-        
-        // The new network name should be in the response
-        if (result.network_name) {
-          onNetworkSelected(result.network_name);
-        }
-        
-        setSelectedRegistryNetwork('');
-        setOpen(false);
-      } else {
-        console.error('Failed to load network from registry');
+  const onDragStart = useCallback(
+    (event: React.DragEvent, item: PaletteItem) => {
+      if (disabledReason) {
+        event.preventDefault();
+        return;
       }
-    } catch (err) {
-      console.error('Error loading network from registry:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
+      event.dataTransfer.setData(PALETTE_DRAG_TYPE, JSON.stringify(item));
+      event.dataTransfer.effectAllowed = "move";
+    },
+    [disabledReason]
+  );
 
-  // Action 2: Create New Agent Network
-  const handleCreateNew = async () => {
-    if (!apiUrl) return;
+  const handleAdd = useCallback(
+    (item: PaletteItem) => {
+      if (disabledReason) return;
+      onAddItem(item);
+      closeList();
+    },
+    [disabledReason, onAddItem, closeList]
+  );
 
-    setLoading(true);
-    try {
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks/create`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          type: 'single_agent'
-        })
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        console.log('New network created:', result);
-        
-        // Refresh sidebar and select the new network
-        onNetworkCreated();
-        
-        if (result.network_name) {
-          onNetworkSelected(result.network_name);
-        }
-        
-        setOpen(false);
-      } else {
-        console.error('Failed to create new network');
-      }
-    } catch (err) {
-      console.error('Error creating new network:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Action 3: Create from Template
-  const handleCreateFromTemplate = async () => {
-    if (!apiUrl) return;
-
-    setLoading(true);
-    try {
-      const requestBody: any = {
-        type: templateParams.type
-      };
-
-      // Add template-specific parameters
-      if (templateParams.type === 'hierarchical') {
-        requestBody.levels = templateParams.levels;
-        requestBody.agents_per_level = templateParams.agents_per_level;
-      } else if (templateParams.type === 'sequential') {
-        requestBody.sequence_length = templateParams.sequence_length;
-      } else if (templateParams.type === 'single_agent') {
-        requestBody.agent_name = templateParams.agent_name;
-      }
-
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks/create`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(requestBody)
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        console.log('Template network created:', result);
-        
-        // Refresh sidebar and select the new network
-        onNetworkCreated();
-        
-        if (result.network_name) {
-          onNetworkSelected(result.network_name);
-        }
-        
-        setTemplateMenuOpen(false);
-        setOpen(false);
-      } else {
-        console.error('Failed to create template network');
-      }
-    } catch (err) {
-      console.error('Error creating template network:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const updateAgentsPerLevel = (level: number, value: number) => {
-    const newAgentsPerLevel = [...templateParams.agents_per_level!];
-    newAgentsPerLevel[level] = value;
-    setTemplateParams({ ...templateParams, agents_per_level: newAgentsPerLevel });
-  };
-
-  return (
-    <Drawer
-        variant="permanent"
-        open={open}
+  /** One row of an open list: click to add, or drag onto a particular agent. */
+  const renderRow = (item: PaletteItem) => (
+    <Box
+      key={`${item.category}:${item.agentName}`}
+      draggable={!disabledReason}
+      onDragStart={(event) => onDragStart(event, item)}
+      sx={{ "&:hover .palette-drag-handle": { opacity: 1 } }}
+    >
+      <ListItemButton
+        dense
+        disabled={Boolean(disabledReason)}
+        onClick={() => handleAdd(item)}
         sx={{
-          width: open ? drawerWidth : 64,
-          flexShrink: 0,
-          whiteSpace: 'nowrap',
-          boxSizing: 'border-box',
-          '& .MuiDrawer-paper': {
-            width: open ? drawerWidth : 64,
-            transition: theme.transitions.create('width', {
-              easing: theme.transitions.easing.sharp,
-              duration: theme.transitions.duration.enteringScreen,
-            }),
-            overflowX: 'hidden',
-            backgroundColor: theme.palette.background.paper,
-            borderRight: `1px solid ${theme.palette.divider}`,
-            zIndex: theme.zIndex.drawer - 1, // Below the main sidebar
-            position: 'relative'
-          }
+          cursor: disabledReason ? "not-allowed" : "grab",
+          borderRadius: 1.5,
+          py: 0.5,
+          px: 1,
+          alignItems: "flex-start",
+          gap: 0.75,
+          "&:active": { cursor: disabledReason ? "not-allowed" : "grabbing" },
         }}
       >
-      {/* Header */}
-      <Box sx={{ 
-        display: 'flex', 
-        alignItems: 'center', 
-        justifyContent: open ? 'space-between' : 'center',
-        p: 1,
-        minHeight: 48,
-        borderBottom: `1px solid ${theme.palette.divider}`
-      }}>
-        {open && (
-          <Typography variant="subtitle2" sx={{ 
-            fontWeight: 600, 
-            color: theme.palette.text.primary,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1
-          }}>
-            <PaletteIcon sx={{ fontSize: 18 }} color="primary" />
-            Editor Palette
-          </Typography>
-        )}
-        <IconButton onClick={handleDrawerToggle} size="small">
-          {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-        </IconButton>
-      </Box>
-
-      <Divider />
-
-      {/* Actions List */}
-      <List sx={{ pt: 1 }}>
-        {/* Action 1: Edit from Registry */}
-        <ListItem disablePadding sx={{ display: 'block' }}>
-          <ListItemButton
-            sx={{
-              minHeight: 48,
-              justifyContent: open ? 'initial' : 'center',
-              px: 2.5,
-            }}
-            onClick={() => {
-              if (!open) setOpen(true);
-            }}
-          >
-            <ListItemIcon
-              sx={{
-                minWidth: 0,
-                mr: open ? 3 : 'auto',
-                justifyContent: 'center',
-              }}
-            >
-              <EditFromRegistryIcon color="primary" />
-            </ListItemIcon>
-            <ListItemText
-              primary="Edit from Registry"
-              sx={{ opacity: open ? 1 : 0 }}
-            />
-          </ListItemButton>
-          
-          {/* Registry Network Selection */}
-          <Collapse in={open} timeout="auto" unmountOnExit>
-            <Box sx={{ px: 1.5, pb: 1.5 }}>
-              <Autocomplete
-                size="small"
-                options={registryNetworks}
-                getOptionLabel={(option) => option}
-                value={selectedRegistryNetwork || null}
-                onChange={(_, newValue) => {
-                  setSelectedRegistryNetwork(newValue || '');
-                }}
-                renderInput={(params) => (
-                  <TextField 
-                    {...params} 
-                    label="Select Agent Network"
-                    sx={{ mb: 1 }}
-                  />
-                )}
-                sx={{ width: '100%' }}
-              />
-              <Button
-                variant="contained"
-                size="small"
-                fullWidth
-                disabled={!selectedRegistryNetwork || loading}
-                onClick={handleEditFromRegistry}
-                sx={{ 
-                  textTransform: 'none',
-                  py: 0.75
-                }}
-              >
-                {loading ? 'Loading...' : 'Load for Editing'}
-              </Button>
-            </Box>
-          </Collapse>
-        </ListItem>
-
-        <Divider />
-
-        {/* Action 2: Create New Agent Network */}
-        <ListItem disablePadding sx={{ display: 'block' }}>
-          <ListItemButton
-            sx={{
-              minHeight: 48,
-              justifyContent: open ? 'initial' : 'center',
-              px: 2.5,
-            }}
-            onClick={handleCreateNew}
-            disabled={loading}
-          >
-            <ListItemIcon
-              sx={{
-                minWidth: 0,
-                mr: open ? 3 : 'auto',
-                justifyContent: 'center',
-              }}
-            >
-              <CreateNewIcon color="success" />
-            </ListItemIcon>
-            <ListItemText
-              primary="Create New Network"
-              sx={{ opacity: open ? 1 : 0 }}
-            />
-          </ListItemButton>
-        </ListItem>
-
-        <Divider />
-
-        {/* Action 3: Create from Template */}
-        <ListItem disablePadding sx={{ display: 'block' }}>
-          <ListItemButton
-            sx={{
-              minHeight: 48,
-              justifyContent: open ? 'initial' : 'center',
-              px: 2.5,
-            }}
-            onClick={() => {
-              if (!open) setOpen(true);
-              setTemplateMenuOpen(!templateMenuOpen);
-            }}
-          >
-            <ListItemIcon
-              sx={{
-                minWidth: 0,
-                mr: open ? 3 : 'auto',
-                justifyContent: 'center',
-              }}
-            >
-              <TemplateIcon color="warning" />
-            </ListItemIcon>
-            <ListItemText
-              primary="Create from Template"
-              sx={{ opacity: open ? 1 : 0 }}
-            />
-            {open && (templateMenuOpen ? <ExpandLess /> : <ExpandMore />)}
-          </ListItemButton>
-
-          {/* Template Configuration */}
-          <Collapse in={open && templateMenuOpen} timeout="auto" unmountOnExit>
-            <Box sx={{ px: 1.5, pb: 1.5 }}>
-              <Paper elevation={1} sx={{ p: 1.5, backgroundColor: alpha(theme.palette.primary.main, 0.05) }}>
-                <FormControl fullWidth size="small" sx={{ mb: 1.5 }}>
-                  <InputLabel>Template Type</InputLabel>
-                  <Select
-                    value={templateParams.type}
-                    label="Template Type"
-                    onChange={(e) => setTemplateParams({ ...templateParams, type: e.target.value as any })}
-                  >
-                    <MenuItem value="single_agent">
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <SingleAgentIcon fontSize="small" />
-                        Single Agent
-                      </Box>
-                    </MenuItem>
-                    <MenuItem value="hierarchical">
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <HierarchicalIcon fontSize="small" />
-                        Hierarchical
-                      </Box>
-                    </MenuItem>
-                    <MenuItem value="sequential">
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <SequentialIcon fontSize="small" />
-                        Sequential
-                      </Box>
-                    </MenuItem>
-                  </Select>
-                </FormControl>
-
-                {/* Template Parameters - Animated */}
-                <Collapse in={true} timeout={300}>
-                  <Box>
-                    {/* Single Agent Parameters */}
-                    {templateParams.type === 'single_agent' && (
-                      <TextField
-                        fullWidth
-                        size="small"
-                        label="Agent Name"
-                        value={templateParams.agent_name}
-                        onChange={(e) => setTemplateParams({ ...templateParams, agent_name: e.target.value })}
-                        sx={{ mb: 1.5 }}
-                      />
-                    )}
-
-                    {/* Hierarchical Parameters */}
-                    {templateParams.type === 'hierarchical' && (
-                      <Box>
-                        <TextField
-                          fullWidth
-                          size="small"
-                          type="number"
-                          label="Levels"
-                          value={templateParams.levels}
-                          onChange={(e) => {
-                            const levels = parseInt(e.target.value) || 2;
-                            const agents_per_level = Array(levels).fill(0).map((_, i) => i === 0 ? 1 : 2);
-                            setTemplateParams({ ...templateParams, levels, agents_per_level });
-                          }}
-                          slotProps={{
-                            htmlInput: { min: 2, max: 5 }
-                          }}
-                          sx={{ mb: 1 }}
-                        />
-                        <Box sx={{ maxHeight: 120, overflowY: 'auto', pr: 0.5 }}>
-                          {templateParams.agents_per_level?.map((count, index) => (
-                            <TextField
-                              key={index}
-                              // fullWidth
-                              size="small"
-                              type="number"
-                              label={`Level ${index + 1}`}
-                              value={count}
-                              onChange={(e) => updateAgentsPerLevel(index, parseInt(e.target.value) || (index === 0 ? 1 : 2))}
-                              slotProps={{
-                                htmlInput: { min: index === 0 ? 1 : 1, max: 10 }
-                              }}
-                              disabled={index === 0} // Frontman level always 1
-                              sx={{ mb: 0.5, mt: 0.5 }}
-                            />
-                          ))}
-                        </Box>
-                      </Box>
-                    )}
-
-                    {/* Sequential Parameters */}
-                    {templateParams.type === 'sequential' && (
-                      <TextField
-                        fullWidth
-                        size="small"
-                        type="number"
-                        label="Sequence Length"
-                        value={templateParams.sequence_length}
-                        onChange={(e) => setTemplateParams({ ...templateParams, sequence_length: parseInt(e.target.value) || 3 })}
-                        slotProps={{
-                          htmlInput: { min: 2, max: 10 }
-                        }}
-                        sx={{ mb: 1.5 }}
-                      />
-                    )}
-                  </Box>
-                </Collapse>
-
-                <Button
-                  variant="contained"
+        <DragIndicatorIcon
+          className="palette-drag-handle"
+          sx={{
+            mt: 0.125,
+            fontSize: 16,
+            opacity: 0.25,
+            transition: "opacity 120ms",
+            color: "text.secondary",
+          }}
+        />
+        <ListItemText
+          primary={
+            <Stack direction="row" spacing={0.5} sx={{ alignItems: "center", minWidth: 0 }}>
+              <Typography variant="caption" sx={{ fontWeight: 700 }} noWrap title={item.agentName}>
+                {item.label}
+              </Typography>
+              {item.needsReauth && (
+                <Chip
                   size="small"
-                  fullWidth
-                  disabled={loading}
-                  onClick={handleCreateFromTemplate}
-                  sx={{ 
-                    textTransform: 'none',
-                    py: 0.75,
-                    mt: 1
+                  color="warning"
+                  variant="outlined"
+                  label="reconnect"
+                  sx={{ height: 18 }}
+                />
+              )}
+            </Stack>
+          }
+          secondary={item.description}
+          slotProps={{
+            secondary: {
+              variant: "caption",
+              sx: {
+                display: "-webkit-box",
+                WebkitLineClamp: 1,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+                fontSize: "0.68rem",
+                lineHeight: 1.35,
+              },
+            },
+          }}
+        />
+      </ListItemButton>
+    </Box>
+  );
+
+  // The rail is dark in both themes, so these are keyed to the rail rather than to
+  // the app's text palette, which would be unreadable on it under the light theme.
+  const notchButtonSx = {
+    width: NOTCH_BUTTON_SIZE,
+    height: NOTCH_BUTTON_SIZE,
+    color: alpha(theme.palette.common.white, 0.72),
+    "&:hover": {
+      backgroundColor: alpha(theme.palette.common.white, 0.14),
+      color: theme.palette.common.white,
+    },
+  } as const;
+
+  return (
+    <ClickAwayListener onClickAway={closeList}>
+      <Box
+        sx={{
+          position: "absolute",
+          left: 16,
+          top: "50%",
+          transform: "translateY(-50%)",
+          zIndex: 15,
+        }}
+      >
+        <Paper
+          elevation={8}
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 0.5,
+            p: 0.75,
+            // A pill rather than a panel: the notch should read as floating over the
+            // canvas, not as a region carved out of it. Tinted away from the paper
+            // colour every other surface uses, so it reads as a tool rail.
+            borderRadius: 6,
+            backgroundColor:
+              theme.palette.mode === "dark"
+                ? alpha(theme.palette.common.black, 0.72)
+                : alpha(theme.palette.grey[900], 0.9),
+            backdropFilter: "blur(10px)",
+            border: `1px solid ${alpha(theme.palette.common.white, 0.12)}`,
+            boxShadow: `0 8px 24px ${alpha(theme.palette.common.black, 0.45)}`,
+          }}
+        >
+          <Tooltip
+            placement="right"
+            title={
+              disabledReason ??
+              (needsFrontman
+                ? "Add the frontman, the agent a user interfaces with"
+                : "Add an agent. Click to attach it to the selection, or drag it onto an agent")
+            }
+          >
+            {/* The span keeps the tooltip alive while the button is disabled. */}
+            <span style={{ display: "inline-flex" }}>
+              <Box
+                draggable={!disabledReason}
+                onDragStart={(event) => onDragStart(event, addItem)}
+                sx={{ display: "inline-flex" }}
+              >
+                <IconButton
+                  disabled={Boolean(disabledReason)}
+                  onClick={() => handleAdd(addItem)}
+                  aria-label={needsFrontman ? "Add frontman" : "Add agent"}
+                  sx={{
+                    ...notchButtonSx,
+                    cursor: disabledReason ? "not-allowed" : "grab",
+                    color: theme.palette.success.light,
+                    backgroundColor: alpha(theme.palette.success.main, 0.22),
+                    "&:hover": { backgroundColor: alpha(theme.palette.success.main, 0.38) },
                   }}
                 >
-                  {loading ? 'Creating...' : 'Create from Template'}
-                </Button>
+                  <AddIcon />
+                </IconButton>
+              </Box>
+            </span>
+          </Tooltip>
+
+          <Divider flexItem sx={{ my: 0.25, borderColor: alpha(theme.palette.common.white, 0.14) }} />
+
+          {SOURCES.map((source) => (
+            <Tooltip
+              key={source.category}
+              placement="right"
+              title={
+                needsFrontman
+                  ? "Add the frontman first: everything else attaches to it"
+                  : source.category
+              }
+            >
+              {/* The span keeps the tooltip alive while the button is disabled. */}
+              <span style={{ display: "inline-flex" }}>
+                <IconButton
+                  ref={(element) => {
+                    anchors.current[source.category] = element;
+                  }}
+                  // Nothing can be referenced before there is an agent to attach it
+                  // to, and the first agent has to be the frontman.
+                  disabled={needsFrontman}
+                  onClick={() => toggleList(source.category)}
+                  aria-label={source.category}
+                  sx={{
+                    ...notchButtonSx,
+                    color: source.color,
+                    backgroundColor: alpha(source.color, 0.14),
+                    "&:hover": { backgroundColor: alpha(source.color, 0.3), color: source.color },
+                    "&.Mui-disabled": {
+                      color: alpha(source.color, 0.3),
+                      backgroundColor: alpha(theme.palette.common.white, 0.05),
+                    },
+                    ...(openCategory === source.category && {
+                      backgroundColor: alpha(source.color, 0.4),
+                      color: theme.palette.common.white,
+                    }),
+                  }}
+                >
+                  {source.icon}
+                </IconButton>
+              </span>
+            </Tooltip>
+          ))}
+        </Paper>
+
+        <Popper
+          open={Boolean(openCategory)}
+          anchorEl={openCategory ? anchors.current[openCategory] : null}
+          placement="right"
+          transition
+          modifiers={[{ name: "offset", options: { offset: [0, 12] } }]}
+          sx={{ zIndex: 16 }}
+        >
+          {({ TransitionProps }) => (
+            // Grows out of the icon it belongs to rather than fading in place, which
+            // reads as the notch opening rather than a panel appearing over it.
+            <Grow {...TransitionProps} timeout={180} style={{ transformOrigin: "left center" }}>
+              <Paper
+                elevation={10}
+                sx={{
+                  width: LIST_WIDTH,
+                  borderRadius: 3,
+                  overflow: "hidden",
+                  border: `1px solid ${theme.palette.divider}`,
+                  backgroundColor: alpha(theme.palette.background.paper, 0.98),
+                  backdropFilter: "blur(8px)",
+                }}
+              >
+                <Box sx={{ px: 1.25, pt: 1.25, pb: 0.75 }}>
+                  <Typography variant="caption" sx={{ fontWeight: 700, display: "block", mb: 0.75 }}>
+                    {openCategory} ({openCategory ? (grouped.get(openCategory) ?? []).length : 0})
+                  </Typography>
+                  <TextField
+                    size="small"
+                    fullWidth
+                    autoFocus
+                    placeholder="Search"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <SearchIcon fontSize="small" />
+                          </InputAdornment>
+                        ),
+                        endAdornment: query ? (
+                          <InputAdornment position="end">
+                            <IconButton
+                              size="small"
+                              onClick={() => setQuery("")}
+                              aria-label="Clear search"
+                            >
+                              <ClearIcon fontSize="small" />
+                            </IconButton>
+                          </InputAdornment>
+                        ) : undefined,
+                      },
+                    }}
+                  />
+                </Box>
+
+                <Box sx={{ maxHeight: LIST_MAX_HEIGHT, overflowY: "auto", px: 0.75, pb: 0.75 }}>
+                  {(() => {
+                    const items = openCategory ? grouped.get(openCategory) ?? [] : [];
+                    if (items.length > 0) return <List disablePadding>{items.map(renderRow)}</List>;
+                    return (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ px: 1, py: 1, display: "block" }}
+                      >
+                        {query
+                          ? "Nothing matches that search."
+                          : SOURCES.find((source) => source.category === openCategory)?.empty}
+                      </Typography>
+                    );
+                  })()}
+                </Box>
+
+                {disabledReason && (
+                  <Box sx={{ px: 1.5, py: 1, borderTop: `1px solid ${theme.palette.divider}` }}>
+                    <Typography variant="caption" color="warning.main">
+                      {disabledReason}
+                    </Typography>
+                  </Box>
+                )}
               </Paper>
-            </Box>
-          </Collapse>
-        </ListItem>
-      </List>
-    </Drawer>
+            </Grow>
+          )}
+        </Popper>
+      </Box>
+    </ClickAwayListener>
   );
 };
 

--- a/nsflow/frontend/src/components/EditorSidebar.tsx
+++ b/nsflow/frontend/src/components/EditorSidebar.tsx
@@ -15,36 +15,25 @@ limitations under the License.
 */
 
 import { useEffect, useState, useRef, useCallback } from "react";
-import { Box, Typography, TextField, Button,  Paper, Card, CardContent, Chip, InputAdornment,
-  useTheme, alpha, Popper, MenuItem, MenuList, ClickAwayListener, Grow, Autocomplete, CircularProgress, Tooltip } from "@mui/material";
-import { PolylineTwoTone as NetworkIcon, Search as SearchIcon,
-  SmartToy as RobotIcon, Refresh as RefreshIcon, WarningAmber as WarningAmberIcon, Close as CloseIcon } from "@mui/icons-material";
+import { Box, Typography, TextField, Paper, Card, CardContent, Chip, InputAdornment,
+  useTheme, alpha, Autocomplete, CircularProgress, Tooltip } from "@mui/material";
+import NetworkIcon from "@mui/icons-material/PolylineTwoTone";
+import SearchIcon from "@mui/icons-material/Search";
+import RobotIcon from "@mui/icons-material/SmartToy";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import CloseIcon from "@mui/icons-material/Close";
 import { useApiPort } from "../context/ApiPortContext";
 import { useChatContext } from "../context/ChatContext";
 import { useChatControls } from "../hooks/useChatControls";
 import { useNeuroSan } from "../context/NeuroSanContext";
-import { getFeatureFlags, toServedNetworkPath } from "../utils/config";
+import { toServedNetworkPath } from "../utils/config";
+import { selectEntry, useEditorNetworkStore } from "../state/editorNetworkStore";
+import { buildEditorGraph } from "../state/editorGraph";
+import { toConnectivityList } from "../state/definitionShape";
+import type { ConnectivityInfo } from "../uiCommon";
 
 
-interface EditingSession {
-  design_id: string;
-  network_name: string;
-  original_network_name?: string;
-  source: string;
-  agent_count: number;
-  created_at: string;
-  updated_at: string;
-  can_undo: boolean;
-  can_redo: boolean;
-  validation?: any;
-}
 
-interface NetworksResponse {
-  registry_networks: string[];
-  editing_sessions: EditingSession[];
-  total_registry: number;
-  total_sessions: number;
-}
 
 interface NetworkOption {
   id: string; // design_id for editing sessions, network name for registry
@@ -80,7 +69,6 @@ const EditorSidebar = ({
   refreshTrigger?: number; // trigger refresh from external components
   externalSelectedNetwork?: string; // Network selected externally (from EditorPalette)
 }) => {
-  const [networkOptions, setNetworkOptions] = useState<NetworkOption[]>([]);
   const [agents, setAgents] = useState<AgentNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -97,6 +85,10 @@ const EditorSidebar = ({
   const [lastChatMessageCount, setLastChatMessageCount] = useState(0);
   const theme = useTheme();
 
+  // The store is the authority for the definition the sidebar lists.
+  const entry = useEditorNetworkStore((state) => selectEntry(state, selectedNetworkId));
+  const reconcileFromServer = useEditorNetworkStore((state) => state.reconcileFromServer);
+
   // Load Existing Agent Network state (view mode)
   const [availableNetworks, setAvailableNetworks] = useState<string[]>([]);
   const [loadingNetworks, setLoadingNetworks] = useState(false);
@@ -106,128 +98,40 @@ const EditorSidebar = ({
   const networksEndRef = useRef<HTMLDivElement>(null);
   
   // Custom dropdown state
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const [dropdownSearchQuery, setDropdownSearchQuery] = useState("");
-  const anchorRef = useRef<HTMLDivElement>(null);
 
-  // Use manual editor plugin flag
-  const { pluginManualEditor } = getFeatureFlags();
-  const canEdit = !!pluginManualEditor;
   const didAutoSelectRef = useRef(false);
   const lastSeenNameRef = useRef<string | null>(null);
   const designPlaceholderRef = useRef<string | null>(null);
 
-  // Edit-mode: Fetch networks with state
-  const fetchNetworks = async () => {
-    console.log(`canEdit value: ${canEdit}`)
-    if (!isReady || !apiUrl || !canEdit) return;
-
-    try {
-      setLoading(true);
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks`);
-      
-      if (!response.ok) {
-        throw new Error(`Failed to fetch networks: ${response.statusText}`);
-      }
-
-      const data: NetworksResponse = await response.json();
-      // console.log('EditorSidebar: Raw API response:', data);
-      
-      // Convert only editing sessions to network options (registry networks handled by EditorPalette)
-      const options: NetworkOption[] = [];
-      
-      // Add editing sessions only if the user canEdit
-      data.editing_sessions.forEach(session => {
-        const option = {
-          id: session.design_id,
-          display_name: session.network_name,
-          type: 'editing_session' as const,
-          agent_count: session.agent_count,
-          source: session.source,
-          design_id: session.design_id
-        };
-        // console.log('EditorSidebar: Creating network option:', option);
-        options.push(option);
-      });
-      
-      // console.log('EditorSidebar: Final network options:', options);
-      setNetworkOptions(options);
-      setError("");
-    } catch (err: any) {
-      console.error("Error fetching networks:", err);
-      setError(`Failed to load networks: ${err.message}`);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Unified: fetch agents for both modes, returning the same nodes list
-  const fetchAgents = async (networkOption?: NetworkOption, definitionOverride?: Record<string, any>) => {
-    if (!isReady || !apiUrl) return;
-
-    try {
-      let response: Response;
-
-      if (canEdit) {
-        // Edit mode requires a design_id
-        if (!networkOption?.design_id) {
-          console.warn("fetchAgents: missing design_id in edit mode");
-          return;
-        }
-        console.log("EditorSidebar: Fetching agents (edit) for", networkOption.display_name, "design_id:", networkOption.design_id);
-        response = await fetch(`${apiUrl}/api/v1/andeditor/networks/${networkOption.design_id}/connectivity`);
-      } else {
-        // View-only mode requires an agentNetworkDefinition
-        const definition = definitionOverride ?? agentNetworkDefinition;
-        if (!definition) {
-          console.warn("fetchAgents: agentNetworkDefinition is not set in view-only mode");
-          return;
-        }
-        console.log("EditorSidebar: Fetching agents (view-only) from JSON definition");
-        response = await fetch(`${apiUrl}/api/v1/connectivity/from_json`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agent_network_definition: definition }),
-        });
-      }
-
-      if (!response.ok) {
-        const name = networkOption?.display_name || "(view-only)";
-        throw new Error(`Failed to fetch agents for ${name} — HTTP ${response.status}`);
-      }
-
-      const data = await response.json();
-      // Both endpoints return { nodes: [...] } — keep sidebar identical across modes
-      if (Array.isArray(data.nodes)) {
-        const sortedNodes = [...data.nodes].sort((a, b) =>
-          a.data?.label?.localeCompare(b.data?.label ?? "", undefined, { sensitivity: "base" })
-        );
-        setAgents(sortedNodes);
-      } else {
+  // Build the sidebar's agent list from the store. This used to POST the
+  // definition to /connectivity/from_json (or GET the andeditor session) purely to
+  // turn it into nodes; buildEditorGraph does the same thing in the browser.
+  const refreshAgentsFromStore = useCallback(
+    (definitionOverride?: unknown) => {
+      // Normalised, never trusted as a list. Callers hand this the raw
+      // agent_network_definition straight off a progress frame, and the designer's
+      // default progress style reports it as a DICT keyed by agent name. A dict has
+      // no `length`, so the empty check passed and buildEditorGraph then iterated an
+      // object: "is not iterable", thrown during render, blanking the whole page.
+      const definition =
+        (definitionOverride === undefined
+          ? entry?.definition
+          : toConnectivityList(definitionOverride)) ?? [];
+      if (definition.length === 0) {
         setAgents([]);
+        return;
       }
-    } catch (err) {
-      console.error("Error fetching agents:", err);
-      setAgents([]);
-    }
-  };
-
-  // Handle network selection
-  const handleNetworkSelect = (networkId: string) => {
-    const networkOption = networkOptions.find(option => option.id === networkId);
-    if (!networkOption) return;
-
-    setSelectedNetworkId(networkId);
-    setSelectedNetworkOption(networkOption);
-    onSelectNetwork(networkOption.display_name, canEdit ? networkOption.design_id : undefined);
-
-    if (canEdit) {
-      fetchAgents(networkOption);
-    } else {
-      // use current definition; refreshFromLogs already keeps it up to date
-      fetchAgents(undefined, agentNetworkDefinition || undefined);
-    }
-  };
+      const { nodes } = buildEditorGraph(definition, entry?.networkName ?? selectedNetworkId ?? "");
+      setAgents(
+        [...nodes].sort((a, b) =>
+          String(a.data?.label ?? "").localeCompare(String(b.data?.label ?? ""), undefined, {
+            sensitivity: "base",
+          })
+        ) as unknown as AgentNode[]
+      );
+    },
+    [entry?.definition, entry?.networkName, selectedNetworkId]
+  );
 
   // Filter agents based on search query
   const filteredAgents = agents.filter((agent) => {
@@ -237,30 +141,7 @@ const EditorSidebar = ({
     return label.includes(q) || instr.includes(q);
   });
 
-  // Filter network options based on dropdown search
-  const filteredNetworkOptions = networkOptions.filter((option) =>
-    option.display_name.toLowerCase().includes(dropdownSearchQuery.toLowerCase())
-  );
-
   // Dropdown controls
-  // Handle dropdown toggle
-  const handleDropdownToggle = () => {
-    setDropdownOpen(!dropdownOpen);
-    setDropdownSearchQuery("");
-  };
-
-  // Handle dropdown close
-  const handleDropdownClose = () => {
-    setDropdownOpen(false);
-    setDropdownSearchQuery("");
-  };
-
-  // Handle network selection from dropdown
-  const handleDropdownNetworkSelect = (networkId: string) => {
-    handleNetworkSelect(networkId);
-    handleDropdownClose();
-  };
-
   const refreshFromLogs = () => {
     const payload = getLatestNetworkPayload();
     // silently ignore; nothing to show yet
@@ -302,8 +183,6 @@ const EditorSidebar = ({
       agent_count: Object.keys(payload.agent_network_definition!).length,
     };
 
-    // always replace the list with the latest single option
-    setNetworkOptions([singleOption]);
     setAgentNetworkDefinition(payload.agent_network_definition!);
 
     const nameChanged =
@@ -313,7 +192,7 @@ const EditorSidebar = ({
 
     // Keep selection semantics identical: nothing selected by default;
     // once we have a valid message, set it if not set already
-    if (!canEdit && nameChanged) {
+    if (nameChanged) {
       didAutoSelectRef.current = true;
       lastSeenNameRef.current = nameFromPayload;
 
@@ -321,13 +200,13 @@ const EditorSidebar = ({
       setSelectedNetworkOption(singleOption);
       setSelectedLoadNetwork(nameFromPayload); // Sync the Autocomplete display
       onSelectNetwork(singleOption.display_name); // no design_id in view-only
-      fetchAgents(undefined, payload.agent_network_definition!); // avoid race
+      refreshAgentsFromStore(payload.agent_network_definition); // avoid race
     }
   };
 
   // Fetch available networks for Load Existing dropdown (view mode)
   useEffect(() => {
-    if (canEdit || !isNsReady || !apiUrl) return;
+    if (!isNsReady || !apiUrl) return;
     const fetchAvailableNetworks = async () => {
       setLoadingNetworks(true);
       try {
@@ -351,12 +230,10 @@ const EditorSidebar = ({
       }
     };
     fetchAvailableNetworks();
-  }, [canEdit, isNsReady, apiUrl, connectionType, host, port]);
+  }, [isNsReady, apiUrl, connectionType, host, port]);
 
   // Handler for loading an existing network (view mode)
   const handleLoadExistingNetwork = useCallback(async (networkName: string | null) => {
-    const network = targetNetwork || activeNetwork;
-
     setSelectedLoadNetwork(networkName);
 
     if (!networkName) {
@@ -380,8 +257,24 @@ const EditorSidebar = ({
         return;
       }
       const payload = await response.json();
-      const pretty = JSON.stringify(payload, null, 2);
-      addSlyDataMessage({ sender: "user", text: `\`\`\`json\n${pretty}\n\`\`\``, network: network });
+      const definition = payload?.agent_network_definition ?? payload;
+      // Straight into the store, which the canvas and this sidebar both render
+      // from. The old code posted it back as a sly_data chat message purely so it
+      // would come back around through the stream.
+      if (definition) {
+        reconcileFromServer(networkName, {
+          definition: Array.isArray(definition)
+            ? (definition as ConnectivityInfo[])
+            : Object.entries(definition).map(([origin, v]) => ({
+                origin,
+                tools: ((v ?? {}) as { tools?: string[]; down_chains?: string[] }).tools ??
+                  ((v ?? {}) as { down_chains?: string[] }).down_chains ?? [],
+                ...(v as Record<string, unknown>),
+              })) as ConnectivityInfo[],
+          networkName,
+        });
+        setSelectedNetworkId(networkName);
+      }
     } catch (e) {
       console.error("Error loading network definition:", e);
     } finally {
@@ -396,18 +289,14 @@ const EditorSidebar = ({
     setSelectedNetworkOption(null);
     setAgents([]);
     setError("");
-  }, [canEdit, isReady]);
+  }, [isReady]);
 
   // Initial load
   useEffect(() => {
     if (!isReady) return;
-    if (canEdit) {
-      fetchNetworks();
-    } else {
-      // reuse flow: hydrate from logs, then fetchAgents()
-      refreshFromLogs();
-    }
-  }, [isReady, apiUrl, canEdit]);
+    // hydrate from whatever the streams have already reported
+    refreshFromLogs();
+  }, [isReady, apiUrl]);
 
   // Refresh from logs
   useEffect(() => {
@@ -418,30 +307,18 @@ const EditorSidebar = ({
   // External refresh trigger
   useEffect(() => {
     if (!refreshTrigger || refreshTrigger <= 0) return;
-    if (canEdit) {
-      fetchNetworks();
-    } else {
-      refreshFromLogs();
-    }
-  }, [refreshTrigger, canEdit]);
+    refreshFromLogs();
+  }, [refreshTrigger]);
 
   // auto-select first session when none selected
+  // Select whatever the palette picked.
   useEffect(() => {
-    if (canEdit && networkOptions.length > 0 && !selectedNetworkId) {
-      const firstNetwork = networkOptions[0];
-      handleNetworkSelect(firstNetwork.id);
+    if (externalSelectedNetwork && externalSelectedNetwork !== selectedNetworkId) {
+      setSelectedNetworkId(externalSelectedNetwork);
+      onSelectNetwork(externalSelectedNetwork);
     }
-  }, [networkOptions, selectedNetworkId, canEdit]);
-
-  // EDIT MODE: handle external selection (EditorPalette)
-  useEffect(() => {
-    if (canEdit && externalSelectedNetwork && networkOptions.length > 0) {
-      const option = networkOptions.find(o => o.display_name === externalSelectedNetwork);
-      if (option && option.id !== selectedNetworkId) {
-        handleNetworkSelect(option.id);
-      }
-    }
-  }, [externalSelectedNetwork, networkOptions, selectedNetworkId, canEdit]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [externalSelectedNetwork]);
 
   // monitor and refresh sessions/agents on new messages
   useEffect(() => {
@@ -450,43 +327,32 @@ const EditorSidebar = ({
     // Only react when count increases and not the initial system message
     if (currentCount > lastChatMessageCount && currentCount > 1) {
       setTimeout(() => {
-        if (canEdit) {
-          fetchNetworks();
-          if (selectedNetworkOption) {
-            fetchAgents(selectedNetworkOption);
-          }
-        } else {
-          // reuse: update from logs, then unified fetchAgents()
-          refreshFromLogs();
-        }
+        refreshFromLogs();
       }, 1000);
     }
 
     setLastChatMessageCount(currentCount);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatMessages.length, lastChatMessageCount, selectedNetworkOption, slyDataTick, canEdit]);
+  }, [chatMessages.length, lastChatMessageCount, selectedNetworkOption, slyDataTick]);
 
   // keep true by default, but turn it off in view mode:
   useEffect(() => {
-    if (!canEdit) {
-      setLoading(false);
-      didAutoSelectRef.current = false;
-      lastSeenNameRef.current = null;
-    }
-  }, [targetNetwork, canEdit]);
+    setLoading(false);
+    didAutoSelectRef.current = false;
+    lastSeenNameRef.current = null;
+  }, [targetNetwork]);
 
   // Rebuild agent list whenever the raw definition changes (view-only)
   useEffect(() => {
-    if (canEdit) return;
     if (!agentNetworkDefinition) return;
-    fetchAgents(undefined, agentNetworkDefinition);
+    refreshAgentsFromStore(agentNetworkDefinition);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [canEdit, agentNetworkDefinition]);
+  }, [agentNetworkDefinition]);
 
   // Auto-load network from URL query param (e.g. /editor?loadNetwork=basic/hello_world)
   const [autoLoadHandled, setAutoLoadHandled] = useState(false);
   useEffect(() => {
-    if (autoLoadHandled || canEdit || loadingNetworks || !availableNetworks.length) return;
+    if (autoLoadHandled || loadingNetworks || !availableNetworks.length) return;
     const params = new URLSearchParams(window.location.search);
     const loadNetwork = params.get('loadNetwork');
     if (loadNetwork && availableNetworks.includes(loadNetwork)) {
@@ -499,7 +365,7 @@ const EditorSidebar = ({
     } else {
       setAutoLoadHandled(true);
     }
-  }, [canEdit, loadingNetworks, availableNetworks, autoLoadHandled, handleLoadExistingNetwork]);
+  }, [loadingNetworks, availableNetworks, autoLoadHandled, handleLoadExistingNetwork]);
 
 
   /* -------------------- Render -------------------- */
@@ -536,7 +402,7 @@ const EditorSidebar = ({
         {/* Status / Errors */}
         {loading && (
           <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>
-            {canEdit ? "Loading sessions..." : "Waiting for activity…"}
+            Waiting for activity…
           </Typography>
         )}
         {error && (
@@ -548,109 +414,8 @@ const EditorSidebar = ({
           </Typography>
         )}
 
-        {/* Selection: Edit mode uses custom dropdown, View mode uses Load Existing Autocomplete */}
-        {!loading && canEdit && (
-          <Box ref={anchorRef}>
-            <TextField
-              size="small"
-              label="Select editing session"
-              value={selectedNetworkOption?.display_name || ""}
-              onClick={handleDropdownToggle}
-              slotProps={{ input: { readOnly: true } }}
-              fullWidth
-              sx={{
-                cursor: "pointer",
-                "& .MuiOutlinedInput-notchedOutline": { borderColor: theme.palette.divider },
-                "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: theme.palette.primary.main },
-                "& .MuiInputBase-input": { cursor: "pointer" },
-              }}
-            />
-
-            <Popper
-              open={dropdownOpen}
-              anchorEl={anchorRef.current}
-              placement="bottom-start"
-              style={{ zIndex: 1300, width: "400px" }}
-              transition
-            >
-              {({ TransitionProps }) => (
-                <Grow {...TransitionProps}>
-                  <Paper elevation={8} sx={{ mt: 0.5, maxHeight: 300, overflow: "auto" }}>
-                    <ClickAwayListener onClickAway={handleDropdownClose}>
-                      <Box>
-                        <Box sx={{ p: 1, borderBottom: `1px solid ${theme.palette.divider}` }}>
-                          <TextField
-                            size="small"
-                            placeholder="Search networks..."
-                            value={dropdownSearchQuery}
-                            onChange={(e) => setDropdownSearchQuery(e.target.value)}
-                            fullWidth
-                            slotProps={{
-                              input: {
-                                startAdornment: (
-                                  <InputAdornment position="start">
-                                    <SearchIcon sx={{ color: theme.palette.text.secondary, fontSize: 18 }} />
-                                  </InputAdornment>
-                                ),
-                              },
-                            }}
-                          />
-                        </Box>
-
-                        <MenuList>
-                          {filteredNetworkOptions.length === 0 ? (
-                            <MenuItem disabled>
-                              <Typography variant="body2" sx={{ color: theme.palette.text.primary }}>
-                                No networks found
-                              </Typography>
-                            </MenuItem>
-                          ) : (
-                            filteredNetworkOptions.map((option) => (
-                              <MenuItem
-                                key={option.id}
-                                onClick={() => { handleDropdownNetworkSelect(option.id); }}
-                                selected={option.id === selectedNetworkId}
-                                sx={{ minWidth: 350 }}
-                              >
-                                <Box sx={{ display: "flex", alignItems: "center", gap: 1, width: "100%" }}>
-                                  <Box sx={{ flexGrow: 1 }}>
-                                    <Typography
-                                      variant="body2"
-                                      sx={{
-                                        color: theme.palette.text.secondary,
-                                        fontWeight: option.id === selectedNetworkId ? 600 : 400,
-                                      }}
-                                    >
-                                      {option.display_name}
-                                    </Typography>
-                                  </Box>
-                                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                                    <Typography variant="caption" sx={{ color: theme.palette.text.secondary }}>
-                                      ({option.agent_count} agents)
-                                    </Typography>
-                                    <Chip
-                                      label="Editing"
-                                      size="small"
-                                      color="secondary"
-                                      sx={{ fontSize: "0.6rem", height: 16 }}
-                                    />
-                                  </Box>
-                                </Box>
-                              </MenuItem>
-                            ))
-                          )}
-                        </MenuList>
-                      </Box>
-                    </ClickAwayListener>
-                  </Paper>
-                </Grow>
-              )}
-            </Popper>
-          </Box>
-        )}
-
-        {/* View mode: Load Existing Agent Network Autocomplete */}
-        {!loading && !canEdit && (
+        {/* Load an existing agent network */}
+        {!loading && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             <Autocomplete
               size="small"
@@ -951,43 +716,13 @@ const EditorSidebar = ({
               p: 2,
             }}
           >
-            {canEdit
-              ? "Select a network to view its agents"
-              : "Waiting for activity…"}
+            Waiting for activity…
           </Typography>
         )}
 
         <div ref={networksEndRef} />
       </Box>
 
-      {/* Manual Refresh (edit mode only) */}
-      <Box sx={{ p: 2, borderTop: `1px solid ${theme.palette.divider}` }}>
-        <Button
-          variant="outlined"
-          color="primary"
-          fullWidth
-          size="small"
-          onClick={() => {
-            if (canEdit) {
-              fetchNetworks();
-              if (selectedNetworkOption) {
-                fetchAgents(selectedNetworkOption);
-              }
-            }
-          }}
-          disabled={loading || !canEdit}
-          startIcon={<RefreshIcon />}
-          sx={{
-            textTransform: "none",
-            fontSize: "0.75rem",
-            "&:disabled": {
-              backgroundColor: alpha(theme.palette.primary.main, 0.1),
-            },
-          }}
-        >
-          {loading ? "Refreshing..." : "Manual Refresh"}
-        </Button>
-      </Box>
     </Paper>
   );
 };

--- a/nsflow/frontend/src/components/EditorSidebar.tsx
+++ b/nsflow/frontend/src/components/EditorSidebar.tsx
@@ -266,10 +266,12 @@ const EditorSidebar = ({
           definition: Array.isArray(definition)
             ? (definition as ConnectivityInfo[])
             : Object.entries(definition).map(([origin, v]) => ({
+                // Spread first. With it last it overwrote the tools computed just
+                // below, which is the one key here that has to end up an array.
+                ...((v ?? {}) as Record<string, unknown>),
                 origin,
                 tools: ((v ?? {}) as { tools?: string[]; down_chains?: string[] }).tools ??
                   ((v ?? {}) as { down_chains?: string[] }).down_chains ?? [],
-                ...(v as Record<string, unknown>),
               })) as ConnectivityInfo[],
           networkName,
         });

--- a/nsflow/frontend/src/components/FloatingEdge.tsx
+++ b/nsflow/frontend/src/components/FloatingEdge.tsx
@@ -1,4 +1,3 @@
-
 /*
 Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
 
@@ -20,8 +19,12 @@ import { getBezierPath, useStore, EdgeProps, ReactFlowState } from "@xyflow/reac
 import { useTheme } from "@mui/material/styles";
 import { getEdgeParams, MeasuredNode } from "../utils/utils";
 
-// Explicitly type the FloatingEdge component using ReactFlow's EdgeProps
-const FloatingEdge: React.FC<EdgeProps> = ({ id, source, target, markerEnd, style }) => {
+/** Half-length of the bar drawn at the source end, in flow units. */
+const SOURCE_BAR_HALF_LENGTH = 9;
+/** Radius of the grab notch drawn at the middle of the edge. */
+const NOTCH_RADIUS = 5;
+
+const FloatingEdge: React.FC<EdgeProps> = ({ id, source, target, markerEnd, style, selected }) => {
   const theme = useTheme();
 
   // Look the two endpoints up directly from the store's node map (O(1) each) rather
@@ -38,8 +41,8 @@ const FloatingEdge: React.FC<EdgeProps> = ({ id, source, target, markerEnd, styl
   // Get correct edge parameters
   const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(sourceNode, targetNode);
 
-  // Generate the bezier path for a smooth curve
-  const [edgePath] = getBezierPath({
+  // labelX/labelY are the curve's midpoint, which is where the notch goes.
+  const [edgePath, labelX, labelY] = getBezierPath({
     sourceX: sx,
     sourceY: sy,
     sourcePosition: sourcePos,
@@ -48,19 +51,57 @@ const FloatingEdge: React.FC<EdgeProps> = ({ id, source, target, markerEnd, styl
     targetY: ty,
   });
 
+  const stroke = selected ? theme.palette.primary.main : style?.stroke || theme.palette.text.primary;
+  const strokeWidth = selected ? 5 : 3;
+
+  // A bar across the source end and an arrow at the target end, so the direction of
+  // the chain is readable without following the curve. The bar is drawn
+  // perpendicular to the line leaving the source rather than using a marker, because
+  // neuro-san's flow direction is the point and xyflow only ships arrow markers.
+  const angle = Math.atan2(ty - sy, tx - sx);
+  const barDx = Math.sin(angle) * SOURCE_BAR_HALF_LENGTH;
+  const barDy = Math.cos(angle) * SOURCE_BAR_HALF_LENGTH;
+
   return (
-    <path
-      id={id}
-      className="react-flow__edge-path"
-      d={edgePath}
-      stroke={theme.palette.text.secondary}
-      markerEnd={markerEnd}
-      style={{
-        ...style,
-        stroke: style?.stroke || theme.palette.text.primary,
-        strokeWidth: 3,
-      }}
-    />
+    <g>
+      <path
+        id={id}
+        className="react-flow__edge-path"
+        d={edgePath}
+        markerEnd={markerEnd}
+        style={{
+          ...style,
+          stroke,
+          strokeWidth,
+        }}
+      />
+
+      {/*
+        Decorations only. pointer-events stays off so every click and right-click
+        falls through to the wide transparent interaction path xyflow renders behind
+        the edge, which is what fires onEdgeClick and onEdgeContextMenu. Without
+        that, the notch would swallow the very interaction it advertises.
+      */}
+      <line
+        x1={sx - barDx}
+        y1={sy + barDy}
+        x2={sx + barDx}
+        y2={sy - barDy}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        style={{ pointerEvents: "none" }}
+      />
+      <circle
+        cx={labelX}
+        cy={labelY}
+        r={selected ? NOTCH_RADIUS + 2 : NOTCH_RADIUS}
+        fill={selected ? theme.palette.primary.main : theme.palette.background.paper}
+        stroke={stroke}
+        strokeWidth={2}
+        style={{ pointerEvents: "none" }}
+      />
+    </g>
   );
 };
 

--- a/nsflow/frontend/src/components/Header.tsx
+++ b/nsflow/frontend/src/components/Header.tsx
@@ -17,17 +17,25 @@ limitations under the License.
 
 import * as React from "react";
 import { useState } from "react";
+import HelpDialog from "./HelpDialog";
 import { ImPower } from "react-icons/im";
 import { useApiPort } from "../context/ApiPortContext";
 import { useChatContext } from "../context/ChatContext";
 import { useLocation } from "react-router-dom";
 import { AppBar, Toolbar, Typography, IconButton, Button, Menu,
   MenuItem, Box, Tooltip, useTheme as useMuiTheme, alpha } from "@mui/material";
-import { Home as HomeIcon, AccountTree as NetworkIcon, Download as DownloadIcon,
-  Autorenew as AutorenewIcon, AccountCircle as AccountIcon, Edit as EditIcon, DrawTwoTone as WandIcon,
-  KeyboardArrowDown as ArrowDownIcon, QuickreplyTwoTone as ChatIcon, Draw as DrawIcon,
-  Fullscreen as FullscreenIcon
-} from "@mui/icons-material";
+import HomeIcon from "@mui/icons-material/Home";
+import NetworkIcon from "@mui/icons-material/AccountTree";
+import DownloadIcon from "@mui/icons-material/Download";
+import AutorenewIcon from "@mui/icons-material/Autorenew";
+import AccountIcon from "@mui/icons-material/AccountCircle";
+import EditIcon from "@mui/icons-material/Edit";
+import WandIcon from "@mui/icons-material/DrawTwoTone";
+import HelpIcon from "@mui/icons-material/HelpOutlined";
+import ArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import ChatIcon from "@mui/icons-material/QuickreplyTwoTone";
+import DrawIcon from "@mui/icons-material/Draw";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
 
 import MuiThemeToggle from "./MuiThemeToggle";
 import { useTheme } from "../context/ThemeContext";
@@ -44,6 +52,8 @@ const Header: React.FC<HeaderProps> = ({ selectedNetwork, isEditorPage = false, 
   const { apiUrl } = useApiPort();
   const { activeNetwork } = useChatContext();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [accountAnchorEl, setAccountAnchorEl] = useState<null | HTMLElement>(null);
   const location = useLocation();
   const { isDarkMode } = useTheme();
   const muiTheme = useMuiTheme();
@@ -367,6 +377,7 @@ const Header: React.FC<HeaderProps> = ({ selectedNetwork, isEditorPage = false, 
                   </Typography>
                 </MenuItem>
               </Menu>
+
             </>
           )}
         </Box>
@@ -412,16 +423,52 @@ const Header: React.FC<HeaderProps> = ({ selectedNetwork, isEditorPage = false, 
             </Tooltip>
           )}
           <MuiThemeToggle />
-          <IconButton
-            sx={{ 
-              color: muiTheme.palette.text.primary,
-              '&:hover': { 
-                backgroundColor: alpha(muiTheme.palette.primary.main, 0.1) 
-              }
-            }}
+          <Tooltip title="Account and help">
+            <IconButton
+              onClick={(e) => setAccountAnchorEl(e.currentTarget)}
+              sx={{ 
+                color: muiTheme.palette.text.primary,
+                '&:hover': { 
+                  backgroundColor: alpha(muiTheme.palette.primary.main, 0.1) 
+                }
+              }}
+            >
+              <AccountIcon />
+            </IconButton>
+          </Tooltip>
+
+          {/*
+            This menu is on the header itself, not inside the Export dropdown. Export
+            is hidden on the editor and Cruse pages and behind a plugin flag, so
+            anything put there is unreachable from exactly the pages a user is most
+            likely to want help on.
+          */}
+          <Menu
+            anchorEl={accountAnchorEl}
+            open={Boolean(accountAnchorEl)}
+            onClose={() => setAccountAnchorEl(null)}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
           >
-            <AccountIcon />
-          </IconButton>
+            <MenuItem
+              onClick={() => {
+                setAccountAnchorEl(null);
+                setIsHelpOpen(true);
+              }}
+              sx={{
+                py: 1.5,
+                px: 2,
+                '&:hover': { backgroundColor: alpha(muiTheme.palette.primary.main, 0.1) }
+              }}
+            >
+              <HelpIcon sx={{ mr: 1.5, fontSize: '20px', color: muiTheme.palette.primary.main }} />
+              <Typography variant="body2" sx={{ fontWeight: 500, color: muiTheme.palette.text.primary }}>
+                Help
+              </Typography>
+            </MenuItem>
+          </Menu>
+
+          <HelpDialog open={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
         </Box>
       </Toolbar>
     </AppBar>

--- a/nsflow/frontend/src/components/HelpDialog.tsx
+++ b/nsflow/frontend/src/components/HelpDialog.tsx
@@ -1,0 +1,164 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * What the two ways of building an agent network are, and where to read more.
+ *
+ * The editor offers chat and direct manipulation side by side, and which one to reach
+ * for is not obvious from the canvas alone. This says it once, in the place a user
+ * looks when they are stuck, rather than spreading it across tooltips.
+ */
+
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Link,
+  Stack,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import ChatIcon from "@mui/icons-material/ChatBubbleOutlined";
+import ExternalIcon from "@mui/icons-material/OpenInNew";
+import ManualIcon from "@mui/icons-material/TouchApp";
+
+/**
+ * Where to read more.
+ *
+ * Repository roots rather than deep links to individual pages: a root outlives a
+ * docs reshuffle, and a help dialog that 404s is worse than one that is one click
+ * from the answer.
+ */
+const RESOURCES: Array<{ label: string; description: string; href: string }> = [
+  {
+    label: "neuro-san-studio",
+    description: "Example agent networks, coded tools and the agent network designer.",
+    href: "https://github.com/cognizant-ai-lab/neuro-san-studio",
+  },
+  {
+    label: "neuro-san",
+    description: "The framework itself: agent HOCON reference, sly_data, MCP and toolbox.",
+    href: "https://github.com/cognizant-ai-lab/neuro-san",
+  },
+  {
+    label: "nsflow",
+    description: "This client: the editor, the chat panel and the FastAPI backend.",
+    href: "https://github.com/cognizant-ai-lab/nsflow",
+  },
+];
+
+const MODES: Array<{ icon: React.ReactElement; title: string; lines: string[] }> = [
+  {
+    icon: <ChatIcon fontSize="small" />,
+    title: "Vibe editing, in the chat",
+    lines: [
+      "Describe what you want and the agent network designer builds or changes it for you.",
+      "Best for starting from nothing, and for broad changes such as rewording every agent's instructions at once.",
+      "Takes a little time, because a language model is doing the work.",
+    ],
+  },
+  {
+    icon: <ManualIcon fontSize="small" />,
+    title: "Manual editing, on the canvas",
+    lines: [
+      "Add agents from the palette, wire them by dragging edges, and edit instructions in the agent panel.",
+      "Best for precise changes you already know you want.",
+      "Applies immediately: each change is saved as you make it, without a language model.",
+    ],
+  },
+];
+
+interface HelpDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const HelpDialog = ({ open, onClose }: HelpDialogProps) => {
+  const theme = useTheme();
+
+  return (
+    // MUI closes on backdrop click and Escape by default, which is what onClose gets.
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", pb: 1 }}>
+        Help
+        <IconButton size="small" onClick={onClose} aria-label="Close help">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          There are two ways to build an agent network, and they work on the same
+          network. You can switch between them at any point.
+        </Typography>
+
+        <Stack spacing={2}>
+          {MODES.map((mode) => (
+            <Box key={mode.title}>
+              <Stack direction="row" spacing={1} sx={{ alignItems: "center", mb: 0.5 }}>
+                <Box sx={{ color: theme.palette.primary.main, display: "flex" }}>{mode.icon}</Box>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                  {mode.title}
+                </Typography>
+              </Stack>
+              {mode.lines.map((line) => (
+                <Typography
+                  key={line}
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ display: "block", pl: 3.5, mb: 0.25 }}
+                >
+                  {line}
+                </Typography>
+              ))}
+            </Box>
+          ))}
+        </Stack>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+          Documentation
+        </Typography>
+        <Stack spacing={1}>
+          {RESOURCES.map((resource) => (
+            <Box key={resource.href}>
+              <Link
+                href={resource.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="body2"
+                sx={{ fontWeight: 600, display: "inline-flex", alignItems: "center", gap: 0.5 }}
+              >
+                {resource.label}
+                <ExternalIcon sx={{ fontSize: 14 }} />
+              </Link>
+              <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                {resource.description}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default HelpDialog;

--- a/nsflow/frontend/src/components/MuiThemeToggle.tsx
+++ b/nsflow/frontend/src/components/MuiThemeToggle.tsx
@@ -16,7 +16,8 @@ limitations under the License.
 
 import * as React from 'react';
 import { IconButton, Tooltip, useTheme as useMuiTheme } from '@mui/material';
-import { Brightness4, Brightness7 } from '@mui/icons-material';
+import LightMode from "@mui/icons-material/LightMode";
+import DarkMode from "@mui/icons-material/DarkMode";
 import { useTheme } from '../context/ThemeContext';
 
 const MuiThemeToggle: React.FC = () => {
@@ -37,7 +38,7 @@ const MuiThemeToggle: React.FC = () => {
           transition: 'all 0.2s ease-in-out',
         }}
       >
-        {isDarkMode ? <Brightness7 /> : <Brightness4 />}
+        {isDarkMode ? <LightMode /> : <DarkMode />}
       </IconButton>
     </Tooltip>
   );

--- a/nsflow/frontend/src/components/NetworkAgentEditorPanel.tsx
+++ b/nsflow/frontend/src/components/NetworkAgentEditorPanel.tsx
@@ -125,6 +125,15 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
       });
     } catch (err) {
       console.error('Failed to rename agent:', err);
+      // The canvas already shows the new name, so without this the user has no way to
+      // know the network on the server still has the old one. Not rolled back: the
+      // store is what the canvas draws from, and renaming it back underneath the user
+      // is a worse surprise than being told the save did not land.
+      setError(
+        err instanceof Error
+          ? `Renamed here but not saved: ${err.message}`
+          : 'Renamed here but not saved.'
+      );
     }
   }, [entry?.definition, renameValue, selectedAgentName, apiUrl, networkId, applyEdit, onAgentRenamed]);
 
@@ -261,8 +270,10 @@ const cleanAgentData = (data: any): any => {
     const cleaned: any = {};
     
     // Only include valid agent properties based on BaseAgentProperties schema
+    // `description` was missing, so the panel offered it for editing and then threw
+    // the edit away, and Save still reported success.
     const validAgentFields = [
-      'instructions', 'function', 'class', 'command', 'tools', 'toolbox', 
+      'instructions', 'description', 'function', 'class', 'command', 'tools', 'toolbox',
       'args', 'allow', 'display_as', 'max_message_history', 'verbose', 'llm_config'
     ];
     

--- a/nsflow/frontend/src/components/NetworkAgentEditorPanel.tsx
+++ b/nsflow/frontend/src/components/NetworkAgentEditorPanel.tsx
@@ -16,33 +16,64 @@ limitations under the License.
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Box,  Paper,  Typography,  IconButton,  useTheme, alpha, Collapse, Button, 
-  CircularProgress, Alert, TextField, InputAdornment } from '@mui/material';
-import { 
-  ExpandLess as ChevronUpIcon, ExpandMore as ChevronDownIcon, Edit as EditIcon,
-  PushPin as PinIcon, PushPinOutlined as UnpinIcon, Save as SaveIcon,
-  Close as CloseIcon, Search as SearchIcon, Add as AddIcon
-} from '@mui/icons-material';
+  CircularProgress, Alert, TextField, InputAdornment, Tooltip, Dialog, DialogTitle,
+  DialogContent, DialogActions } from '@mui/material';
+import ChevronUpIcon from "@mui/icons-material/ExpandLess";
+import ChevronDownIcon from "@mui/icons-material/ExpandMore";
+import EditIcon from "@mui/icons-material/Edit";
+import PinIcon from "@mui/icons-material/PushPin";
+import UnpinIcon from "@mui/icons-material/PushPinOutlined";
+import SaveIcon from "@mui/icons-material/Save";
+import RenameIcon from "@mui/icons-material/DriveFileRenameOutline";
+import CloseIcon from "@mui/icons-material/Close";
+import SearchIcon from "@mui/icons-material/Search";
+import AddIcon from "@mui/icons-material/Add";
 import { useApiPort } from '../context/ApiPortContext';
 import { useJsonEditorTheme } from '../context/ThemeContext';
 import { JsonEditor, ThemeInput } from 'json-edit-react';
-import { useChatContext } from "../context/ChatContext";
+import { selectEntry, useEditorNetworkStore } from "../state/editorNetworkStore";
+import { canRename, renameAgent, updateAgent } from "../state/editorOperations";
+import { sendEditorUpdate } from "../state/editorRoundTrip";
+
+/**
+ * Which of an agent's fields this panel edits.
+ *
+ * `origin` and `tools` are structure, and structure belongs to the canvas: the name
+ * identifies the node everywhere else in the definition, and the down-chains are what
+ * the edges are. Editing either as free text here would let the two disagree, and
+ * both already have direct affordances — rename via the node, wire via the edges or
+ * the chat. What is left is the agent's content, which is what a user opens this
+ * panel for.
+ */
+const STRUCTURAL_FIELDS = ["origin", "tools"] as const;
+
+const toEditableFields = (agent: Record<string, unknown>): Record<string, unknown> => {
+  const editable: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(agent)) {
+    if ((STRUCTURAL_FIELDS as readonly string[]).includes(key)) continue;
+    editable[key] = value;
+  }
+  return editable;
+};
+
 
 interface NetworkAgentEditorPanelProps {
-  selectedDesignId: string;
+  networkId: string;
   selectedAgentName: string | null;
   onAgentUpdated: () => void;
+  /** Called with the new name after a rename, so the caller can follow the agent. */
+  onAgentRenamed?: (newName: string) => void;
   onClose?: () => void;
   autoExpand?: boolean; // When true, panel auto-expands on agent selection
-  enableEditing?: boolean; // Flag to control editing capabilities
 }
 
 const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
-  selectedDesignId,
+  networkId,
   selectedAgentName,
   onAgentUpdated,
+  onAgentRenamed,
   onClose,
-  autoExpand = false,
-  enableEditing = false
+  autoExpand = false
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isPinned, setIsPinned] = useState(false);
@@ -54,23 +85,53 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
   const [hasChanges, setHasChanges] = useState(false);
   const [, setOriginalData] = useState<any>(null);
   const [schema, setSchema] = useState<any>(null);
-  const { getLatestNetworkPayload } = useChatContext();
   
   const panelRef = useRef<HTMLDivElement>(null);
   const theme = useTheme();
   const jsonEditorTheme = useJsonEditorTheme();
   const { apiUrl } = useApiPort();
+  const entry = useEditorNetworkStore((state) => selectEntry(state, networkId));
+  const applyEdit = useEditorNetworkStore((state) => state.applyEdit);
 
   const [searchText, setSearchText] = useState('');
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState('');
+
+  // Only an LLM agent of this network can be renamed: a tool's name is the tool it
+  // resolves to, and an external reference's name is what it points at.
+  const canRenameSelected = Boolean(
+    selectedAgentName && canRename(entry?.definition ?? [], selectedAgentName)
+  );
+
+  const submitRename = useCallback(async () => {
+    const definition = entry?.definition ?? [];
+    const proposed = renameValue.trim();
+    if (!selectedAgentName || !apiUrl) return;
+    const next = renameAgent(definition, selectedAgentName, proposed);
+    setIsRenaming(false);
+    if (next === definition) return;
+
+    applyEdit(networkId, next);
+    // The panel follows the agent to its new name, or it would sit on one that no
+    // longer exists.
+    onAgentRenamed?.(proposed);
+    try {
+      await sendEditorUpdate({
+        apiUrl,
+        networkId,
+        agentName: proposed,
+        definition: next,
+        message: `Rename agent "${selectedAgentName}" to "${proposed}"`,
+      });
+    } catch (err) {
+      console.error('Failed to rename agent:', err);
+    }
+  }, [entry?.definition, renameValue, selectedAgentName, apiUrl, networkId, applyEdit, onAgentRenamed]);
 
   // Data validation helpers
   const hasData = jsonData && typeof jsonData === 'object' && !Array.isArray(jsonData) && Object.keys(jsonData).length > 0;
-  const canEdit = !!enableEditing;
-  const hasChangesToSave = canEdit && hasChanges;
+  const hasChangesToSave = hasChanges;
 
-  const getViewDefinition = useCallback(() => {
-    return getLatestNetworkPayload()?.agent_network_definition as Record<string, any> | undefined;
-  }, [getLatestNetworkPayload]);
 
   // Handle clicking outside to collapse when not pinned
   useEffect(() => {
@@ -100,7 +161,7 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
 
   // Load agent data when selectedAgentName or apiUrl changes
   useEffect(() => {
-    if (selectedAgentName && apiUrl && (canEdit ? !!selectedDesignId : true)) {
+    if (selectedAgentName && apiUrl) {
       loadAgentData();
     } else {
       setJsonData({});
@@ -109,7 +170,7 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
       setError(null);
       setSuccess(null);
     }
-  }, [selectedAgentName, selectedDesignId, apiUrl, canEdit]);
+  }, [selectedAgentName, apiUrl, entry?.definition]);
 
   // Expand panel when autoExpand becomes true (e.g. double-click on already-selected agent)
   useEffect(() => {
@@ -118,23 +179,19 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
     }
   }, [autoExpand, selectedAgentName]);
 
+  // The editable surface of an agent is simply what a connectivity entry carries.
+  // This used to be fetched from /andeditor/schemas/base-agent-properties; holding
+  // it here removes a backend round-trip for a list that only changes when
+  // neuro-san's own entry shape changes.
   const loadSchema = async () => {
-    if (!apiUrl) return;
-
-    try {
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/schemas/base-agent-properties`);
-      
-      if (!response.ok) {
-        throw new Error(`Failed to load schema: ${response.statusText}`);
-      }
-
-      const schemaData = await response.json();
-      // console.log('Loaded schema:', schemaData);
-      setSchema(schemaData);
-    } catch (err) {
-      console.error('Error loading schema:', err);
-      // Don't show error to user for schema loading failure
-    }
+    setSchema({
+      type: "object",
+      properties: {
+        instructions: { type: "string" },
+        description: { type: "string" },
+        display_as: { type: "string" },
+      },
+    });
   };
 
   const createDefaultDataFromSchema = (schema: any): any => {
@@ -162,56 +219,30 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
   const loadAgentData = async () => {
     if (!selectedAgentName || !apiUrl) return;
 
-    // In edit-mode we still need designId; in view-mode we don’t
-    if (canEdit && !selectedDesignId) return;
-
     setIsLoading(true);
     setError(null);
     setSuccess(null);
 
     try {
-      let response: Response;
-      if (canEdit && selectedDesignId) {
-        // EDIT MODE (unchanged)
-        response = await fetch(
-          `${apiUrl}/api/v1/andeditor/networks/${selectedDesignId}/agents/${selectedAgentName}`
-        );
-      } else {
-        // VIEW MODE
-        const definition = getViewDefinition();
-        if (!definition) {
-          setIsLoading(false);
-          // optional: keep quiet until we have the first payload
-          return;
-        }
-        response = await fetch(
-          `${apiUrl}/api/v1/connectivity/from_json/agents/${encodeURIComponent(selectedAgentName)}`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ agent_network_definition: definition }),
-          }
-        );
-      }
-      
-      if (!response.ok) {
-        throw new Error(`Failed to load agent: ${response.statusText}`);
+      // The agent is already in the store: the definition the canvas renders is the
+      // same one the panel edits, so there is nothing to fetch.
+      const agentData = entry?.definition.find((agent) => agent.origin === selectedAgentName);
+      if (!agentData) {
+        setIsLoading(false);
+        return;
       }
 
-      const data = await response.json();
-      const agentData = data.agent?? data;
-      // console.log('Loaded agent data:', agentData);
-
-      setJsonData(agentData);
-      setOriginalData(agentData);
+      const editable = toEditableFields(agentData);
+      setJsonData(editable);
+      setOriginalData(editable);
       setHasChanges(false);
-      
-      // Auto-expand the panel only when explicitly requested (double-click, right-click → open)
+
+      // Auto-expand the panel only when explicitly requested (double-click, right-click -> open)
       if (autoExpand && !isExpanded) setIsExpanded(true);
     } catch (err) {
       console.error('Error loading agent data:', err);
       setError(err instanceof Error ? err.message : 'Failed to load agent data');
-      
+
       // If agent doesn't exist, create default structure from schema
       if (schema && !hasData) {
         const defaultData = createDefaultDataFromSchema(schema);
@@ -224,7 +255,7 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
     }
   };
 
-  const cleanAgentData = (data: any): any => {
+const cleanAgentData = (data: any): any => {
     if (!data || typeof data !== 'object') return {};
     
     const cleaned: any = {};
@@ -293,7 +324,7 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
   };
 
   const saveAgentData = async () => {
-    if (!canEdit || !selectedAgentName || !selectedDesignId || !apiUrl || !hasChanges) return;
+    if (!selectedAgentName || !apiUrl || !hasChanges) return;
 
     setIsSaving(true);
     setError(null);
@@ -313,30 +344,27 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
       // console.log('Final request body:', JSON.stringify(cleanedData, null, 2));
       
       // Also log the URL for debugging
-      // console.log('API URL:', `${apiUrl}/api/v1/andeditor/networks/${selectedDesignId}/agents/${selectedAgentName}`);
       
       // Log the headers for debugging
       // console.log('Request headers:', { 'Content-Type': 'application/json' });
       
-      const response = await fetch(`${apiUrl}/api/v1/andeditor/networks/${selectedDesignId}/agents/${selectedAgentName}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(cleanedData)
+      if (!entry || !selectedAgentName) throw new Error('No agent selected');
+
+      // Apply locally so the canvas updates at once, then let the designer
+      // canonicalise it. `updateAgent` returns the same array when nothing matched.
+      const next = updateAgent(entry.definition, selectedAgentName, cleanedData);
+      applyEdit(networkId, next);
+      await sendEditorUpdate({
+        apiUrl: apiUrl as string,
+        networkId,
+        agentName: selectedAgentName,
+        definition: next,
       });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error('API Error Response:', errorText);
-        console.error('Request body that failed:', JSON.stringify(cleanedData, null, 2));
-        throw new Error(`Failed to save agent: ${response.status} ${response.statusText} - ${errorText}`);
-      }
-
-      await response.json();
       setSuccess('Agent updated successfully');
       setHasChanges(false);
       setOriginalData(cleanedData);
-      
-      // Notify parent component
+
       onAgentUpdated();
       
       // Clear success message after 3 seconds
@@ -352,20 +380,16 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
 
   // Handle JSON data updates from the editor
   const handleJsonUpdate = useCallback((update: any) => {
-    if (!canEdit) return;
-    
-    // console.log('JsonEditor onUpdate called with:', update);
+    // `update.newData` holds the new full JSON value; `update.data` may be empty.
     // `update.newData` contains the new full JSON value, `update.data` might be empty
     const next = update.newData ?? update.data ?? {}; // fall back to empty object if no data
     // console.log('JsonEditor update - next data:', next, 'keys count:', Object.keys(next).length);
     setJsonData(next);
     setHasChanges(true);
-  }, [canEdit]);
+  }, []);
 
   // Handle adding a new root item
   const handleAddRootItem = useCallback(() => {
-    if (!canEdit) return;
-    
     setJsonData((prev: any) => {
       if (
         prev &&
@@ -380,7 +404,7 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
       setHasChanges(true);
       return next;
     });
-  }, [canEdit]);
+  }, []);
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
@@ -450,7 +474,64 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
               >
                 Agent: {selectedAgentName}
               </Typography>
+              {canRenameSelected && (
+                // Renaming is an edit like any other, but it is the one that also has
+                // to follow every reference, so it goes through renameAgent rather
+                // than the JSON editor below.
+                <Tooltip title="Rename this agent">
+                  <IconButton
+                    size="small"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setRenameValue(selectedAgentName ?? "");
+                      setIsRenaming(true);
+                    }}
+                    sx={{ ml: 0.5, color: theme.palette.text.secondary }}
+                  >
+                    <RenameIcon sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </Tooltip>
+              )}
             </Box>
+            <Dialog
+              open={isRenaming}
+              onClose={() => setIsRenaming(false)}
+              maxWidth="xs"
+              fullWidth
+              onClick={(event) => event.stopPropagation()}
+            >
+              <DialogTitle sx={{ pb: 1 }}>Rename agent</DialogTitle>
+              <DialogContent sx={{ pb: 1 }}>
+                <TextField
+                  autoFocus
+                  fullWidth
+                  size="small"
+                  value={renameValue}
+                  onChange={(event) => setRenameValue(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.preventDefault();
+                      void submitRename();
+                    }
+                  }}
+                  helperText="Every agent that chains to this one follows the new name."
+                />
+              </DialogContent>
+              <DialogActions sx={{ px: 3, pb: 2 }}>
+                <Button size="small" onClick={() => setIsRenaming(false)} sx={{ textTransform: 'none' }}>
+                  Cancel
+                </Button>
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={() => void submitRename()}
+                  disabled={!renameValue.trim() || renameValue.trim() === selectedAgentName}
+                  sx={{ textTransform: 'none' }}
+                >
+                  Rename
+                </Button>
+              </DialogActions>
+            </Dialog>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 280 }}>
               {/* Search input (compact + rounded) */}
               <TextField
@@ -484,30 +565,28 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
                 }}
               />
 
-              {/* Add button - only show when editing is enabled */}
-              {canEdit && (
-                <IconButton
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleAddRootItem();
-                  }}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  disabled={hasData}
-                  sx={{
-                    color: hasData ? theme.palette.text.disabled : theme.palette.primary.main,
-                    '&:disabled': { color: theme.palette.text.disabled },
-                    '&:hover': hasData ? undefined : { backgroundColor: alpha(theme.palette.primary.main, 0.1) },
-                    p: 0.5,
-                  }}
-                  title="Add root item"
-                >
-                  <AddIcon fontSize="small" />
-                </IconButton>
-              )}
+              {/* Add button */}
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleAddRootItem();
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                disabled={hasData}
+                sx={{
+                  color: hasData ? theme.palette.text.disabled : theme.palette.primary.main,
+                  '&:disabled': { color: theme.palette.text.disabled },
+                  '&:hover': hasData ? undefined : { backgroundColor: alpha(theme.palette.primary.main, 0.1) },
+                  p: 0.5,
+                }}
+                title="Add root item"
+              >
+                <AddIcon fontSize="small" />
+              </IconButton>
 
-              {/* Save button - only show when editing is enabled */}
-              {canEdit && hasChangesToSave && (
+              {/* Save button */}
+              {hasChangesToSave && (
                 <Button
                   size="small"
                   variant="contained"
@@ -642,19 +721,19 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
                 rootFontSize="14px"
                 indent={2}
                 rootName="agent"
-                restrictDrag={!canEdit}
+                restrictDrag={false}
                 insertAtTop={false}
                 showIconTooltips={true}
-                viewOnly={!canEdit}
+                viewOnly={false}
               />
             ) : selectedAgentName ? (
               <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 2, color: theme.palette.text.secondary }}>
                 <EditIcon sx={{ fontSize: 48, color: theme.palette.text.disabled }} />
                 <Typography variant="body1" sx={{ color: theme.palette.text.primary }}>No agent data available</Typography>
                 <Typography variant="body2" sx={{ textAlign: 'center', maxWidth: 300, color: theme.palette.text.secondary }}>
-                  Agent '{selectedAgentName}' has no {canEdit ? 'editable ' : ''}properties or failed to load.
+                  Agent '{selectedAgentName}' has no editable properties or failed to load.
                 </Typography>
-                {canEdit && schema && (
+                {schema && (
                   <Button
                     variant="outlined"
                     size="small"
@@ -675,13 +754,10 @@ const NetworkAgentEditorPanel: React.FC<NetworkAgentEditorPanelProps> = ({
               <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 2, color: theme.palette.text.secondary }}>
                 <EditIcon sx={{ fontSize: 48, color: theme.palette.text.disabled }} />
                 <Typography variant="body1" sx={{ color: theme.palette.text.primary }}>
-                  Select an agent to {canEdit ? 'edit' : 'view'}
+                  Select an agent to edit
                 </Typography>
                 <Typography variant="body2" sx={{ textAlign: 'center', maxWidth: 300, color: theme.palette.text.secondary }}>
-                  {canEdit 
-                    ? 'Right-click on an agent and select "Edit Agent" or double-click to start editing.'
-                    : 'Right-click on an agent and select "View Agent" to see its properties.'
-                  }
+                  Right-click on an agent and select "Edit Agent" or double-click to start editing.
                 </Typography>
                 {schema && (
                   <Typography variant="caption" sx={{ textAlign: 'center', maxWidth: 300, color: theme.palette.text.secondary, mt: 1 }}>

--- a/nsflow/frontend/src/components/NetworkNameField.tsx
+++ b/nsflow/frontend/src/components/NetworkNameField.tsx
@@ -1,0 +1,107 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Names a network that is still a draft.
+ *
+ * Shown in place of the canvas's "Editing: <name>" label while a network built by
+ * hand has no name yet. Naming it is what makes it persist, so this is the step
+ * between drawing a network and being able to launch it.
+ */
+
+import { useCallback, useState } from "react";
+import { IconButton, InputAdornment, TextField, Tooltip } from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+
+import { sanitizeNetworkName } from "../state/paletteSources";
+
+interface NetworkNameFieldProps {
+  /** The current name, when renaming rather than naming for the first time. */
+  initialName?: string;
+  onSubmit: (name: string) => void;
+  /** Provided only when there is a name to fall back to, so cancelling is possible. */
+  onCancel?: () => void;
+}
+
+const NetworkNameField = ({ initialName = "", onSubmit, onCancel }: NetworkNameFieldProps) => {
+  const [value, setValue] = useState(initialName);
+
+  // What will actually be saved. Spaces and capitals are corrected rather than
+  // rejected, so the only real failure is typing nothing usable at all.
+  const sanitized = sanitizeNetworkName(value);
+  const canSubmit = sanitized.length > 0;
+  const wasChanged = canSubmit && sanitized !== value.trim();
+
+  const submit = useCallback(() => {
+    if (canSubmit) onSubmit(sanitized);
+  }, [canSubmit, onSubmit, sanitized]);
+
+  return (
+    <TextField
+      size="small"
+      autoFocus
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          submit();
+        }
+        if (event.key === "Escape" && onCancel) {
+          event.preventDefault();
+          onCancel();
+        }
+      }}
+      placeholder="Name this network"
+      error={value.trim().length > 0 && !canSubmit}
+      helperText={
+        value.trim().length > 0 && !canSubmit
+          ? "Use letters or digits somewhere in the name"
+          : wasChanged
+            ? `Will be saved as "${sanitized}"`
+            : initialName
+              ? "Saves a copy under the new name"
+              : "Naming it saves it"
+      }
+      slotProps={{
+        input: {
+          endAdornment: (
+            <InputAdornment position="end">
+              {onCancel && (
+                <Tooltip title="Cancel">
+                  <IconButton size="small" onClick={onCancel} aria-label="Cancel rename">
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
+              <Tooltip title={canSubmit ? "Save under this name" : "Enter a name"}>
+                <span style={{ display: "inline-flex" }}>
+                  <IconButton size="small" onClick={submit} disabled={!canSubmit} aria-label="Save network name">
+                    <CheckIcon fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </InputAdornment>
+          ),
+        },
+      }}
+      sx={{ minWidth: 200 }}
+    />
+  );
+};
+
+export default NetworkNameField;

--- a/nsflow/frontend/src/components/slydata/EditorSlyDataPanel.tsx
+++ b/nsflow/frontend/src/components/slydata/EditorSlyDataPanel.tsx
@@ -17,7 +17,12 @@ limitations under the License.
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, IconButton, Paper, Tooltip, Typography, alpha, TextField, InputAdornment } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
-import { DataObject as DataObjectIcon, Download as DownloadIcon, Upload as UploadIcon, Info as InfoIcon, Delete as DeleteIcon, Add as AddIcon } from '@mui/icons-material';
+import DataObjectIcon from "@mui/icons-material/DataObject";
+import DownloadIcon from "@mui/icons-material/Download";
+import UploadIcon from "@mui/icons-material/Upload";
+import InfoIcon from "@mui/icons-material/Info";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddIcon from "@mui/icons-material/Add";
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { JsonEditor, ThemeInput } from 'json-edit-react';
 import ScrollableMessageContainer from '../ScrollableMessageContainer';

--- a/nsflow/frontend/src/pages/Editor/Editor.tsx
+++ b/nsflow/frontend/src/pages/Editor/Editor.tsx
@@ -30,7 +30,6 @@ import { getInitialTheme } from "../../utils/theme";
 
 const EditorContent: React.FC = () => {
   const [selectedNetwork, setSelectedNetwork] = useState<string>("");
-  const [selectedDesignId, setSelectedDesignId] = useState<string>("");
   const { setIsEditorMode } = useChatContext();
 
   useEffect(() => {
@@ -42,18 +41,9 @@ const EditorContent: React.FC = () => {
     return () => setIsEditorMode(false);
   }, [setIsEditorMode]);
 
-  // Callback to refresh sidebar when new networks are created
-  const handleNetworkCreated = () => {
-    // Note: Current sidebar doesn't support refresh trigger
-    // This is a placeholder for future enhancement
-    console.log('Network created - sidebar refresh not implemented');
-  };
-
   // Callback to select a network in sidebar
-  const handleNetworkSelected = (networkName: string, designId?: string) => {
-    console.log('Editor: Network selected:', { networkName, designId });
+  const handleNetworkSelected = (networkName: string) => {
     setSelectedNetwork(networkName);
-    setSelectedDesignId(designId || "");
   };
 
   return (
@@ -72,12 +62,7 @@ const EditorContent: React.FC = () => {
                 
                 <Panel defaultSize={55} minSize={40}>
                   {/* Editable AgentFlow */}
-                  <EditorAgentFlow 
-                    selectedNetwork={selectedNetwork}
-                    selectedDesignId={selectedDesignId}
-                    onNetworkCreated={handleNetworkCreated}
-                    onNetworkSelected={handleNetworkSelected}
-                  />
+                  <EditorAgentFlow selectedNetwork={selectedNetwork} />
                 </Panel>
                 
                 <PanelResizeHandle className="w-1 bg-gray-700 cursor-ew-resize" />

--- a/nsflow/frontend/src/state/definitionShape.test.ts
+++ b/nsflow/frontend/src/state/definitionShape.test.ts
@@ -1,0 +1,127 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * These rules are all load-bearing against a live designer, and each one was arrived
+ * at by measuring what the designer does when it is broken:
+ *
+ *  - agent entry with no instructions/description -> read as a toolbox tool, and if
+ *    it has down-chains, validation fails and the designer LLM rewrites the network
+ *  - toolbox entry with anything in it -> read as an LLM agent
+ *  - empty-string instructions dropped -> the agent silently becomes a tool
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { AgentNetworkDefinitionEntry } from "../uiCommon";
+import { listToDict, toConnectivityList } from "./definitionShape";
+
+describe("listToDict", () => {
+  it("keeps an agent an agent and a tool a tool", () => {
+    const definition: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: ["ddgs_search"], instructions: "Answer.", description: "Front" },
+      { origin: "ddgs_search", tools: [] },
+    ];
+    const dict = listToDict(definition);
+
+    expect(dict).toEqual({
+      frontman: { tools: ["ddgs_search"], instructions: "Answer.", description: "Front" },
+      // No keys at all: that absence is the only thing marking it as a toolbox tool.
+      ddgs_search: {},
+    });
+  });
+
+  it("keeps instructions the user deliberately cleared", () => {
+    // The designer's own converter would drop these for being falsy, turning the
+    // agent into a toolbox tool behind the user's back.
+    const cleared: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: [], instructions: "", description: "" },
+    ];
+    const dict = listToDict(cleared);
+
+    expect(dict).toEqual({ frontman: { instructions: "", description: "" } });
+  });
+
+  it("omits an empty tools list, which would make a tool look like an agent", () => {
+    expect(listToDict([{ origin: "ddgs_search", tools: [] }])).toEqual({ ddgs_search: {} });
+  });
+
+  it("omits external references, which are not definitions", () => {
+    const withExternals: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: ["/other_network", "https://mcp.example.com/mcp"], instructions: "Go." },
+      { origin: "/other_network", tools: [] },
+      { origin: "https://mcp.example.com/mcp", tools: [] },
+    ];
+    const dict = listToDict(withExternals);
+
+    // They survive only as names in the parent's tools, which is what makes them
+    // references out rather than nodes of this network.
+    expect(Object.keys(dict)).toEqual(["frontman"]);
+    expect(dict.frontman).toEqual({
+      tools: ["/other_network", "https://mcp.example.com/mcp"],
+      instructions: "Go.",
+    });
+  });
+});
+
+describe("toConnectivityList", () => {
+  it("normalises the dict shape the designer echoes back", () => {
+    expect(toConnectivityList({ frontman: { tools: ["x"], instructions: "Hi" }, x: {} })).toEqual([
+      { origin: "frontman", tools: ["x"], instructions: "Hi" },
+      { origin: "x", tools: [] },
+    ]);
+  });
+
+  it("accepts down_chains as an alias for tools", () => {
+    expect(toConnectivityList({ frontman: { down_chains: ["x"] } })).toEqual([
+      { origin: "frontman", tools: ["x"] },
+    ]);
+  });
+
+  it("round-trips an emptied agent without reclassifying it", () => {
+    const original: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: [], instructions: "", description: "" },
+    ];
+    expect(toConnectivityList(listToDict(original))).toEqual(original);
+  });
+
+  it("normalises tools that arrive as an index-keyed object", () => {
+    // Observed from the designer, and undone by the agent panel since before this
+    // store existed. Left alone, every downstream spread of `tools` throws
+    // "is not iterable" and the canvas goes blank.
+    expect(toConnectivityList({ frontman: { tools: { "0": "a", "1": "b" } } })).toEqual([
+      { origin: "frontman", tools: ["a", "b"] },
+    ]);
+    expect(toConnectivityList([{ origin: "frontman", tools: { "0": "a" } }])).toEqual([
+      { origin: "frontman", tools: ["a"] },
+    ]);
+  });
+
+  it("survives a definition whose tools are missing or malformed", () => {
+    expect(toConnectivityList([{ origin: "a" }, { origin: "b", tools: null }])).toEqual([
+      { origin: "a", tools: [] },
+      { origin: "b", tools: [] },
+    ]);
+  });
+
+  it("keeps the list shape, and rejects anything else", () => {
+    expect(toConnectivityList([{ origin: "frontman", tools: [] }])).toEqual([
+      { origin: "frontman", tools: [] },
+    ]);
+    expect(toConnectivityList(undefined)).toBeUndefined();
+    expect(toConnectivityList("nope")).toBeUndefined();
+  });
+});

--- a/nsflow/frontend/src/state/definitionShape.ts
+++ b/nsflow/frontend/src/state/definitionShape.ts
@@ -1,0 +1,156 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Converts between the two shapes an agent network definition takes.
+ *
+ * The designer's native shape is a DICT keyed by agent name. The connectivity report
+ * and the editor store use a LIST of `{origin, tools, ...}`. Frames arrive in either,
+ * so the store normalises to the list; edits are sent as the dict.
+ *
+ * Sending the dict rather than the list is not a style choice. The designer's own
+ * list-to-dict converter copies `tools`, `instructions` and `description` only when
+ * their value is TRUTHY, so an empty-string `instructions` is silently dropped on the
+ * way in. That matters because emptiness is meaningful:
+ *
+ *   - an entry with NO instructions/description keys is a TOOLBOX tool
+ *   - an entry WITH them, even empty, is an LLM agent
+ *
+ * So a user who clears an agent's instructions and sends the list form has that agent
+ * quietly reclassified as a toolbox tool, which then fails validation ("toolbox agent
+ * 'x' references tool 'y'") and summons the designer LLM to repair the network:
+ * verified against a live designer at 39 seconds and thousands of tokens per edit,
+ * renaming and restructuring what the user drew. Sending the dict preserves the
+ * distinction and the same edit applies deterministically in under a second.
+ */
+
+import type { ConnectivityInfo } from "../uiCommon";
+
+/** One agent's entry in the dict shape. */
+type DictEntry = {
+  tools?: string[];
+  down_chains?: string[];
+  instructions?: string;
+  description?: string;
+};
+
+/**
+ * Whether a name refers to something outside this network.
+ *
+ * Mirrors neuro-san's `is_url_or_path`: a leading slash is another agent network and
+ * an http(s) URL is an MCP server. Neither is ever a definition of its own, so both
+ * live only as a name in some parent's tools.
+ */
+export const isExternalName = (name: string): boolean =>
+  name.startsWith("/") || name.startsWith("http://") || name.startsWith("https://");
+
+/**
+ * Whether an entry is a toolbox tool rather than an LLM agent.
+ *
+ * The test is the absence of both text fields, because that absence is exactly what
+ * the designer uses: its `AddAgent` writes `instructions` and `description` for an
+ * agent and nothing at all for a tool. An external reference is not a toolbox tool,
+ * even though its entry is also bare.
+ */
+export const isToolboxTool = (entry: ConnectivityInfo | undefined): boolean => {
+  if (!entry?.origin || isExternalName(entry.origin)) return false;
+  const withText = entry as ConnectivityInfo & { instructions?: string; description?: string };
+  return withText.instructions === undefined && withText.description === undefined;
+};
+
+/**
+ * Down-chains as an array, whatever shape the frame used.
+ *
+ * A definition arriving from the designer sometimes carries `tools` as an
+ * index-keyed object rather than an array — the editor panel has had to undo that
+ * since before this store existed. Anything downstream spreads `tools`, so letting
+ * one through unconverted throws "is not iterable" and takes the whole canvas down.
+ * Normalising here means every later consumer can assume an array.
+ */
+export const toToolsArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.filter((tool): tool is string => typeof tool === "string");
+  if (value && typeof value === "object") {
+    return Object.values(value).filter((tool): tool is string => typeof tool === "string");
+  }
+  return [];
+};
+
+/**
+ * Convert the dict shape to the canonical connectivity list.
+ *
+ * `down_chains` is accepted alongside `tools` because the backend canonicalises
+ * children under that name when converting between the two shapes.
+ */
+export const dictToList = (definition: Record<string, unknown>): ConnectivityInfo[] =>
+  Object.entries(definition).map(([origin, value]) => {
+    const entry = (value ?? {}) as DictEntry;
+    return {
+      origin,
+      tools: toToolsArray(entry.tools ?? entry.down_chains),
+      // Presence, not truthiness: an empty-string instructions still marks an LLM
+      // agent, and dropping it here would turn that agent into a toolbox tool.
+      ...(entry.instructions === undefined ? {} : { instructions: entry.instructions }),
+      ...(entry.description === undefined ? {} : { description: entry.description }),
+    } as ConnectivityInfo;
+  });
+
+/**
+ * Accept either shape and return the list the store holds.
+ *
+ * The list shape is normalised too, not passed through: `tools` can arrive as an
+ * object in either shape, and this is the one place server data enters the store.
+ */
+export const toConnectivityList = (definition: unknown): ConnectivityInfo[] | undefined => {
+  if (Array.isArray(definition)) {
+    return definition.map((entry) => ({ ...entry, tools: toToolsArray(entry?.tools) }));
+  }
+  if (definition && typeof definition === "object") return dictToList(definition as Record<string, unknown>);
+  return undefined;
+};
+
+/**
+ * Convert the connectivity list to the dict shape the designer stores.
+ *
+ * Three rules, each of which the designer depends on:
+ *
+ *  - External references are omitted. They are not definitions, and the designer
+ *    drops them anyway; leaving them in would make them nodes.
+ *  - `tools` is written only when non-empty. An empty `tools: []` would make a
+ *    toolbox tool's entry non-empty, which is precisely what stops it being
+ *    recognised as a tool.
+ *  - `instructions` and `description` are written whenever the key is present, even
+ *    when empty, because presence is what distinguishes an agent from a tool.
+ */
+export const listToDict = (definition: ConnectivityInfo[]): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+
+  for (const entry of definition) {
+    const origin = entry.origin;
+    if (!origin || isExternalName(origin)) continue;
+
+    const value: Record<string, unknown> = {};
+    const tools = toToolsArray(entry.tools);
+    if (tools.length > 0) value.tools = tools;
+
+    const withText = entry as ConnectivityInfo & { instructions?: string; description?: string };
+    if (withText.instructions !== undefined) value.instructions = withText.instructions;
+    if (withText.description !== undefined) value.description = withText.description;
+
+    result[origin] = value;
+  }
+
+  return result;
+};

--- a/nsflow/frontend/src/state/editorGraph.test.ts
+++ b/nsflow/frontend/src/state/editorGraph.test.ts
@@ -1,0 +1,134 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it } from "vitest";
+
+import type { AgentNetworkDefinitionEntry, ConnectivityInfo } from "../uiCommon";
+import { buildEditorGraph } from "./editorGraph";
+
+const COFFEE: ConnectivityInfo[] = [
+  { origin: "frontman", tools: ["barista", "loyalty"] },
+  { origin: "barista", tools: [] },
+  { origin: "loyalty", tools: ["rewards_db"] },
+];
+
+describe("buildEditorGraph", () => {
+  it("returns an empty graph rather than throwing on a non-list definition", () => {
+    // The designer's default progress style reports the definition as a dict. This
+    // runs during render, so throwing here blanks the page; callers are expected to
+    // normalise first, and this makes forgetting survivable.
+    const asDict = { frontman: { tools: ["barista"] } } as unknown as ConnectivityInfo[];
+    expect(buildEditorGraph(asDict, "coffee_shop")).toEqual({ nodes: [], edges: [] });
+    expect(buildEditorGraph(undefined as unknown as ConnectivityInfo[], "x")).toEqual({
+      nodes: [],
+      edges: [],
+    });
+  });
+
+  it("creates one node per agent, including down-chain-only references", () => {
+    const { nodes } = buildEditorGraph(COFFEE, "coffee_shop");
+    expect(nodes.map((n) => n.id).sort()).toEqual(["barista", "frontman", "loyalty", "rewards_db"]);
+  });
+
+  it("marks agents without their own entry as undefined_agent", () => {
+    const { nodes } = buildEditorGraph(COFFEE, "coffee_shop");
+    const byId = Object.fromEntries(nodes.map((n) => [n.id, n]));
+    expect(byId.frontman.type).toBe("agent");
+    expect(byId.frontman.data.is_defined).toBe(true);
+    expect(byId.rewards_db.type).toBe("undefined_agent");
+    expect(byId.rewards_db.data.is_defined).toBe(false);
+  });
+
+  it("reproduces the node data shape the backend produced", () => {
+    const { nodes } = buildEditorGraph(COFFEE, "coffee_shop");
+    const frontman = nodes.find((n) => n.id === "frontman")!;
+    expect(frontman.data).toEqual({
+      label: "frontman",
+      depth: 0,
+      parent: undefined,
+      children: ["barista", "loyalty"],
+      instructions: "",
+      dropdown_tools: [],
+      sub_networks: [],
+      network_name: "coffee_shop",
+      is_defined: true,
+    });
+    expect(frontman.position).toEqual({ x: 100, y: 100 });
+  });
+
+  it("carries instructions through from the definition entry", () => {
+    const withInstructions: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: [], instructions: "Greet the customer." },
+    ];
+    const { nodes } = buildEditorGraph(withInstructions, "coffee_shop");
+    expect(nodes[0].data.instructions).toBe("Greet the customer.");
+  });
+
+  it("computes depth and parent from the frontman down", () => {
+    const { nodes } = buildEditorGraph(COFFEE, "coffee_shop");
+    const byId = Object.fromEntries(nodes.map((n) => [n.id, n.data]));
+    expect(byId.frontman.depth).toBe(0);
+    expect(byId.barista.depth).toBe(1);
+    expect(byId.barista.parent).toBe("frontman");
+    expect(byId.rewards_db.depth).toBe(2);
+    expect(byId.rewards_db.parent).toBe("loyalty");
+  });
+
+  it("creates one edge per down-chain, in the backend's shape", () => {
+    const { edges } = buildEditorGraph(COFFEE, "coffee_shop");
+    expect(edges).toHaveLength(3);
+    expect(edges).toContainEqual({
+      id: "frontman-barista",
+      source: "frontman",
+      target: "barista",
+      animated: false,
+      type: "default",
+    });
+  });
+
+  it("returns an empty graph for an empty definition", () => {
+    expect(buildEditorGraph([], "coffee_shop")).toEqual({ nodes: [], edges: [] });
+  });
+
+  it("does not loop forever on a cyclic definition", () => {
+    const cyclic: ConnectivityInfo[] = [
+      { origin: "a", tools: ["b"] },
+      { origin: "b", tools: ["a"] },
+    ];
+    const { nodes, edges } = buildEditorGraph(cyclic, "cyclic_net");
+    expect(nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+    expect(edges).toHaveLength(2);
+  });
+
+  it("treats a leading-slash origin as an external agent, never as a definition", () => {
+    // Taken from a live agent_network_designer connectivity response: external
+    // agents appear as their own entries AND inside another agent's tools, but the
+    // backend excludes them from the definition dict, so they must not count as
+    // defined here either.
+    const withExternal: ConnectivityInfo[] = [
+      { origin: "agent_network_designer", tools: ["/agent_network_editor", "web_search"] },
+      { origin: "/agent_network_editor", tools: [] },
+      { origin: "web_search", tools: [] },
+    ];
+    const { nodes } = buildEditorGraph(withExternal, "agent_network_designer");
+    const byId = Object.fromEntries(nodes.map((n) => [n.id, n.data]));
+
+    expect(byId["/agent_network_editor"].is_defined).toBe(false);
+    expect(byId["web_search"].is_defined).toBe(true);
+    // still reachable in the graph, as a child of the frontman
+    expect(byId["/agent_network_editor"].parent).toBe("agent_network_designer");
+  });
+});

--- a/nsflow/frontend/src/state/editorGraph.ts
+++ b/nsflow/frontend/src/state/editorGraph.ts
@@ -1,0 +1,149 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Builds the React Flow graph from an agent network definition, in the browser.
+ *
+ * This replaces the POST /api/v1/connectivity/from_json round-trip the editor used
+ * to make. The output shape deliberately mirrors what the backend produced, so the
+ * existing consumer code and layout manager need no changes: positions are
+ * placeholders, because the editor runs its layout manager over the result.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+
+import { type ConnectivityInfo, getFrontman } from "../uiCommon";
+import { toToolsArray } from "./definitionShape";
+
+export type EditorNodeData = {
+  label: string;
+  depth: number;
+  parent: string | undefined;
+  children: string[];
+  instructions: string;
+  dropdown_tools: never[];
+  sub_networks: never[];
+  network_name: string;
+  is_defined: boolean;
+  // @xyflow/react 12 requires a node's data to satisfy Record<string, unknown>.
+  [key: string]: unknown;
+};
+
+const DEFAULT_POSITION = { x: 100, y: 100 };
+
+type DefinitionEntry = ConnectivityInfo & { instructions?: string };
+
+/**
+ * Whether an agent is external to this network.
+ *
+ * A leading slash marks a reference into another agent network, and an http(s) URL
+ * marks an MCP server. Such entries are reachable inside a tools list but are never
+ * definitions of their own, so they render as undefined agents. This mirrors
+ * neuro-san's own `is_url_or_path`, which is what decides whether an entry survives
+ * into a network's definitions.
+ */
+const isExternal = (name: string): boolean =>
+  name.startsWith("/") || name.startsWith("http://") || name.startsWith("https://");
+
+const downChains = (entry: ConnectivityInfo | undefined): string[] => toToolsArray(entry?.tools);
+
+export const buildEditorGraph = (
+  definition: ConnectivityInfo[],
+  networkName: string
+): { nodes: Node<EditorNodeData>[]; edges: Edge[] } => {
+  // A backstop, not politeness. This runs during render, so anything thrown here
+  // takes the whole page down, and the definition arrives from several callers —
+  // one of which was handing over the designer's DICT-shaped progress payload, whose
+  // missing `length` slipped past an emptiness check and then failed to iterate.
+  // Callers should normalise with toConnectivityList; this makes forgetting cheap.
+  if (!Array.isArray(definition) || definition.length === 0) return { nodes: [], edges: [] };
+
+  // Entries keyed by name, for reading tools and instructions back out. External
+  // references are kept here so their tools resolve, but excluded from `defined`
+  // below so they never count as definitions.
+  const entries = new Map<string, DefinitionEntry>();
+  for (const entry of definition) {
+    if (entry.origin) entries.set(entry.origin, entry as DefinitionEntry);
+  }
+  const defined = new Set([...entries.keys()].filter((name) => !isExternal(name)));
+
+  // Breadth-first from the frontman, so depth and parent match the backend's
+  // traversal. Tracking visited nodes also makes a cyclic definition terminate.
+  const depth = new Map<string, number>();
+  const parent = new Map<string, string | undefined>();
+  const frontman = getFrontman(definition)?.origin ?? definition[0]?.origin;
+
+  const queue: string[] = [];
+  if (frontman) {
+    depth.set(frontman, 0);
+    parent.set(frontman, undefined);
+    queue.push(frontman);
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const child of downChains(entries.get(current))) {
+      if (depth.has(child)) continue;
+      depth.set(child, (depth.get(current) ?? 0) + 1);
+      parent.set(child, current);
+      queue.push(child);
+    }
+  }
+
+  // Every agent that is defined or merely referenced becomes a node, so a dangling
+  // down-chain still shows up on the canvas.
+  const allNames = new Set<string>(entries.keys());
+  for (const entry of definition) {
+    for (const child of downChains(entry)) allNames.add(child);
+  }
+
+  const nodes: Node<EditorNodeData>[] = [...allNames].map((name) => {
+    const entry = entries.get(name);
+    const isDefined = defined.has(name);
+    return {
+      id: name,
+      type: isDefined ? "agent" : "undefined_agent",
+      position: { ...DEFAULT_POSITION },
+      data: {
+        label: name,
+        depth: depth.get(name) ?? 0,
+        parent: parent.get(name),
+        children: downChains(entry),
+        instructions: entry?.instructions ?? "",
+        dropdown_tools: [],
+        sub_networks: [],
+        network_name: networkName,
+        is_defined: isDefined,
+      },
+    };
+  });
+
+  const edges: Edge[] = [];
+  for (const entry of definition) {
+    if (!entry.origin) continue;
+    for (const target of downChains(entry)) {
+      edges.push({
+        id: `${entry.origin}-${target}`,
+        source: entry.origin,
+        target,
+        animated: false,
+        type: "default",
+      });
+    }
+  }
+
+  return { nodes, edges };
+};

--- a/nsflow/frontend/src/state/editorNetworkStore.test.ts
+++ b/nsflow/frontend/src/state/editorNetworkStore.test.ts
@@ -1,0 +1,197 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { ConnectivityInfo } from "../uiCommon";
+import {
+  canRedo,
+  canUndo,
+  MAX_HISTORY_SNAPSHOTS,
+  useEditorNetworkStore,
+} from "./editorNetworkStore";
+
+const NET = "coffee_shop";
+
+const def = (...origins: string[]): ConnectivityInfo[] => origins.map((origin) => ({ origin, tools: [] }));
+
+const entry = () => useEditorNetworkStore.getState().entries[NET];
+
+describe("editorNetworkStore", () => {
+  beforeEach(() => {
+    useEditorNetworkStore.getState().reset(NET);
+    useEditorNetworkStore.getState().reset("book_shop");
+  });
+
+  it("seeds an entry on first edit, with one snapshot at cursor 0", () => {
+    useEditorNetworkStore.getState().applyEdit(NET, def("frontman"));
+    expect(entry().definition).toEqual(def("frontman"));
+    expect(entry().history).toHaveLength(1);
+    expect(entry().cursor).toBe(0);
+    expect(canUndo(entry())).toBe(false);
+    expect(canRedo(entry())).toBe(false);
+  });
+
+  it("pushes a snapshot per edit and advances the cursor", () => {
+    const store = useEditorNetworkStore.getState();
+    store.applyEdit(NET, def("frontman"));
+    store.applyEdit(NET, def("frontman", "barista"));
+    expect(entry().history).toHaveLength(2);
+    expect(entry().cursor).toBe(1);
+    expect(canUndo(entry())).toBe(true);
+  });
+
+  it("undo and redo move the cursor and restore the definition", () => {
+    const store = useEditorNetworkStore.getState();
+    store.applyEdit(NET, def("frontman"));
+    store.applyEdit(NET, def("frontman", "barista"));
+
+    store.undo(NET);
+    expect(entry().definition).toEqual(def("frontman"));
+    expect(entry().cursor).toBe(0);
+    expect(canRedo(entry())).toBe(true);
+
+    store.redo(NET);
+    expect(entry().definition).toEqual(def("frontman", "barista"));
+    expect(entry().cursor).toBe(1);
+  });
+
+  it("editing after an undo discards the redo tail", () => {
+    const store = useEditorNetworkStore.getState();
+    store.applyEdit(NET, def("a"));
+    store.applyEdit(NET, def("a", "b"));
+    store.undo(NET);
+    store.applyEdit(NET, def("a", "c"));
+
+    expect(entry().history).toHaveLength(2);
+    expect(entry().cursor).toBe(1);
+    expect(canRedo(entry())).toBe(false);
+    expect(entry().definition).toEqual(def("a", "c"));
+  });
+
+  it("undo at the start and redo at the end are no-ops", () => {
+    const store = useEditorNetworkStore.getState();
+    store.applyEdit(NET, def("a"));
+    store.undo(NET);
+    store.undo(NET);
+    expect(entry().cursor).toBe(0);
+    store.redo(NET);
+    expect(entry().cursor).toBe(0);
+  });
+
+  it("caps history and keeps the cursor on the newest snapshot", () => {
+    const store = useEditorNetworkStore.getState();
+    for (let i = 0; i < MAX_HISTORY_SNAPSHOTS + 10; i++) {
+      store.applyEdit(NET, def(`agent_${i}`));
+    }
+    expect(entry().history).toHaveLength(MAX_HISTORY_SNAPSHOTS);
+    expect(entry().cursor).toBe(MAX_HISTORY_SNAPSHOTS - 1);
+    expect(entry().definition).toEqual(def(`agent_${MAX_HISTORY_SNAPSHOTS + 9}`));
+  });
+
+  it("reconcileFromServer canonicalises in place without adding history", () => {
+    const store = useEditorNetworkStore.getState();
+    store.applyEdit(NET, def("frontman"));
+    const before = entry().history.length;
+
+    store.reconcileFromServer(NET, {
+      definition: [{ origin: "frontman", tools: ["barista"] }],
+      networkName: "coffee_shop_v2",
+      hocon: 'agent { name = "frontman" }',
+    });
+
+    // Server echoes and progress frames arrive continuously; one undo step per
+    // frame would bury the user's own edits.
+    expect(entry().history).toHaveLength(before);
+    expect(entry().cursor).toBe(0);
+    expect(entry().definition).toEqual([{ origin: "frontman", tools: ["barista"] }]);
+    expect(entry().history[0]).toEqual([{ origin: "frontman", tools: ["barista"] }]);
+    expect(entry().networkName).toBe("coffee_shop_v2");
+    expect(entry().hocon).toBe('agent { name = "frontman" }');
+  });
+
+  it("reconcileFromServer seeds an entry when the server speaks first", () => {
+    useEditorNetworkStore.getState().reconcileFromServer(NET, { definition: def("frontman") });
+    expect(entry().definition).toEqual(def("frontman"));
+    expect(entry().history).toHaveLength(1);
+    expect(entry().cursor).toBe(0);
+  });
+
+  it("keeps networks isolated from one another", () => {
+    const store = useEditorNetworkStore.getState();
+    store.applyEdit(NET, def("a"));
+    store.applyEdit("book_shop", def("z"));
+    expect(entry().definition).toEqual(def("a"));
+    expect(useEditorNetworkStore.getState().entries.book_shop.definition).toEqual(def("z"));
+  });
+
+  it("does not mutate the caller's definition array", () => {
+    const mine = def("a");
+    useEditorNetworkStore.getState().applyEdit(NET, mine);
+    useEditorNetworkStore.getState().applyEdit(NET, def("a", "b"));
+    expect(mine).toEqual(def("a"));
+  });
+
+  it("persists entries to IndexedDB so a reload can restore them", async () => {
+    useEditorNetworkStore.getState().applyEdit("persisted_net", def("frontman", "barista"));
+
+    // zustand's persist middleware writes asynchronously; let the microtask and the
+    // fake-indexeddb transaction settle before reading it back.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const { indexedDBStorage } = await import("../uiCommon");
+    const stored = (await indexedDBStorage.getItem("nsflow-editor-network")) as {
+      state: { entries: Record<string, { definition: ConnectivityInfo[]; cursor: number }> };
+    } | null;
+
+    expect(stored?.state.entries.persisted_net.definition).toEqual(def("frontman", "barista"));
+    expect(stored?.state.entries.persisted_net.cursor).toBe(0);
+
+    useEditorNetworkStore.getState().reset("persisted_net");
+  });
+});
+
+describe("reconcile churn", () => {
+  beforeEach(() => {
+    useEditorNetworkStore.getState().reset(NET);
+  });
+
+  it("keeps the entry reference stable when the server repeats a definition", () => {
+    // The designer streams many progress frames per turn, most carrying a
+    // definition we already hold. A new object each time would rebuild the canvas
+    // on every frame.
+    const payload = { definition: def("frontman", "barista"), networkName: "coffee_shop" };
+    useEditorNetworkStore.getState().reconcileFromServer(NET, payload);
+    const first = entry();
+
+    useEditorNetworkStore.getState().reconcileFromServer(NET, {
+      definition: def("frontman", "barista"),
+      networkName: "coffee_shop",
+    });
+
+    expect(entry()).toBe(first);
+  });
+
+  it("still updates when the definition actually changes", () => {
+    useEditorNetworkStore.getState().reconcileFromServer(NET, { definition: def("frontman") });
+    const first = entry();
+
+    useEditorNetworkStore.getState().reconcileFromServer(NET, { definition: def("frontman", "barista") });
+
+    expect(entry()).not.toBe(first);
+    expect(entry().definition).toEqual(def("frontman", "barista"));
+  });
+});

--- a/nsflow/frontend/src/state/editorNetworkStore.ts
+++ b/nsflow/frontend/src/state/editorNetworkStore.ts
@@ -1,0 +1,226 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * The authority for in-progress manual edits to an agent network.
+ *
+ * This replaces nsflow's server-side editor state (backend/utils/editor:
+ * SimpleStateManager for the live model, OperationStore for JSONL inverse-op undo
+ * history, draft_states/ for reload survival). Edits apply here first and the
+ * canvas renders from here; the round-trip to the agent then canonicalises what
+ * the server considers true. Undo/redo is a cursor over local snapshots, with no
+ * inverse ops and no server involvement.
+ *
+ * `applyEdit` is deliberately the single mutation seam. Every editing affordance
+ * we add (drag-and-drop to add a node, right-click to delete, the hover pencil to
+ * edit instructions) computes a new definition and calls it, so richer editing
+ * stays UI work rather than state work.
+ *
+ * Persisted to IndexedDB with ui-common's storage adapter, which is what makes an
+ * in-progress network survive a full page reload.
+ */
+
+import { create } from "zustand";
+import { persist, type PersistStorage, type StorageValue } from "zustand/middleware";
+
+import { type ConnectivityInfo, indexedDBStorage } from "../uiCommon";
+
+/**
+ * How many undo steps to keep. Matches ui-common's MAX_CHAT_HISTORY_ITEMS so the
+ * two stores behave consistently.
+ *
+ * Direct-manipulation editing (dragging especially) can produce edits faster than
+ * a user thinks of them as steps. If that makes undo feel too fine-grained, the
+ * fix is to coalesce rapid edits inside `applyEdit` rather than to raise this.
+ */
+export const MAX_HISTORY_SNAPSHOTS = 50;
+
+const STORE_KEY = "nsflow-editor-network";
+
+export type ServerNetworkPayload = {
+  readonly definition: ConnectivityInfo[];
+  readonly networkName?: string;
+  readonly hocon?: string;
+};
+
+export type EditorNetworkEntry = {
+  readonly networkName?: string;
+  readonly definition: ConnectivityInfo[];
+  readonly hocon?: string;
+  readonly slyData: Record<string, unknown>;
+  readonly history: ConnectivityInfo[][];
+  readonly cursor: number;
+};
+
+type EditorNetworkStore = {
+  readonly entries: Record<string, EditorNetworkEntry>;
+  applyEdit: (networkId: string, definition: ConnectivityInfo[]) => void;
+  reconcileFromServer: (networkId: string, payload: ServerNetworkPayload) => void;
+  setSlyData: (networkId: string, slyData: Record<string, unknown>) => void;
+  undo: (networkId: string) => void;
+  redo: (networkId: string) => void;
+  reset: (networkId: string) => void;
+};
+
+const EMPTY_ENTRY: EditorNetworkEntry = {
+  definition: [],
+  slyData: {},
+  history: [],
+  cursor: -1,
+};
+
+/**
+ * Snapshots are deep-copied on the way in: definitions arriving from the progress
+ * stream are live references into React state, and history entries must not change
+ * underneath us afterwards.
+ */
+const snapshot = (definition: ConnectivityInfo[]): ConnectivityInfo[] =>
+  JSON.parse(JSON.stringify(definition)) as ConnectivityInfo[];
+
+export const canUndo = (entry: EditorNetworkEntry | undefined): boolean => Boolean(entry) && entry!.cursor > 0;
+
+export const canRedo = (entry: EditorNetworkEntry | undefined): boolean =>
+  Boolean(entry) && entry!.cursor < entry!.history.length - 1;
+
+export const selectEntry = (
+  state: EditorNetworkStore,
+  networkId: string | undefined
+): EditorNetworkEntry | undefined => (networkId ? state.entries[networkId] : undefined);
+
+/** Only `entries` is persisted; the actions are recreated on load. */
+type PersistedEditorState = Pick<EditorNetworkStore, "entries">;
+
+const editorStorage: PersistStorage<PersistedEditorState> = {
+  getItem: async (name) => (await indexedDBStorage.getItem(name)) as StorageValue<PersistedEditorState> | null,
+  setItem: async (name, value) => {
+    await indexedDBStorage.setItem(name, value);
+  },
+  removeItem: async (name) => {
+    await indexedDBStorage.removeItem(name);
+  },
+};
+
+export const useEditorNetworkStore = create<EditorNetworkStore>()(
+  persist(
+    (set) => ({
+      entries: {},
+
+      applyEdit: (networkId, definition) =>
+        set((state) => {
+          const existing = state.entries[networkId] ?? EMPTY_ENTRY;
+          // Truncate the redo tail: editing after an undo abandons that future.
+          const kept = existing.history.slice(0, existing.cursor + 1);
+          const capped = [...kept, snapshot(definition)].slice(-MAX_HISTORY_SNAPSHOTS);
+          return {
+            entries: {
+              ...state.entries,
+              [networkId]: {
+                ...existing,
+                definition: snapshot(definition),
+                history: capped,
+                cursor: capped.length - 1,
+              },
+            },
+          };
+        }),
+
+      // Canonicalises the current snapshot rather than pushing a new one: server
+      // echoes and progress frames stream continuously, and one undo step per frame
+      // would bury the user's own edits.
+      reconcileFromServer: (networkId, payload) =>
+        set((state) => {
+          const existing = state.entries[networkId] ?? EMPTY_ENTRY;
+
+          // The designer emits progress frames continuously during generation, and
+          // most repeat a definition we already hold. Returning the identical state
+          // object keeps the entry reference stable so the canvas does not rebuild
+          // itself on every frame.
+          if (
+            state.entries[networkId] &&
+            payload.networkName === existing.networkName &&
+            payload.hocon === existing.hocon &&
+            JSON.stringify(payload.definition) === JSON.stringify(existing.definition)
+          ) {
+            return state;
+          }
+
+          const next = snapshot(payload.definition);
+          const history = existing.history.length === 0 ? [next] : [...existing.history];
+          const cursor = existing.cursor < 0 ? 0 : existing.cursor;
+          history[cursor] = next;
+          return {
+            entries: {
+              ...state.entries,
+              [networkId]: {
+                ...existing,
+                definition: next,
+                history,
+                cursor,
+                // The definition/name pair must stay atomic: the backend persists
+                // the definition under agent_network_name, so pairing a fresh
+                // definition with a stale name can overwrite another network.
+                networkName: payload.networkName ?? existing.networkName,
+                hocon: payload.hocon ?? existing.hocon,
+              },
+            },
+          };
+        }),
+
+      setSlyData: (networkId, slyData) =>
+        set((state) => {
+          const existing = state.entries[networkId] ?? EMPTY_ENTRY;
+          return { entries: { ...state.entries, [networkId]: { ...existing, slyData } } };
+        }),
+
+      undo: (networkId) =>
+        set((state) => {
+          const existing = state.entries[networkId];
+          if (!canUndo(existing)) return state;
+          const cursor = existing!.cursor - 1;
+          return {
+            entries: {
+              ...state.entries,
+              [networkId]: { ...existing!, cursor, definition: snapshot(existing!.history[cursor]) },
+            },
+          };
+        }),
+
+      redo: (networkId) =>
+        set((state) => {
+          const existing = state.entries[networkId];
+          if (!canRedo(existing)) return state;
+          const cursor = existing!.cursor + 1;
+          return {
+            entries: {
+              ...state.entries,
+              [networkId]: { ...existing!, cursor, definition: snapshot(existing!.history[cursor]) },
+            },
+          };
+        }),
+
+      reset: (networkId) =>
+        set((state) => {
+          const { [networkId]: _dropped, ...rest } = state.entries;
+          return { entries: rest };
+        }),
+    }),
+    {
+      name: STORE_KEY,
+      storage: editorStorage,
+      partialize: (state): PersistedEditorState => ({ entries: state.entries }),
+    }
+  )
+);

--- a/nsflow/frontend/src/state/editorOperations.test.ts
+++ b/nsflow/frontend/src/state/editorOperations.test.ts
@@ -1,0 +1,450 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it } from "vitest";
+
+import type { AgentNetworkDefinitionEntry, ConnectivityInfo } from "../uiCommon";
+import {
+  addAgent,
+  canDelete,
+  canDuplicate,
+  canHaveChildren,
+  connectAgents,
+  definitionIssues,
+  deleteAgent,
+  disconnectAgents,
+  duplicateAgent,
+  canRename,
+  renameAgent,
+  reparentAgent,
+  rootsOf,
+  uniqueAgentName,
+  updateAgent,
+} from "./editorOperations";
+
+/**
+ * A realistic network: LLM agents carry instructions, and `rewards_db` is a toolbox
+ * tool, which is expressed by its entry having neither instructions nor description.
+ * That distinction is not decoration here — it decides what may be given children.
+ */
+const COFFEE: AgentNetworkDefinitionEntry[] = [
+  { origin: "frontman", tools: ["barista", "loyalty"], instructions: "Greet.", description: "Front" },
+  { origin: "barista", tools: [], instructions: "Make coffee.", description: "Barista" },
+  { origin: "loyalty", tools: ["rewards_db"], instructions: "Handle points.", description: "Loyalty" },
+  { origin: "rewards_db", tools: [] },
+];
+
+describe("uniqueAgentName", () => {
+  it("keeps a free name and numbers a taken one", () => {
+    expect(uniqueAgentName(COFFEE, "roaster")).toBe("roaster");
+    expect(uniqueAgentName(COFFEE, "barista")).toBe("barista_2");
+  });
+
+  it("lets an agent be given many children, not just one", () => {
+    // The canvas builds child names from the parent ("<parent>_child"), so without
+    // this an agent could be given exactly one child and every later attempt was
+    // rejected as a duplicate with no feedback.
+    let definition: ConnectivityInfo[] = COFFEE;
+    for (let i = 0; i < 4; i += 1) {
+      const name = uniqueAgentName(definition, "barista_child");
+      definition = addAgent(definition, name, "barista");
+    }
+
+    expect(definition.find((entry) => entry.origin === "barista")?.tools).toEqual([
+      "barista_child",
+      "barista_child_2",
+      "barista_child_3",
+      "barista_child_4",
+    ]);
+  });
+
+  it("keeps counting past names that are themselves taken", () => {
+    const taken = [...COFFEE, { origin: "barista_2", tools: [] }];
+    expect(uniqueAgentName(taken, "barista")).toBe("barista_3");
+  });
+});
+
+describe("addAgent", () => {
+  it("appends a new agent with no tools", () => {
+    const next = addAgent(COFFEE, "roaster");
+    expect(next.find((a) => a.origin === "roaster")).toEqual({ origin: "roaster", tools: [] });
+  });
+
+  it("attaches to the frontman when no parent is named, never leaving it floating", () => {
+    // A free-floating agent gives the network a second root, which neuro-san repairs
+    // with its LLM rather than rejecting. Defaulting the parent here is what makes
+    // that unreachable however the agent was added.
+    const next = addAgent(COFFEE, "roaster");
+    expect(next.find((a) => a.origin === "frontman")?.tools).toEqual(["barista", "loyalty", "roaster"]);
+    expect(definitionIssues(next)).toEqual([]);
+  });
+
+  it("makes the first agent of an empty network the frontman", () => {
+    const next = addAgent([], "frontman", undefined, { instructions: "Hi.", description: "Front" });
+    expect(rootsOf(next)).toEqual(["frontman"]);
+    expect(definitionIssues(next)).toEqual([]);
+  });
+
+  it("attaches the new agent to a parent when one is given", () => {
+    const next = addAgent(COFFEE, "roaster", "frontman");
+    expect(next.find((a) => a.origin === "frontman")?.tools).toEqual(["barista", "loyalty", "roaster"]);
+  });
+
+  it("refuses to add a duplicate name, returning the definition unchanged", () => {
+    expect(addAgent(COFFEE, "barista")).toBe(COFFEE);
+  });
+
+  it("refuses a toolbox tool as the parent, which would be an invalid network", () => {
+    // A toolbox tool with down-chains fails the designer's structure validation and
+    // gets the whole network rewritten by the LLM, so the edit must not happen at all.
+    expect(addAgent(COFFEE, "roaster", "rewards_db")).toBe(COFFEE);
+  });
+
+  it("refuses an external reference as the parent", () => {
+    const withExternal = [...COFFEE, { origin: "/other_network", tools: [] }];
+    expect(addAgent(withExternal, "roaster", "/other_network")).toBe(withExternal);
+  });
+
+  it("does not mutate the input", () => {
+    const before = JSON.stringify(COFFEE);
+    addAgent(COFFEE, "roaster", "frontman");
+    expect(JSON.stringify(COFFEE)).toBe(before);
+  });
+});
+
+describe("canDuplicate", () => {
+  it("refuses the frontman and allows any other agent", () => {
+    // The copy inherits the original's parents, so duplicating the one agent that
+    // has none would produce a second root.
+    expect(canDuplicate(COFFEE, "frontman")).toBe(false);
+    expect(canDuplicate(COFFEE, "barista")).toBe(true);
+  });
+
+  it("refuses a name that is not in the definition", () => {
+    expect(canDuplicate(COFFEE, "ghost")).toBe(false);
+  });
+});
+
+describe("canDelete", () => {
+  it("refuses the frontman and allows any other agent", () => {
+    // There is no parent to promote the frontman's children to, and removing it
+    // would leave the network with no entry point. Editing its instructions or
+    // starting a new draft covers what a user would want instead.
+    expect(canDelete(COFFEE, "frontman")).toBe(false);
+    expect(canDelete(COFFEE, "loyalty")).toBe(true);
+  });
+
+  it("allows deleting a dangling reference, which has no entry of its own", () => {
+    expect(canDelete([{ origin: "frontman", tools: ["ghost"] }], "ghost")).toBe(true);
+  });
+});
+
+describe("canHaveChildren", () => {
+  it("allows an LLM agent and refuses a tool or an external reference", () => {
+    expect(canHaveChildren(COFFEE, "frontman")).toBe(true);
+    expect(canHaveChildren(COFFEE, "rewards_db")).toBe(false);
+    expect(canHaveChildren(COFFEE, "/other_network")).toBe(false);
+    expect(canHaveChildren(COFFEE, "https://mcp.example.com/mcp")).toBe(false);
+  });
+
+  it("allows a name that is not in the definition yet", () => {
+    // It is about to be added as an agent, so refusing would block the first edit.
+    expect(canHaveChildren(COFFEE, "roaster")).toBe(true);
+  });
+});
+
+describe("connectAgents", () => {
+  it("adds the target to the source's down-chains", () => {
+    const next = connectAgents(COFFEE, "barista", "rewards_db");
+    expect(next.find((a) => a.origin === "barista")?.tools).toEqual(["rewards_db"]);
+  });
+
+  it("refuses an edge out of a toolbox tool", () => {
+    expect(connectAgents(COFFEE, "rewards_db", "barista")).toBe(COFFEE);
+  });
+
+  it("refuses a self-edge, a duplicate, and an unknown source", () => {
+    expect(connectAgents(COFFEE, "frontman", "frontman")).toBe(COFFEE);
+    expect(connectAgents(COFFEE, "frontman", "barista")).toBe(COFFEE);
+    expect(connectAgents(COFFEE, "ghost", "barista")).toBe(COFFEE);
+  });
+
+  it("does not mutate the input", () => {
+    const before = JSON.stringify(COFFEE);
+    connectAgents(COFFEE, "barista", "rewards_db");
+    expect(JSON.stringify(COFFEE)).toBe(before);
+  });
+});
+
+describe("definitionIssues", () => {
+  it("accepts a network with one root", () => {
+    expect(definitionIssues(COFFEE)).toEqual([]);
+  });
+
+  it("reports a second root, which is what breaks a free-floating agent", () => {
+    // Measured against a live designer: sending this reports "No front man agent
+    // found in network" and hands the network to the LLM to restructure, discarding
+    // the user's edit. So it must be caught before it goes on the wire.
+    const orphaned: AgentNetworkDefinitionEntry[] = [
+      ...COFFEE,
+      { origin: "stray", tools: [], instructions: "Hi.", description: "Stray" },
+    ];
+    expect(definitionIssues(orphaned)).toEqual([
+      "More than one agent has no parent (frontman, stray). Connect all but one of them.",
+    ]);
+  });
+
+  it("reports a tool that has been given down-chains", () => {
+    const definition: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: ["rewards_db"], instructions: "Go.", description: "Front" },
+      { origin: "rewards_db", tools: ["oops"] },
+      { origin: "oops", tools: [], instructions: "Hi.", description: "Oops" },
+    ];
+    expect(definitionIssues(definition)).toContain(
+      '"rewards_db" is a tool, so it cannot have down-chain agents.'
+    );
+  });
+
+  it("reports a cycle with no entry point", () => {
+    const cyclic: AgentNetworkDefinitionEntry[] = [
+      { origin: "a", tools: ["b"], instructions: "A", description: "A" },
+      { origin: "b", tools: ["a"], instructions: "B", description: "B" },
+    ];
+    expect(definitionIssues(cyclic)).toEqual([
+      "Every agent is a down-chain of another, so the network has no entry point.",
+    ]);
+  });
+
+  it("does not count an external reference as a root", () => {
+    const withExternal: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: ["/other_network"], instructions: "Go.", description: "Front" },
+      { origin: "/other_network", tools: [] },
+    ];
+    expect(definitionIssues(withExternal)).toEqual([]);
+  });
+});
+
+describe("disconnectAgents", () => {
+  it("removes the down-chain but keeps both agents", () => {
+    const next = disconnectAgents(COFFEE, "frontman", "barista");
+    expect(next.find((a) => a.origin === "frontman")?.tools).toEqual(["loyalty"]);
+    // The agent itself survives so it can be reconnected somewhere else.
+    expect(next.find((a) => a.origin === "barista")).toBeDefined();
+  });
+
+  it("is a no-op when the connection is not there", () => {
+    expect(disconnectAgents(COFFEE, "frontman", "rewards_db")).toBe(COFFEE);
+  });
+});
+
+describe("reparentAgent", () => {
+  it("moves an agent in one edit, never passing through a rootless state", () => {
+    const next = reparentAgent(COFFEE, "barista", "frontman", "loyalty");
+    expect(next.find((a) => a.origin === "frontman")?.tools).toEqual(["loyalty"]);
+    expect(next.find((a) => a.origin === "loyalty")?.tools).toEqual(["rewards_db", "barista"]);
+    // The whole point: the intermediate state is never observable.
+    expect(definitionIssues(next)).toEqual([]);
+  });
+
+  it("refuses a move onto a tool, leaving the definition alone", () => {
+    expect(reparentAgent(COFFEE, "barista", "frontman", "rewards_db")).toBe(COFFEE);
+  });
+});
+
+describe("reusing an agent elsewhere in the network", () => {
+  // frontman -> b, and frontman -> l1 -> l2. The goal is to move b under l2.
+  const NETWORK: AgentNetworkDefinitionEntry[] = [
+    { origin: "frontman", tools: ["b", "l1"], instructions: "Front.", description: "Front" },
+    { origin: "b", tools: [], instructions: "B.", description: "B" },
+    { origin: "l1", tools: ["l2"], instructions: "L1.", description: "L1" },
+    { origin: "l2", tools: [], instructions: "L2.", description: "L2" },
+  ];
+
+  it("holds the detached step back, then saves once it is reconnected", () => {
+    // Step one leaves b with no parent. Measured against a live designer, sending
+    // this costs 28.5 seconds and twelve LLM tools, and the network comes back
+    // restructured — so definitionIssues has to catch it and the editor has to wait.
+    const detached = disconnectAgents(NETWORK, "frontman", "b");
+    expect(detached.find((entry) => entry.origin === "b")).toBeDefined();
+    expect(definitionIssues(detached)).toEqual([
+      "More than one agent has no parent (frontman, b). Connect all but one of them.",
+    ]);
+
+    // Step two makes it valid again, and this is what actually goes to the designer.
+    const reconnected = connectAgents(detached, "l2", "b");
+    expect(reconnected.find((entry) => entry.origin === "l2")?.tools).toEqual(["b"]);
+    expect(definitionIssues(reconnected)).toEqual([]);
+  });
+
+  it("does it in one edit when the edge endpoint is dragged instead", () => {
+    const moved = reparentAgent(NETWORK, "b", "frontman", "l2");
+    expect(moved.find((entry) => entry.origin === "frontman")?.tools).toEqual(["l1"]);
+    expect(moved.find((entry) => entry.origin === "l2")?.tools).toEqual(["b"]);
+    // Never invalid at any point, so it is sent straight away.
+    expect(definitionIssues(moved)).toEqual([]);
+  });
+});
+
+describe("deleteAgent", () => {
+  it("refuses the frontman, leaving the definition untouched", () => {
+    expect(deleteAgent(COFFEE, "frontman")).toBe(COFFEE);
+  });
+
+  it("promotes the deleted agent's children to its parent, leaving no orphan", () => {
+    // loyalty owns rewards_db. Deleting loyalty must not leave rewards_db with
+    // nothing chaining down to it, which would give the network a second root.
+    const next = deleteAgent(COFFEE, "loyalty");
+    expect(next.find((a) => a.origin === "frontman")?.tools).toEqual(["barista", "rewards_db"]);
+    expect(definitionIssues(next)).toEqual([]);
+  });
+
+  it("promotes several children at once, into the deleted agent's position", () => {
+    // A -> B -> C, D, E. Deleting B must leave A -> C, D, E, and where B sat.
+    const chain: AgentNetworkDefinitionEntry[] = [
+      { origin: "a", tools: ["b", "f"], instructions: "A.", description: "A" },
+      { origin: "b", tools: ["c", "d", "e"], instructions: "B.", description: "B" },
+      { origin: "c", tools: [], instructions: "C.", description: "C" },
+      { origin: "d", tools: [], instructions: "D.", description: "D" },
+      { origin: "e", tools: [], instructions: "E.", description: "E" },
+      { origin: "f", tools: [], instructions: "F.", description: "F" },
+    ];
+    const next = deleteAgent(chain, "b");
+    expect(next.find((entry) => entry.origin === "a")?.tools).toEqual(["c", "d", "e", "f"]);
+    expect(next.map((entry) => entry.origin)).not.toContain("b");
+    expect(definitionIssues(next)).toEqual([]);
+  });
+
+  it("does not duplicate a child the parent already had", () => {
+    const shared: AgentNetworkDefinitionEntry[] = [
+      { origin: "frontman", tools: ["mid", "shared"], instructions: "Go.", description: "Front" },
+      { origin: "mid", tools: ["shared"], instructions: "Mid.", description: "Mid" },
+      { origin: "shared", tools: [], instructions: "Shared.", description: "Shared" },
+    ];
+    expect(deleteAgent(shared, "mid").find((a) => a.origin === "frontman")?.tools).toEqual([
+      "shared",
+    ]);
+  });
+
+  it("removes the agent's own entry", () => {
+    expect(deleteAgent(COFFEE, "barista").map((a) => a.origin)).toEqual(["frontman", "loyalty", "rewards_db"]);
+  });
+
+  it("also removes it from every other agent's tools, leaving no dangling edge", () => {
+    const next = deleteAgent(COFFEE, "barista");
+    expect(next.find((a) => a.origin === "frontman")?.tools).toEqual(["loyalty"]);
+  });
+
+  it("removes references even when the agent has no entry of its own", () => {
+    const dangling: ConnectivityInfo[] = [{ origin: "frontman", tools: ["ghost"] }];
+    expect(deleteAgent(dangling, "ghost")).toEqual([{ origin: "frontman", tools: [] }]);
+  });
+
+  it("does not mutate the input", () => {
+    const before = JSON.stringify(COFFEE);
+    deleteAgent(COFFEE, "barista");
+    expect(JSON.stringify(COFFEE)).toBe(before);
+  });
+});
+
+describe("duplicateAgent", () => {
+  it("refuses the frontman, which would leave the copy with no parent", () => {
+    expect(duplicateAgent(COFFEE, "frontman", "frontman_copy")).toBe(COFFEE);
+  });
+
+  it("leaves the network valid after duplicating an ordinary agent", () => {
+    expect(definitionIssues(duplicateAgent(COFFEE, "barista", "barista_copy"))).toEqual([]);
+  });
+
+  it("copies the agent's tools and instructions under the new name", () => {
+    const withInstructions: ConnectivityInfo[] = [
+      { origin: "frontman", tools: ["loyalty"] },
+      { origin: "loyalty", tools: ["rewards_db"], instructions: "Handle rewards." } as ConnectivityInfo,
+    ];
+    const next = duplicateAgent(withInstructions, "loyalty", "loyalty_copy");
+    expect(next.find((a) => a.origin === "loyalty_copy")).toMatchObject({
+      origin: "loyalty_copy",
+      tools: ["rewards_db"],
+      instructions: "Handle rewards.",
+    });
+  });
+
+  it("attaches the copy wherever the original was referenced", () => {
+    const next = duplicateAgent(COFFEE, "barista", "barista_2");
+    expect(next.find((a) => a.origin === "frontman")?.tools).toEqual(["barista", "loyalty", "barista_2"]);
+  });
+
+  it("returns the definition unchanged for an unknown source or a taken name", () => {
+    expect(duplicateAgent(COFFEE, "nope", "x")).toBe(COFFEE);
+    expect(duplicateAgent(COFFEE, "barista", "loyalty")).toBe(COFFEE);
+  });
+});
+
+describe("renameAgent", () => {
+  it("follows every reference, so no parent is left pointing at a gone name", () => {
+    const next = renameAgent(COFFEE, "barista", "brewer");
+    expect(next.find((entry) => entry.origin === "brewer")).toBeDefined();
+    expect(next.find((entry) => entry.origin === "barista")).toBeUndefined();
+    // The parent's tools list is the reference that would otherwise dangle.
+    expect(next.find((entry) => entry.origin === "frontman")?.tools).toEqual(["brewer", "loyalty"]);
+    expect(definitionIssues(next)).toEqual([]);
+  });
+
+  it("renames the frontman too, which has no parent to follow", () => {
+    const next = renameAgent(COFFEE, "frontman", "greeter");
+    expect(rootsOf(next)).toEqual(["greeter"]);
+    expect(definitionIssues(next)).toEqual([]);
+  });
+
+  it("refuses a name that is taken, or an unknown agent", () => {
+    expect(renameAgent(COFFEE, "barista", "loyalty")).toBe(COFFEE);
+    expect(renameAgent(COFFEE, "ghost", "brewer")).toBe(COFFEE);
+    expect(renameAgent(COFFEE, "barista", "barista")).toBe(COFFEE);
+  });
+
+  it("refuses a tool or an external reference, whose name is what it resolves to", () => {
+    const withExternal = [...COFFEE, { origin: "/other_network", tools: [] }];
+    expect(canRename(COFFEE, "rewards_db")).toBe(false);
+    expect(renameAgent(COFFEE, "rewards_db", "points_db")).toBe(COFFEE);
+    expect(canRename(withExternal, "/other_network")).toBe(false);
+  });
+
+  it("does not mutate the input", () => {
+    const before = JSON.stringify(COFFEE);
+    renameAgent(COFFEE, "barista", "brewer");
+    expect(JSON.stringify(COFFEE)).toBe(before);
+  });
+});
+
+describe("updateAgent", () => {
+  it("merges the patch into the named agent only", () => {
+    const next = updateAgent(COFFEE, "barista", { instructions: "Make the coffee." });
+    expect(next.find((a) => a.origin === "barista")).toMatchObject({
+      origin: "barista",
+      tools: [],
+      instructions: "Make the coffee.",
+    });
+    expect(next.find((a) => a.origin === "loyalty")).toEqual(COFFEE[2]);
+  });
+
+  it("can rewire down-chains, which is how an edge edit is expressed", () => {
+    const next = updateAgent(COFFEE, "frontman", { tools: ["loyalty"] });
+    expect(next.find((a) => a.origin === "frontman")?.tools).toEqual(["loyalty"]);
+  });
+
+  it("returns the definition unchanged for an unknown agent", () => {
+    expect(updateAgent(COFFEE, "nope", { instructions: "x" })).toBe(COFFEE);
+  });
+});

--- a/nsflow/frontend/src/state/editorOperations.ts
+++ b/nsflow/frontend/src/state/editorOperations.ts
@@ -1,0 +1,423 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Pure transforms on an agent network definition.
+ *
+ * These replace the per-operation REST calls the editor used to make (POST an
+ * agent, POST a duplicate, DELETE an agent). Doing the transform in the browser is
+ * what lets an edit apply instantly; `editorRoundTrip` then sends the result to the
+ * designer to be canonicalised.
+ *
+ * They are deliberately pure and free of React or store imports, so every editing
+ * affordance can share them: drag-and-drop to add, right-click to delete, the hover
+ * pencil to edit instructions, and dragging an edge to rewire down-chains. Each one
+ * computes the next definition and hands it to `applyEdit`.
+ *
+ * Every function returns the ORIGINAL array unchanged (same reference) when the
+ * operation does not apply, so callers can skip a pointless round-trip with a
+ * `next === definition` check.
+ */
+
+import type { ConnectivityInfo } from "../uiCommon";
+import { isExternalName, isToolboxTool, toToolsArray } from "./definitionShape";
+
+// Never spread `tools` directly: it can arrive as an index-keyed object, which
+// throws "is not iterable". toToolsArray is the one place that shape is undone.
+const toolsOf = (entry: ConnectivityInfo): string[] => toToolsArray(entry.tools);
+
+const has = (definition: ConnectivityInfo[], name: string): boolean =>
+  definition.some((entry) => entry.origin === name);
+
+/**
+ * A name based on `base` that the definition does not already use.
+ *
+ * For anonymous additions only, where "agent" becoming "agent_2" is what the user
+ * expects. A name that resolves to something specific, like a toolbox tool or
+ * another network, must never be adjusted this way: the adjusted name would resolve
+ * to nothing at all.
+ */
+export const uniqueAgentName = (definition: ConnectivityInfo[], base: string): string => {
+  if (!has(definition, base)) return base;
+  let suffix = 2;
+  while (has(definition, `${base}_${suffix}`)) suffix += 1;
+  return `${base}_${suffix}`;
+};
+
+/**
+ * What a newly added LLM agent starts out with.
+ *
+ * The designer's own `AddAgent` coded tool writes `instructions` and `description`
+ * for an agent and nothing at all for a tool, which is how the two are told apart
+ * downstream: an entry with neither key is a TOOLBOX tool. So an agent added without
+ * them is validated as a toolbox agent, and if it has down-chains validation reports
+ * "toolbox agent 'x' references tool 'y'" and the designer LLM is summoned to repair
+ * the network. Measured against a live designer: 39 seconds and thousands of tokens
+ * per edit, renaming and restructuring what the user drew.
+ *
+ * `AddAgent` writes them as empty strings, but an empty value trips a second
+ * validator ("provide non-empty 'instructions' and 'description'") which summons the
+ * instructions writer instead: 22 seconds. So these defaults are non-empty, which is
+ * what keeps a hand-added agent on the deterministic sub-second path.
+ *
+ * They stay deliberately generic, saying only what is certainly true rather than
+ * inventing a purpose, because the user is expected to replace them. A user who then
+ * clears them keeps the empty value: emptiness is preserved on the way to the
+ * designer (see `definitionShape`), which is free to fill them in from there.
+ */
+export const newAgentAttributes = (name: string): Record<string, unknown> => ({
+  instructions: `You are ${name}.`,
+  description: `The ${name} agent.`,
+});
+
+/**
+ * The agents nothing else chains down to.
+ *
+ * A valid network has exactly one, the frontman. More than one is what neuro-san
+ * reports as "No front man agent found in network", so this is the test every
+ * add-like operation uses to make sure it never creates a second one.
+ */
+export const rootsOf = (definition: ConnectivityInfo[]): string[] => {
+  const referenced = new Set<string>();
+  for (const entry of definition) {
+    for (const tool of toolsOf(entry)) referenced.add(tool);
+  }
+  return definition
+    .map((entry) => entry.origin)
+    .filter((origin): origin is string => Boolean(origin) && !isExternalName(origin as string))
+    .filter((origin) => !referenced.has(origin));
+};
+
+/**
+ * The agent a new one attaches to when the caller names no parent.
+ *
+ * Undefined only for an empty network, where the new agent becomes the root itself.
+ */
+const defaultParent = (definition: ConnectivityInfo[]): string | undefined => rootsOf(definition)[0];
+
+/**
+ * Why this definition cannot be saved yet, or an empty list when it can.
+ *
+ * Rearranging a network passes through states that are legitimate to look at but not
+ * to persist: detach an agent and, for that moment, the network has two roots. Sent
+ * as-is, neuro-san reports "No front man agent found in network" and hands the
+ * network to the designer LLM to repair, which restructures it and throws away the
+ * edit in progress. Measured against a live designer at 30+ seconds.
+ *
+ * So the editor holds such a state locally and waits. Both rules below are ones the
+ * designer was observed to enforce, not guesses.
+ */
+export const definitionIssues = (definition: ConnectivityInfo[]): string[] => {
+  if (definition.length === 0) return ["Nothing to save yet."];
+
+  const issues: string[] = [];
+
+  const roots = rootsOf(definition);
+  if (roots.length === 0) {
+    // Every agent is referenced, so the graph is a cycle with no entry point.
+    issues.push("Every agent is a down-chain of another, so the network has no entry point.");
+  } else if (roots.length > 1) {
+    issues.push(`More than one agent has no parent (${roots.join(", ")}). Connect all but one of them.`);
+  }
+
+  for (const entry of definition) {
+    if (isToolboxTool(entry) && toolsOf(entry).length > 0) {
+      issues.push(`"${entry.origin}" is a tool, so it cannot have down-chain agents.`);
+    }
+  }
+
+  return issues;
+};
+
+/**
+ * Whether `name` is allowed down-chain agents.
+ *
+ * Only LLM agents are. A toolbox tool with down-chains is an invalid network:
+ * validation reports "toolbox agent 'x' references tool 'y'" and the designer LLM is
+ * summoned to repair it, measured at 31 seconds against a live designer. An external
+ * network or MCP server has no entry of its own here, so it cannot be given children
+ * either. An unknown name is treated as allowed, since it is about to be added.
+ */
+export const canHaveChildren = (definition: ConnectivityInfo[], name: string): boolean => {
+  if (isExternalName(name)) return false;
+  const entry = definition.find((candidate) => candidate.origin === name);
+  return entry ? !isToolboxTool(entry) : true;
+};
+
+/**
+ * Add an agent as a down-chain of `parentName`, or of the frontman when no parent is
+ * named. On an empty network the new agent becomes the frontman itself.
+ *
+ * There is deliberately no way to add a free-floating agent. One that nothing chains
+ * down to gives the network a second root, and neuro-san's response to that is not
+ * to reject the edit but to hand the network to the designer LLM to repair, which
+ * restructures it and discards the edit. Defaulting the parent here rather than in
+ * each caller is what makes that unreachable from any affordance.
+ *
+ * Returns the definition unchanged if the name is already taken, since two agents
+ * with one name would be ambiguous everywhere downstream, or if the named parent
+ * cannot have children.
+ *
+ * @param attributes extra fields for the new entry. Pass `newAgentAttributes(name)`
+ *        for an LLM agent; omit it for a toolbox tool, whose entry has to stay empty
+ *        for the designer to recognise it as one.
+ */
+export const addAgent = (
+  definition: ConnectivityInfo[],
+  name: string,
+  parentName?: string,
+  attributes?: Record<string, unknown>
+): ConnectivityInfo[] => {
+  if (!name || has(definition, name)) return definition;
+  if (parentName && !canHaveChildren(definition, parentName)) return definition;
+
+  const parent = parentName ?? defaultParent(definition);
+  const withParentLink = definition.map((entry) =>
+    parent && entry.origin === parent ? { ...entry, tools: [...toolsOf(entry), name] } : entry
+  );
+  return [...withParentLink, { origin: name, tools: [], ...attributes } as ConnectivityInfo];
+};
+
+/**
+ * Whether `name` may be duplicated.
+ *
+ * The frontman may not. A copy inherits the original's parents, and the frontman has
+ * none, so the copy would be a second root. It is also meaningless: a network has one
+ * entry point.
+ */
+export const canDuplicate = (definition: ConnectivityInfo[], name: string): boolean =>
+  has(definition, name) && !rootsOf(definition).includes(name);
+
+/**
+ * Whether `name` may be deleted.
+ *
+ * The frontman may not. It is the one agent with no parent, so there is nowhere to
+ * promote its children to, and removing it leaves the network with no entry point.
+ * Nothing is lost by refusing: its instructions and description are editable, and
+ * starting a new draft discards the whole network at once.
+ *
+ * A name with no entry of its own is deletable, since that only removes a dangling
+ * reference.
+ */
+export const canDelete = (definition: ConnectivityInfo[], name: string): boolean =>
+  !rootsOf(definition).includes(name);
+
+/**
+ * Make `target` a down-chain of `source`, which is what drawing an edge means.
+ *
+ * This is how a free agent gets wired up after being dropped on empty canvas, so it
+ * has to change the definition rather than just the rendered edges: an edge that
+ * only exists in React Flow state disappears the next time the canvas renders from
+ * the store, and never reaches the network.
+ *
+ * Returns the definition unchanged when the edge would be invalid or is already
+ * there, so callers can skip a pointless round-trip with a `next === definition` check.
+ */
+export const connectAgents = (
+  definition: ConnectivityInfo[],
+  source: string,
+  target: string
+): ConnectivityInfo[] => {
+  // A self-edge is a cycle of one, and neither end may be missing.
+  if (!source || !target || source === target) return definition;
+  if (!has(definition, source) || !canHaveChildren(definition, source)) return definition;
+
+  const parent = definition.find((entry) => entry.origin === source);
+  if (!parent || toolsOf(parent).includes(target)) return definition;
+
+  return definition.map((entry) =>
+    entry.origin === source ? { ...entry, tools: [...toolsOf(entry), target] } : entry
+  );
+};
+
+/**
+ * Stop `target` being a down-chain of `source`, which is what deleting an edge means.
+ *
+ * The target keeps its own entry: removing a connection is not removing an agent, and
+ * the user is expected to reconnect it somewhere else. That does leave the network
+ * temporarily rootless in the designer's eyes if the target had no other parent, so
+ * callers that care should reconnect it before sending.
+ */
+export const disconnectAgents = (
+  definition: ConnectivityInfo[],
+  source: string,
+  target: string
+): ConnectivityInfo[] => {
+  const parent = definition.find((entry) => entry.origin === source);
+  if (!parent || !toolsOf(parent).includes(target)) return definition;
+
+  return definition.map((entry) =>
+    entry.origin === source
+      ? { ...entry, tools: toolsOf(entry).filter((tool) => tool !== target) }
+      : entry
+  );
+};
+
+/**
+ * Move `target` from one parent to another in a single edit.
+ *
+ * Rearranging by deleting a connection and adding a new one would leave the network
+ * momentarily rootless, and the round-trip in between reports "No front man agent
+ * found in network" and hands the network to the designer LLM to repair. Doing both
+ * halves in one edit never puts an invalid definition on the wire.
+ */
+export const reparentAgent = (
+  definition: ConnectivityInfo[],
+  target: string,
+  fromParent: string,
+  toParent: string
+): ConnectivityInfo[] => {
+  if (fromParent === toParent) return definition;
+  const detached = disconnectAgents(definition, fromParent, target);
+  const attached = connectAgents(detached, toParent, target);
+  // Either half refusing means the move is not possible; leave the original alone.
+  return attached === detached ? definition : attached;
+};
+
+/**
+ * Remove an agent, every reference to it, and re-home whatever it was chaining down
+ * to.
+ *
+ * Dropping the references matters as much as dropping the entry: a leftover name in
+ * some other agent's tools would render as a dangling "undefined agent" node.
+ *
+ * The children are promoted to the deleted agent's own parent rather than being left
+ * where they are. Left alone they would have nothing chaining down to them, which
+ * gives the network extra roots and hands it to the designer LLM to repair. Promoting
+ * keeps the sub-tree and keeps the network valid in one edit.
+ *
+ * The frontman cannot be deleted at all: there would be no parent to promote its
+ * children to, and the network would be left with no entry point. See `canDelete`.
+ */
+export const deleteAgent = (definition: ConnectivityInfo[], name: string): ConnectivityInfo[] => {
+  if (!canDelete(definition, name)) return definition;
+
+  const removed = definition.find((entry) => entry.origin === name);
+  if (!removed) {
+    // No entry of its own, so there is nothing to promote: just drop the references.
+    return definition.map((entry) => {
+      const tools = toolsOf(entry);
+      return tools.includes(name) ? { ...entry, tools: tools.filter((tool) => tool !== name) } : entry;
+    });
+  }
+
+  const parent = definition.find((entry) => toolsOf(entry).includes(name))?.origin;
+  const orphans = toolsOf(removed);
+
+  return definition
+    .filter((entry) => entry.origin !== name)
+    .map((entry) => {
+      const tools = toolsOf(entry);
+      if (!tools.includes(name)) return entry;
+
+      // The children take the deleted agent's place in the list rather than being
+      // appended, so the sub-tree stays where the user last saw it. Any child the
+      // parent already had is skipped, since a name may appear only once.
+      const promoted =
+        entry.origin === parent ? orphans.filter((orphan) => !tools.includes(orphan)) : [];
+      const next: string[] = [];
+      for (const tool of tools) {
+        if (tool === name) next.push(...promoted);
+        else next.push(tool);
+      }
+      return { ...entry, tools: next };
+    });
+};
+
+/**
+ * Copy an agent under a new name, attached wherever the original was referenced.
+ *
+ * Reusing the original's parents is what makes the copy appear next to it on the
+ * canvas rather than floating unattached, which is also why the frontman cannot be
+ * duplicated: it has no parents to reuse.
+ */
+export const duplicateAgent = (
+  definition: ConnectivityInfo[],
+  sourceName: string,
+  newName: string
+): ConnectivityInfo[] => {
+  const source = definition.find((entry) => entry.origin === sourceName);
+  if (!source || !newName || has(definition, newName)) return definition;
+  // The copy is attached wherever the original was referenced, so duplicating an
+  // agent with no parents would produce one with no parents.
+  if (!canDuplicate(definition, sourceName)) return definition;
+
+  const withCopyLinked = definition.map((entry) =>
+    toolsOf(entry).includes(sourceName) ? { ...entry, tools: [...toolsOf(entry), newName] } : entry
+  );
+  return [...withCopyLinked, { ...source, origin: newName, tools: toolsOf(source) }];
+};
+
+/**
+ * Rename an agent, following every reference to it.
+ *
+ * The name is the identity: it is the node id on the canvas, the key in the
+ * definition the designer stores, and the string every parent lists in its tools.
+ * Changing only the entry would leave those parents pointing at a name that no
+ * longer exists, which renders as a dangling "undefined agent" and fails validation.
+ *
+ * Refused when the new name is taken, when either name is missing, or when the
+ * agent is an external reference or a toolbox tool — those names resolve to
+ * something outside this network, so renaming them would simply break the link.
+ */
+export const renameAgent = (
+  definition: ConnectivityInfo[],
+  currentName: string,
+  newName: string
+): ConnectivityInfo[] => {
+  if (!currentName || !newName || currentName === newName) return definition;
+  if (!has(definition, currentName) || has(definition, newName)) return definition;
+  if (!canRename(definition, currentName)) return definition;
+
+  return definition.map((entry) => {
+    const tools = toolsOf(entry);
+    const renamedTools = tools.includes(currentName)
+      ? tools.map((tool) => (tool === currentName ? newName : tool))
+      : tools;
+    const origin = entry.origin === currentName ? newName : entry.origin;
+    return origin === entry.origin && renamedTools === tools
+      ? entry
+      : ({ ...entry, origin, tools: renamedTools } as ConnectivityInfo);
+  });
+};
+
+/**
+ * Whether `name` may be renamed.
+ *
+ * Only an LLM agent of this network. A toolbox tool's name IS the tool it resolves
+ * to, and an external reference's name is the network or MCP server it points at, so
+ * renaming either would break the reference rather than relabel anything.
+ */
+export const canRename = (definition: ConnectivityInfo[], name: string): boolean => {
+  if (!name || isExternalName(name)) return false;
+  const entry = definition.find((candidate) => candidate.origin === name);
+  return Boolean(entry) && !isToolboxTool(entry);
+};
+
+/**
+ * Merge a patch into one agent.
+ *
+ * This covers both editing instructions and rewiring down-chains, since an edge
+ * change is just a new `tools` array.
+ */
+export const updateAgent = (
+  definition: ConnectivityInfo[],
+  name: string,
+  patch: Partial<ConnectivityInfo> & Record<string, unknown>
+): ConnectivityInfo[] => {
+  if (!has(definition, name)) return definition;
+  return definition.map((entry) => (entry.origin === name ? { ...entry, ...patch } : entry));
+};

--- a/nsflow/frontend/src/state/editorRoundTrip.test.ts
+++ b/nsflow/frontend/src/state/editorRoundTrip.test.ts
@@ -1,0 +1,244 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEditorNetworkStore } from "./editorNetworkStore";
+import { parseEchoedPayload, sendEditorUpdate } from "./editorRoundTrip";
+
+const NET = "coffee_shop";
+const API = "http://localhost:8005";
+
+/** Frames as a live agent_network_designer actually returns them for an edit. */
+const FRAMES = [
+  { response: { type: "SYSTEM", text: "" } },
+  { response: { type: "AGENT", text: "editing" } },
+  {
+    response: {
+      type: "AGENT_FRAMEWORK",
+      sly_data: {
+        agent_network_definition: [
+          { origin: "coffee_frontman", tools: ["barista"] },
+          { origin: "barista", tools: [] },
+        ],
+      },
+    },
+  },
+];
+
+/** A fetch whose body streams the given lines, like the facade route does. */
+const streamingFetch = (lines: object[]) =>
+  vi.fn(async (_url: string, _init: RequestInit) => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Split across chunks that do not align to line boundaries, so the reader
+        // is forced to buffer partial lines the way a real network does.
+        const text = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+        const mid = Math.floor(text.length / 2);
+        controller.enqueue(encoder.encode(text.slice(0, mid)));
+        controller.enqueue(encoder.encode(text.slice(mid)));
+        controller.close();
+      },
+    });
+    return new Response(body, { status: 200, headers: { "content-type": "application/json-lines" } });
+  });
+
+describe("parseEchoedPayload", () => {
+  it("extracts the definition from a frame that carries one", () => {
+    const payload = parseEchoedPayload(FRAMES[2]);
+    expect(payload?.definition).toEqual([
+      { origin: "coffee_frontman", tools: ["barista"] },
+      { origin: "barista", tools: [] },
+    ]);
+  });
+
+  it("ignores frames with no definition, so a name-only frame cannot clobber state", () => {
+    expect(parseEchoedPayload(FRAMES[0])).toBeUndefined();
+    expect(parseEchoedPayload({ response: { type: "AGENT_FRAMEWORK", sly_data: { agent_network_name: "x" } } }))
+      .toBeUndefined();
+  });
+
+  it("reads the network name and hocon when the frame carries them", () => {
+    const payload = parseEchoedPayload({
+      response: {
+        type: "AGENT_FRAMEWORK",
+        sly_data: {
+          agent_network_definition: [{ origin: "a", tools: [] }],
+          agent_network_name: "coffee_shop",
+          agent_network_hocon_text: 'agent { name = "a" }',
+        },
+      },
+    });
+    expect(payload?.networkName).toBe("coffee_shop");
+    expect(payload?.hocon).toBe('agent { name = "a" }');
+  });
+});
+
+describe("sendEditorUpdate", () => {
+  beforeEach(() => {
+    useEditorNetworkStore.getState().reset(NET);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to nsflow's own streaming_chat route, targeting the designer", async () => {
+    const fetchMock = streamingFetch(FRAMES);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEditorUpdate({
+      apiUrl: API,
+      networkId: NET,
+      agentName: "barista",
+      definition: [{ origin: "coffee_frontman", tools: ["barista"] }],
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    // nsflow's own origin, never a neuro-san server directly
+    expect(url).toBe(`${API}/api/v1/agent_network_designer/streaming_chat`);
+    expect(init.method).toBe("POST");
+
+    const body = JSON.parse(String(init.body));
+    // Sent as the designer's dict shape, not the list shape the store holds. The
+    // designer's list-to-dict converter drops falsy values, so an agent whose
+    // instructions the user cleared would arrive with no instructions key at all and
+    // be reclassified as a toolbox tool.
+    expect(body.sly_data.agent_network_definition).toEqual({
+      coffee_frontman: { tools: ["barista"] },
+    });
+    // deterministic edit: the designer must not re-reason about the whole network
+    expect(body.sly_data.skip_designer).toBe(true);
+  });
+
+  it("reconciles the echoed definition into the store", async () => {
+    vi.stubGlobal("fetch", streamingFetch(FRAMES));
+
+    await sendEditorUpdate({
+      apiUrl: API,
+      networkId: NET,
+      agentName: "barista",
+      definition: [{ origin: "coffee_frontman", tools: [] }],
+    });
+
+    expect(useEditorNetworkStore.getState().entries[NET].definition).toEqual([
+      { origin: "coffee_frontman", tools: ["barista"] },
+      { origin: "barista", tools: [] },
+    ]);
+  });
+
+  it("reassembles frames split across chunk boundaries", async () => {
+    // streamingFetch deliberately splits mid-line; if the reader did not buffer,
+    // the definition-bearing frame would fail to parse and never reach the store.
+    vi.stubGlobal("fetch", streamingFetch(FRAMES));
+    const seen: string[] = [];
+
+    await sendEditorUpdate({
+      apiUrl: API,
+      networkId: NET,
+      agentName: "barista",
+      definition: [],
+      onFrame: (frame) => seen.push(String(frame.type)),
+    });
+
+    expect(seen).toEqual(["SYSTEM", "AGENT", "AGENT_FRAMEWORK"]);
+  });
+
+  it("leaves the store untouched when no frame carries a definition", async () => {
+    vi.stubGlobal("fetch", streamingFetch([FRAMES[0], FRAMES[1]]));
+
+    await sendEditorUpdate({ apiUrl: API, networkId: NET, agentName: "barista", definition: [] });
+
+    expect(useEditorNetworkStore.getState().entries[NET]).toBeUndefined();
+  });
+
+  it("throws on a non-ok response so callers can surface it", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, _init: RequestInit) => new Response("nope", { status: 502 })));
+
+    await expect(
+      sendEditorUpdate({ apiUrl: API, networkId: NET, agentName: "barista", definition: [] })
+    ).rejects.toThrow(/502/);
+  });
+});
+
+describe("network name handling", () => {
+  beforeEach(() => {
+    useEditorNetworkStore.getState().reset(NET);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults the network name to what the store already learned", async () => {
+    // Verified against a live designer: an edit without agent_network_name is
+    // canonicalised but never persisted, so forgetting it fails silently.
+    useEditorNetworkStore.getState().reconcileFromServer(NET, {
+      definition: [{ origin: "coffee_frontman", tools: [] }],
+      networkName: "coffee_shop_canonical",
+    });
+
+    const fetchMock = streamingFetch(FRAMES);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEditorUpdate({ apiUrl: API, networkId: NET, agentName: "barista", definition: [] });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body.sly_data.agent_network_name).toBe("coffee_shop_canonical");
+  });
+
+  it("lets an explicit name override the stored one, for renames", async () => {
+    useEditorNetworkStore.getState().reconcileFromServer(NET, {
+      definition: [{ origin: "a", tools: [] }],
+      networkName: "old_name",
+    });
+
+    const fetchMock = streamingFetch(FRAMES);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEditorUpdate({
+      apiUrl: API, networkId: NET, agentName: "a", definition: [], networkName: "new_name",
+    });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1].body)).sly_data.agent_network_name).toBe("new_name");
+  });
+
+  it("throws on an empty stream, which is how a mid-stream failure shows up", async () => {
+    // A streaming response commits its 200 before the first chunk, so the backend
+    // cannot report a later failure except by ending the stream. Treating that as
+    // success would leave the optimistic apply looking saved when nothing was.
+    vi.stubGlobal("fetch", streamingFetch([]));
+
+    await expect(
+      sendEditorUpdate({ apiUrl: API, networkId: NET, agentName: "a", definition: [] })
+    ).rejects.toThrow(/empty stream/);
+  });
+
+  it("says what the edit was, so the transcript is not all agent updates", async () => {
+    // Naming a network is not an agent edit, and the message is what shows up in the
+    // chat panel and the designer's logs.
+    const fetchMock = streamingFetch(FRAMES);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEditorUpdate({
+      apiUrl: API, networkId: NET, agentName: "a", definition: [], message: 'Name this agent network "x"',
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body.user_message.text).toBe('Name this agent network "x"');
+  });
+});

--- a/nsflow/frontend/src/state/editorRoundTrip.ts
+++ b/nsflow/frontend/src/state/editorRoundTrip.ts
@@ -1,0 +1,194 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Sends a manual edit to the agent network designer and folds the echoed,
+ * canonical definition back into the store.
+ *
+ * This goes through nsflow's own backend, never to a neuro-san server directly:
+ * nsflow is the single ingress, and its neuro-san-shaped
+ * `/api/v1/{agent}/streaming_chat` route performs the sly_data merge and MCP token
+ * injection that a direct call would bypass.
+ *
+ * It deliberately does NOT use the chat WebSocket. That socket is the chat
+ * transcript, so an edit sent over it would appear as a synthetic chat turn in the
+ * chat panel, and editing would stop working whenever the panel is unmounted. The
+ * HTTP route is stateless and independent of the chat session, and the designer's
+ * progress frames arrive inline on the same stream.
+ */
+
+import {
+  AGENT_NETWORK_DEFINITION_KEY,
+  AGENT_NETWORK_DESIGNER_ID,
+  AGENT_NETWORK_HOCON,
+  AGENT_NETWORK_NAME_KEY,
+  type ChatMessage,
+  type ConnectivityInfo,
+} from "../uiCommon";
+import { listToDict, toConnectivityList } from "./definitionShape";
+import { type ServerNetworkPayload, useEditorNetworkStore } from "./editorNetworkStore";
+
+/** One line of the stream: neuro-san wraps each chat message under `response`. */
+type StreamFrame = { response?: ChatMessage & { sly_data?: Record<string, unknown> } };
+
+/**
+ * Read one streamed frame.
+ *
+ * Returns undefined unless the frame actually carries a definition: a frame with
+ * only a name must never reach the store, because the definition and name have to
+ * stay atomic. The backend persists the definition under `agent_network_name`, so
+ * pairing a fresh definition with a stale name can overwrite a different network.
+ *
+ * The echoed definition arrives in the designer's DICT shape, not the list shape we
+ * send, so it is normalised here. Requiring a list meant the canonical echo was
+ * silently discarded and the store kept whatever the optimistic apply had left.
+ */
+export const parseEchoedPayload = (frame: unknown): ServerNetworkPayload | undefined => {
+  const slyData = (frame as StreamFrame)?.response?.sly_data;
+  if (!slyData) return undefined;
+
+  const definition = toConnectivityList(slyData[AGENT_NETWORK_DEFINITION_KEY]);
+  if (!definition) return undefined;
+
+  return {
+    definition,
+    networkName: slyData[AGENT_NETWORK_NAME_KEY] as string | undefined,
+    hocon: slyData[AGENT_NETWORK_HOCON] as string | undefined,
+  };
+};
+
+/**
+ * Handle one line of the stream: report it for progress, and reconcile it into the
+ * store if it carries a definition.
+ */
+const handleFrameLine = (
+  line: string,
+  networkId: string,
+  onFrame?: (frame: ChatMessage) => void
+): void => {
+  if (!line.trim()) return;
+  let frame: unknown;
+  try {
+    frame = JSON.parse(line);
+  } catch {
+    // A partial or malformed line is not worth failing the whole edit over.
+    return;
+  }
+  const message = (frame as StreamFrame)?.response;
+  if (message && onFrame) onFrame(message);
+
+  const payload = parseEchoedPayload(frame);
+  if (payload) useEditorNetworkStore.getState().reconcileFromServer(networkId, payload);
+};
+
+export type SendEditorUpdateArgs = {
+  /** nsflow's own API origin. */
+  readonly apiUrl: string;
+  /** Store key for the network being edited. */
+  readonly networkId: string;
+  /** The agent whose change prompted this edit, named in the message text. */
+  readonly agentName: string;
+  /** The edited definition, in canonical connectivity-list form. */
+  readonly definition: ConnectivityInfo[];
+  /**
+   * The backend's canonical network name. Defaults to whatever the store holds for
+   * this network, which is almost always what you want: verified against a live
+   * designer, an edit sent WITHOUT a name is canonicalised but never persisted (the
+   * echo carries no `agent_network_hocon_text` and no name), while an edit sent
+   * WITH one is assembled and saved under it. Passing it explicitly is only for
+   * renames.
+   */
+  readonly networkName?: string;
+  /**
+   * What the edit is, for the chat transcript and the designer's logs. Defaults to
+   * naming the agent, which is what most edits are; a whole-network change like
+   * naming the network says so instead.
+   */
+  readonly message?: string;
+  readonly signal?: AbortSignal;
+  /** Called per streamed frame, for progress feedback while an edit applies. */
+  readonly onFrame?: (frame: ChatMessage) => void;
+};
+
+export const sendEditorUpdate = async ({
+  apiUrl,
+  networkId,
+  agentName,
+  definition,
+  networkName,
+  message,
+  signal,
+  onFrame,
+}: SendEditorUpdateArgs): Promise<void> => {
+  const store = useEditorNetworkStore.getState();
+  // Fall back to the name the store already learned from a previous echo, so an
+  // edit cannot silently stop persisting just because a caller omitted it.
+  const targetName = networkName ?? store.entries[networkId]?.networkName;
+
+  const response = await fetch(`${apiUrl}/api/v1/${AGENT_NETWORK_DESIGNER_ID}/streaming_chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    signal,
+    body: JSON.stringify({
+      // The API wants a user message even for a deterministic edit.
+      user_message: { text: message ?? `Update instructions for agent "${agentName}"` },
+      chat_filter: { chat_filter_type: "MAXIMAL" },
+      sly_data: {
+        // Sent as the designer's dict shape; see definitionShape for why the list
+        // shape silently reclassifies an agent with empty instructions as a tool.
+        [AGENT_NETWORK_DEFINITION_KEY]: listToDict(definition),
+        ...(targetName ? { [AGENT_NETWORK_NAME_KEY]: targetName } : {}),
+        // Apply the edit as given instead of having the designer reason about the
+        // whole network again.
+        skip_designer: true,
+      },
+    }),
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Editor update failed: ${response.status} ${response.statusText}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  // Chunks do not arrive aligned to line boundaries, so hold the tail until a
+  // newline completes it.
+  let buffered = "";
+  let frames = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffered += decoder.decode(value, { stream: true });
+    const lines = buffered.split("\n");
+    buffered = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) frames += 1;
+      handleFrameLine(line, networkId, onFrame);
+    }
+  }
+  if (buffered.trim()) frames += 1;
+  handleFrameLine(buffered, networkId, onFrame);
+
+  // A streaming response commits its 200 before the first chunk, so a failure
+  // partway through cannot change the status: the backend logs it and the stream
+  // simply ends. An empty stream is therefore the only signal that the edit never
+  // reached the designer, and treating it as success would leave the optimistic
+  // apply on the canvas looking saved when nothing was.
+  if (frames === 0) {
+    throw new Error("Editor update failed: the designer returned an empty stream");
+  }
+};

--- a/nsflow/frontend/src/state/editorSession.test.ts
+++ b/nsflow/frontend/src/state/editorSession.test.ts
@@ -1,0 +1,79 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useEditorNetworkStore } from "./editorNetworkStore";
+import { draftKeyFor, isDraftKey, useEditorDraftSession } from "./editorSession";
+
+const SESSION_KEY = "nsflow.editorDraftSession";
+
+describe("useEditorDraftSession", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("continues the session across a reload", () => {
+    // A reload remounts the hook with sessionStorage intact, which is the only
+    // reliable signal a browser gives: the same draft has to come back.
+    const first = renderHook(() => useEditorDraftSession());
+    const key = first.result.current.draftKey;
+    // Simulate the page going away rather than a route change.
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+    first.unmount();
+
+    const second = renderHook(() => useEditorDraftSession());
+    expect(second.result.current.draftKey).toBe(key);
+  });
+
+  it("starts a new session when the Editor is left and re-entered", () => {
+    // Unmounting without the page unloading is a route change, so the next visit to
+    // the Editor must be a clean canvas rather than reopening the old draft.
+    const first = renderHook(() => useEditorDraftSession());
+    const key = first.result.current.draftKey;
+    first.unmount();
+
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+    const second = renderHook(() => useEditorDraftSession());
+    expect(second.result.current.draftKey).not.toBe(key);
+  });
+
+  it("hands out a fresh draft on request", () => {
+    const { result } = renderHook(() => useEditorDraftSession());
+    const before = result.current.draftKey;
+
+    act(() => result.current.startNewSession());
+
+    expect(result.current.draftKey).not.toBe(before);
+    expect(isDraftKey(result.current.draftKey)).toBe(true);
+  });
+
+  it("forgets drafts from other sessions, so IndexedDB does not grow forever", () => {
+    const stale = draftKeyFor("stale_session");
+    useEditorNetworkStore.getState().applyEdit(stale, [{ origin: "frontman", tools: [] }]);
+    useEditorNetworkStore.getState().applyEdit("coffee_shop", [{ origin: "frontman", tools: [] }]);
+
+    renderHook(() => useEditorDraftSession());
+
+    const entries = useEditorNetworkStore.getState().entries;
+    expect(entries[stale]).toBeUndefined();
+    // A real network is not a draft and must survive.
+    expect(entries.coffee_shop).toBeDefined();
+  });
+});

--- a/nsflow/frontend/src/state/editorSession.ts
+++ b/nsflow/frontend/src/state/editorSession.ts
@@ -1,0 +1,124 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Scopes an unnamed draft network to one editing session.
+ *
+ * The editor store is persisted to IndexedDB so that work survives a reload. Without
+ * a session boundary that persistence is indefinite, and every later visit to the
+ * Editor reopens the agents from whenever the user last drew something, which is not
+ * what "open the Editor" is expected to mean.
+ *
+ * What a session is, and why:
+ *
+ *   - Reloading the Editor CONTINUES the session. The id lives in `sessionStorage`,
+ *     which survives a reload and dies with the tab.
+ *   - Navigating away from the Editor and back STARTS a new one. Leaving is treated
+ *     as ending the session, so arriving is always a clean canvas.
+ *   - A new tab starts a new one, since `sessionStorage` is per tab.
+ *
+ * A hard reload is deliberately NOT distinguished from an ordinary one: browsers
+ * report both as navigation type "reload" and expose nothing else to tell them
+ * apart, so any rule claiming to separate them would be guessing. `startNewSession`
+ * is the explicit way to get a clean canvas without leaving the page.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useEditorNetworkStore } from "./editorNetworkStore";
+
+/** Where the current session's id is kept. Per tab, cleared when the tab closes. */
+const SESSION_STORAGE_KEY = "nsflow.editorDraftSession";
+
+/**
+ * Prefix for a draft's store key.
+ *
+ * The leading underscores keep it clear of a real network name, which comes from a
+ * registry and never starts with one.
+ */
+export const DRAFT_KEY_PREFIX = "__draft_";
+
+export const draftKeyFor = (sessionId: string): string => `${DRAFT_KEY_PREFIX}${sessionId}__`;
+
+export const isDraftKey = (networkId: string): boolean => networkId.startsWith(DRAFT_KEY_PREFIX);
+
+const newSessionId = (): string =>
+  `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+
+/**
+ * Forget drafts from earlier sessions.
+ *
+ * Each session gets its own store key, so without this every visit would leave
+ * another abandoned draft in IndexedDB forever. A draft that was named is already
+ * saved server-side and shows up in the sidebar, so nothing is lost by dropping it
+ * from the local store.
+ */
+const dropOtherDrafts = (keepKey: string): void => {
+  const store = useEditorNetworkStore.getState();
+  for (const key of Object.keys(store.entries)) {
+    if (isDraftKey(key) && key !== keepKey) store.reset(key);
+  }
+};
+
+/**
+ * The store key for this session's unnamed draft, plus a way to start over.
+ *
+ * @return the draft key, and `startNewSession` which abandons the current draft and
+ *         returns a clean one.
+ */
+export const useEditorDraftSession = (): { draftKey: string; startNewSession: () => void } => {
+  const [sessionId, setSessionId] = useState<string>(() => {
+    const existing = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (existing) return existing;
+    const created = newSessionId();
+    sessionStorage.setItem(SESSION_STORAGE_KEY, created);
+    return created;
+  });
+
+  // Distinguishes the page going away from a route change inside the app. On unload
+  // the session must be kept so a reload continues it; on a route change it must be
+  // dropped so coming back is a new session.
+  const isUnloadingRef = useRef(false);
+
+  useEffect(() => {
+    const markUnloading = () => {
+      isUnloadingRef.current = true;
+    };
+    // pagehide rather than beforeunload: it also fires when a page enters the back/
+    // forward cache, which beforeunload does not reliably do.
+    window.addEventListener("pagehide", markUnloading);
+    return () => {
+      window.removeEventListener("pagehide", markUnloading);
+      if (!isUnloadingRef.current) sessionStorage.removeItem(SESSION_STORAGE_KEY);
+    };
+  }, []);
+
+  const draftKey = draftKeyFor(sessionId);
+
+  // Runs on mount and whenever the session changes, so an abandoned draft never
+  // outlives the session that made it.
+  useEffect(() => {
+    dropOtherDrafts(draftKey);
+  }, [draftKey]);
+
+  const startNewSession = useCallback(() => {
+    const created = newSessionId();
+    sessionStorage.setItem(SESSION_STORAGE_KEY, created);
+    setSessionId(created);
+  }, []);
+
+  return { draftKey, startNewSession };
+};

--- a/nsflow/frontend/src/state/paletteSources.test.ts
+++ b/nsflow/frontend/src/state/paletteSources.test.ts
@@ -1,0 +1,169 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  asExternalAgentName,
+  fetchPaletteItems,
+  mcpServerLabel,
+  rankPaletteItems,
+  sanitizeNetworkName,
+  type PaletteItem,
+} from "./paletteSources";
+
+const item = (label: string, description?: string): PaletteItem =>
+  ({ category: "Toolbox", label, agentName: label, description }) as PaletteItem;
+
+describe("rankPaletteItems", () => {
+  it("ranks a name match above a description match", () => {
+    const ranked = rankPaletteItems(
+      [item("web_fetch", "Reads a page"), item("ddgs_search", "Searches the web")],
+      "web"
+    );
+    expect(ranked.map((entry) => entry.label)).toEqual(["web_fetch", "ddgs_search"]);
+  });
+
+  it("keeps everything, in the given order, when there is no query", () => {
+    const items = [item("b"), item("a")];
+    expect(rankPaletteItems(items, "  ")).toBe(items);
+  });
+
+  it("drops items that match nothing", () => {
+    expect(rankPaletteItems([item("web_fetch", "Reads a page")], "wikimedia")).toEqual([]);
+  });
+});
+
+describe("sanitizeNetworkName", () => {
+  it("turns what a user types into a name neuro-san accepts", () => {
+    // neuro-san validates names against ^[a-zA-Z0-9_-]+$, so these would be rejected
+    // outright. Correcting is friendlier than refusing, and unambiguous.
+    expect(sanitizeNetworkName("Car Wash Customer Care")).toBe("car_wash_customer_care");
+    expect(sanitizeNetworkName("  Retail Ops!  ")).toBe("retail_ops");
+    expect(sanitizeNetworkName("my.network.v2")).toBe("my_network_v2");
+  });
+
+  it("leaves an already-valid name alone", () => {
+    expect(sanitizeNetworkName("car_wash")).toBe("car_wash");
+    expect(sanitizeNetworkName("retail-ops-2")).toBe("retail-ops-2");
+  });
+
+  it("returns empty when there is nothing usable, so the caller can refuse it", () => {
+    expect(sanitizeNetworkName("   ")).toBe("");
+    expect(sanitizeNetworkName("!!!")).toBe("");
+  });
+});
+
+describe("asExternalAgentName", () => {
+  it("marks another network as a reference out to it", () => {
+    // The leading slash is what keeps the referenced network out of this network's
+    // own definitions, so it stays a reference rather than becoming a copy.
+    expect(asExternalAgentName("coffee_shop")).toBe("/coffee_shop");
+    expect(asExternalAgentName("/coffee_shop")).toBe("/coffee_shop");
+  });
+});
+
+describe("mcpServerLabel", () => {
+  it("shortens a server URL, keeping what distinguishes it", () => {
+    expect(mcpServerLabel("https://mcp.deepwiki.com/mcp")).toBe("mcp.deepwiki.com");
+    expect(mcpServerLabel("https://example.com/server/mcp/free")).toBe("example.com/free");
+    // Not a URL at all: showing the raw string beats showing nothing.
+    expect(mcpServerLabel("not a url")).toBe("not a url");
+  });
+});
+
+describe("fetchPaletteItems", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** Serve each palette source from `bodies`, or fail it when absent. */
+  const stubFetch = (bodies: Record<string, unknown>) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        const match = Object.keys(bodies).find((key) => url.includes(key));
+        if (!match) return { ok: false, json: async () => ({}) };
+        return { ok: true, json: async () => bodies[match] };
+      })
+    );
+  };
+
+  it("offers networks, tools and MCP servers by the names neuro-san resolves", async () => {
+    stubFetch({
+      "/designer/references": {
+        networks: ["/coffee_shop"],
+        mcp_servers: ["https://mcp.deepwiki.com/mcp"],
+      },
+      "/toolbox": { tools: [{ name: "ddgs_search", description: "Search", display_as: "coded_tool" }] },
+      "/list": { agents: [{ agent_name: "coffee_shop", description: "Coffee" }] },
+    });
+
+    const items = await fetchPaletteItems("http://api");
+
+    expect(items.map((entry) => [entry.category, entry.agentName])).toEqual([
+      ["Agent Networks", "/coffee_shop"],
+      ["Toolbox", "ddgs_search"],
+      // An MCP server is referenced by its URL, so the URL is the name.
+      ["MCP Servers", "https://mcp.deepwiki.com/mcp"],
+    ]);
+    // The description comes from /api/v1/list, which decorates but does not decide.
+    expect(items[0].description).toBe("Coffee");
+  });
+
+  it("offers only what the designer recognises, not everything the server hosts", async () => {
+    // The whole point of the designer reference set. A network the server serves but
+    // the designer does not know fails validation with "references an unrecognized
+    // URL or path tool", and the designer answers that by rewriting the network with
+    // its LLM, so every later edit breaks until the reference is removed.
+    stubFetch({
+      "/designer/references": { networks: ["/industry/banking_ops"] },
+      "/list": {
+        agents: [{ agent_name: "industry/banking_ops" }, { agent_name: "basic/coffee_finder" }],
+      },
+    });
+
+    const items = await fetchPaletteItems("http://api");
+
+    expect(items.map((entry) => entry.agentName)).toEqual(["/industry/banking_ops"]);
+  });
+
+  it("flags an MCP server whose stored token has expired", async () => {
+    stubFetch({
+      "/designer/references": { mcp_servers: ["https://mcp.deepwiki.com/mcp"] },
+      "/mcp/oauth/connections": {
+        connections: [{ server_url: "https://mcp.deepwiki.com/mcp", needs_reauth: true }],
+      },
+    });
+
+    expect((await fetchPaletteItems("http://api"))[0].needsReauth).toBe(true);
+  });
+
+  it("leaves out the network being edited, which cannot be its own child", async () => {
+    stubFetch({ "/designer/references": { networks: ["/coffee_shop", "/other"] } });
+
+    const items = await fetchPaletteItems("http://api", "coffee_shop");
+
+    expect(items.map((entry) => entry.label)).toEqual(["other"]);
+  });
+
+  it("skips a source that fails rather than emptying the palette", async () => {
+    // An unreachable reference set should not hide the toolbox.
+    stubFetch({ "/toolbox": { tools: [{ name: "ddgs_search" }] } });
+
+    const items = await fetchPaletteItems("http://api");
+
+    expect(items.map((entry) => entry.label)).toEqual(["ddgs_search"]);
+  });
+});

--- a/nsflow/frontend/src/state/paletteSources.ts
+++ b/nsflow/frontend/src/state/paletteSources.ts
@@ -1,0 +1,302 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * The things a user can drag onto the editor canvas, and how each becomes an entry
+ * in the agent network definition.
+ *
+ * A blank agent, plus three sources each already served by nsflow:
+ *   - agent networks   GET /api/v1/list
+ *   - toolbox tools    GET /api/v1/toolbox
+ *   - MCP servers      GET /api/v1/mcp/oauth/connections
+ *
+ * There are deliberately no starter templates. A user draws whatever shape they
+ * want by adding a frontman and dragging the rest in, so the editor never has to
+ * guess at a shape or keep a set of canned ones in step with anything.
+ */
+
+export const BUILDING_BLOCKS = "Building Blocks";
+
+export type PaletteCategory =
+  | typeof BUILDING_BLOCKS
+  | "Agent Networks"
+  | "Toolbox"
+  | "MCP Servers";
+
+/** Fixed order, so sections do not reshuffle as search results come and go. */
+export const CATEGORY_ORDER: PaletteCategory[] = [
+  BUILDING_BLOCKS,
+  "Agent Networks",
+  "Toolbox",
+  "MCP Servers",
+];
+
+export type PaletteItem = {
+  readonly category: PaletteCategory;
+  /** The name shown in the palette. */
+  readonly label: string;
+  /** The name this is referenced by in a definition, which is also the node id. */
+  readonly agentName: string;
+  /** Shown in the palette only. Deliberately never written into a definition. */
+  readonly description?: string;
+  /** neuro-san's own label for the kind of tool, shown as a chip on the row. */
+  readonly displayAs?: string;
+  /** Set on an MCP connection whose token has expired, so the palette can say so. */
+  readonly needsReauth?: boolean;
+  /**
+   * Whether the dropped name may be adjusted to avoid a collision.
+   *
+   * A blank agent is anonymous, so a second one becomes `agent_2`. Everything else
+   * names a specific thing the server resolves, so a duplicate drop has to be a
+   * no-op instead of silently creating `ddgs_search_2`, which resolves to nothing.
+   */
+  readonly uniquifyName?: boolean;
+  /**
+   * Whether this becomes an LLM agent, as opposed to a tool or an external
+   * reference. An agent's entry needs instructions and a description; a tool's entry
+   * must have neither, since that absence is what marks it as a tool.
+   */
+  readonly isLlmAgent?: boolean;
+};
+
+/** What travels in the drag payload. Mirrors Flowise's application/reactflow key. */
+export const PALETTE_DRAG_TYPE = "application/reactflow";
+
+/**
+ * The network's entry point, offered only while the canvas is blank.
+ *
+ * The frontman is the one agent with no parent, so it is also the one thing that
+ * cannot be added by dropping it onto something. It disappears from the palette once
+ * a definition exists, because a network has exactly one.
+ */
+export const FRONTMAN_ITEM: PaletteItem = {
+  category: BUILDING_BLOCKS,
+  label: "Frontman",
+  agentName: "frontman",
+  description: "The agent the network talks to. Every network starts with one.",
+  isLlmAgent: true,
+};
+
+/** A blank agent, so a network can be built up by dragging as well as by chat. */
+export const NEW_AGENT_ITEM: PaletteItem = {
+  category: BUILDING_BLOCKS,
+  label: "Agent",
+  agentName: "agent",
+  description: "An LLM agent. Drop it on another agent to attach it as a down-chain.",
+  uniquifyName: true,
+  isLlmAgent: true,
+};
+
+/**
+ * Turn what a user typed into a name neuro-san will accept.
+ *
+ * Names become HOCON filenames and URL path segments, and neuro-san validates them
+ * against `^[a-zA-Z0-9_-]+$`, so "Car Wash Customer Care" would be rejected. Rather
+ * than refuse it, this is what the user obviously meant: lower_snake_case.
+ *
+ * Applied on save rather than while typing, so the field does not fight the user
+ * mid-word.
+ */
+export const sanitizeNetworkName = (proposed: string): string =>
+  proposed
+    .trim()
+    .toLowerCase()
+    // Anything that is not a name character becomes a separator, so spaces, dots and
+    // punctuation all collapse the same way.
+    .replace(/[^a-z0-9_-]+/g, "_")
+    // Collapse runs and trim the separators a collapse can leave at either end.
+    .replace(/_{2,}/g, "_")
+    .replace(/^[_-]+|[_-]+$/g, "");
+
+/**
+ * An agent network dropped onto a different network is a reference OUT to it, not a
+ * copy of it. neuro-san spells such a reference with a leading slash, so this is the
+ * convention rather than an invention: a live designer network lists
+ * "/agent_network_editor" exactly this way.
+ */
+export const asExternalAgentName = (networkName: string): string =>
+  networkName.startsWith("/") ? networkName : `/${networkName}`;
+
+/**
+ * What a dropped item becomes, and why `isLlmAgent` decides it.
+ *
+ * The designer tells the kinds apart by name and by which keys an entry carries,
+ * never by any marker the editor could set:
+ *
+ *  - An external network ("/name") or an MCP server ("https://...") is omitted from
+ *    the definitions and lives only as a name in its parent's tools, which is what
+ *    makes it an external reference.
+ *  - A toolbox tool must arrive with NO instructions and NO description. That absence
+ *    is the only thing marking it as a tool, so its palette description must never be
+ *    written into the entry, however tempting.
+ *  - An LLM agent must arrive WITH both, and non-empty, or it is classified as a tool
+ *    or sent to the instructions writer. `newAgentAttributes` supplies them.
+ */
+
+/**
+ * Rank items against a query.
+ *
+ * Deliberately simple: a name match beats a description match, and an earlier match
+ * beats a later one. Enough to make a long toolbox list usable without pulling in a
+ * fuzzy-search dependency.
+ */
+export const rankPaletteItems = (items: PaletteItem[], query: string): PaletteItem[] => {
+  const q = query.trim().toLowerCase();
+  if (!q) return items;
+
+  const scored = items
+    .map((item) => {
+      const label = item.label.toLowerCase();
+      const description = (item.description ?? "").toLowerCase();
+      const inLabel = label.indexOf(q);
+      const inDescription = description.indexOf(q);
+
+      let score = -1;
+      if (label === q) score = 1000;
+      else if (inLabel === 0) score = 500 - label.length;
+      else if (inLabel > 0) score = 200 - inLabel;
+      else if (inDescription >= 0) score = 50 - Math.min(inDescription, 49);
+
+      return { item, score };
+    })
+    .filter((entry) => entry.score >= 0);
+
+  scored.sort((a, b) => b.score - a.score || a.item.label.localeCompare(b.item.label));
+  return scored.map((entry) => entry.item);
+};
+
+/** Group ranked items for display, preserving rank inside each category. */
+export const groupByCategory = (items: PaletteItem[]): Map<PaletteCategory, PaletteItem[]> => {
+  const grouped = new Map<PaletteCategory, PaletteItem[]>();
+  for (const item of items) {
+    const bucket = grouped.get(item.category);
+    if (bucket) bucket.push(item);
+    else grouped.set(item.category, [item]);
+  }
+  return grouped;
+};
+
+type ListResponse = { agents?: Array<{ agent_name?: string; description?: string }> };
+type ToolboxResponse = { tools?: Array<{ name?: string; description?: string; display_as?: string }> };
+type McpConnectionsResponse = { connections?: Array<{ server_url?: string; needs_reauth?: boolean }> };
+type ReferencesResponse = { networks?: string[]; mcp_servers?: string[] };
+
+/**
+ * A short label for an MCP server, since the full URL is too long for a palette row.
+ *
+ * The host alone is ambiguous when one host serves several MCP endpoints
+ * ("example.com/mcp/a" and "example.com/mcp/b"), so the last meaningful path segment
+ * is kept when there is one.
+ */
+export const mcpServerLabel = (serverUrl: string): string => {
+  try {
+    const url = new URL(serverUrl);
+    const segments = url.pathname.split("/").filter((segment) => segment && segment !== "mcp");
+    const tail = segments[segments.length - 1];
+    return tail ? `${url.host}/${tail}` : url.host;
+  } catch {
+    // Not a parseable URL; the raw string is still the most useful thing to show.
+    return serverUrl;
+  }
+};
+
+const getJson = async <T,>(url: string): Promise<T | undefined> => {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return undefined;
+    return (await response.json()) as T;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Load everything the palette can offer.
+ *
+ * What may be OFFERED comes from the designer's own reference set, not from
+ * everything the server hosts. The two are different, and the difference is not
+ * cosmetic: referencing a network the designer does not recognise fails validation
+ * with "references an unrecognized URL or path tool", and the designer's answer to a
+ * failed validation is to invoke its LLM and restructure the network. One such
+ * reference therefore breaks every later edit until it is removed. /api/v1/list and
+ * the OAuth connection store are still read, but only to decorate the rows.
+ *
+ * A source that fails is skipped rather than failing the whole palette: an MCP
+ * server store being unreachable should not hide the toolbox.
+ */
+export const fetchPaletteItems = async (apiUrl: string, currentNetwork?: string): Promise<PaletteItem[]> => {
+  const [references, toolbox, list, connections] = await Promise.all([
+    getJson<ReferencesResponse>(`${apiUrl}/api/v1/designer/references`),
+    getJson<ToolboxResponse>(`${apiUrl}/api/v1/toolbox`),
+    getJson<ListResponse>(`${apiUrl}/api/v1/list`),
+    getJson<McpConnectionsResponse>(`${apiUrl}/api/v1/mcp/oauth/connections`),
+  ]);
+
+  // Descriptions are worth showing but are not what decides the offer, so a missing
+  // list simply means rows without a subtitle.
+  const describedBy = new Map<string, string>();
+  for (const agent of list?.agents ?? []) {
+    if (agent.agent_name && agent.description) describedBy.set(agent.agent_name, agent.description);
+  }
+
+  // An MCP server can be offered by the designer while its stored token has expired.
+  // That is worth flagging on the row, but it does not change what may be referenced.
+  const needsReauth = new Set<string>();
+  for (const connection of connections?.connections ?? []) {
+    if (connection.server_url && connection.needs_reauth) needsReauth.add(connection.server_url);
+  }
+
+  const items: PaletteItem[] = [];
+
+  for (const networkName of references?.networks ?? []) {
+    // Already in "/<name>" form; asExternalAgentName leaves it alone.
+    const agentName = asExternalAgentName(networkName);
+    const label = agentName.replace(/^\//, "");
+    // Referencing the network being edited would make it its own child.
+    if (!label || label === currentNetwork) continue;
+    items.push({
+      category: "Agent Networks",
+      label,
+      agentName,
+      description: describedBy.get(label),
+    });
+  }
+
+  for (const tool of toolbox?.tools ?? []) {
+    if (!tool.name) continue;
+    items.push({
+      category: "Toolbox",
+      label: tool.name,
+      agentName: tool.name,
+      description: tool.description,
+      displayAs: tool.display_as ?? "coded_tool",
+    });
+  }
+
+  for (const serverUrl of references?.mcp_servers ?? []) {
+    if (!serverUrl) continue;
+    items.push({
+      category: "MCP Servers",
+      label: mcpServerLabel(serverUrl),
+      // neuro-san references an MCP server by its URL, so the URL is the name.
+      agentName: serverUrl,
+      description: serverUrl,
+      needsReauth: needsReauth.has(serverUrl),
+    });
+  }
+
+  return items;
+};

--- a/nsflow/frontend/src/state/progressBridge.test.ts
+++ b/nsflow/frontend/src/state/progressBridge.test.ts
@@ -1,0 +1,164 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEditorNetworkStore } from "./editorNetworkStore";
+import { applyFramesToStore, definitionFromFrames, useEditorProgressBridge } from "./progressBridge";
+
+/** What the mocked ChatContext returns; each test sets this before rendering. */
+const chatContext: Record<string, unknown> = {};
+
+vi.mock("../context/ChatContext", () => ({
+  useChatContext: () => chatContext,
+}));
+
+const NET = "coffee_shop";
+
+/** Frames arrive as ChatContext Messages, whose `text` may be a string or object. */
+const frame = (payload: unknown) => ({ text: JSON.stringify(payload) });
+
+describe("definitionFromFrames", () => {
+  it("normalises the dict dialect the internal progress style emits", () => {
+    // AGENT_NETWORK_DESIGNER_PROGRESS_STYLE defaults to "internal", which reports
+    // the definition as a dict keyed by agent name rather than a connectivity list.
+    const progress = frame({
+      agent_network_definition: {
+        frontman: { instructions: "Greet", description: "Front", tools: ["barista"] },
+      },
+      agent_network_name: "coffee_shop",
+    });
+    expect(definitionFromFrames(progress, undefined, true)).toEqual([
+      { origin: "frontman", tools: ["barista"], instructions: "Greet", description: "Front" },
+    ]);
+  });
+
+  it("accepts down_chains as an alias for tools in the dict dialect", () => {
+    const progress = frame({ agent_network_definition: { frontman: { down_chains: ["barista"] } } });
+    expect(definitionFromFrames(progress, undefined, true)).toEqual([
+      { origin: "frontman", tools: ["barista"] },
+    ]);
+  });
+
+  it("passes the connectivity list dialect through unchanged", () => {
+    const progress = frame({
+      connectivity_info: [{ origin: "frontman", tools: ["barista"] }],
+      agent_network_name: "coffee_shop",
+    });
+    expect(definitionFromFrames(progress, undefined, true)).toEqual([
+      { origin: "frontman", tools: ["barista"] },
+    ]);
+  });
+
+  it("prefers whichever stream is fresher", () => {
+    const progress = frame({ connectivity_info: [{ origin: "from_progress", tools: [] }] });
+    const slyData = frame({ connectivity_info: [{ origin: "from_slydata", tools: [] }] });
+
+    expect(definitionFromFrames(progress, slyData, true)).toEqual([{ origin: "from_progress", tools: [] }]);
+    expect(definitionFromFrames(progress, slyData, false)).toEqual([{ origin: "from_slydata", tools: [] }]);
+  });
+
+  it("falls back to the other stream when the preferred frame carries no definition", () => {
+    const nameOnly = frame({ agent_network_name: "coffee_shop" });
+    const withDefinition = frame({ connectivity_info: [{ origin: "frontman", tools: [] }] });
+    expect(definitionFromFrames(nameOnly, withDefinition, true)).toEqual([{ origin: "frontman", tools: [] }]);
+  });
+
+  it("returns undefined when neither stream carries a definition", () => {
+    expect(definitionFromFrames(undefined, undefined, true)).toBeUndefined();
+    expect(definitionFromFrames(frame({ agent_network_name: "x" }), undefined, true)).toBeUndefined();
+  });
+});
+
+describe("applyFramesToStore", () => {
+  beforeEach(() => {
+    useEditorNetworkStore.getState().reset(NET);
+  });
+
+  it("reconciles a definition-carrying frame without creating an undo step", () => {
+    useEditorNetworkStore.getState().applyEdit(NET, [{ origin: "frontman", tools: [] }]);
+    const before = useEditorNetworkStore.getState().entries[NET].history.length;
+
+    applyFramesToStore(
+      NET,
+      frame({ connectivity_info: [{ origin: "frontman", tools: ["barista"] }], agent_network_name: "coffee_shop" }),
+      undefined,
+      true
+    );
+
+    const entry = useEditorNetworkStore.getState().entries[NET];
+    expect(entry.definition).toEqual([{ origin: "frontman", tools: ["barista"] }]);
+    expect(entry.history).toHaveLength(before);
+    expect(entry.networkName).toBe("coffee_shop");
+  });
+
+  it("does nothing when no definition is present", () => {
+    applyFramesToStore(NET, frame({ agent_network_name: "coffee_shop" }), undefined, true);
+    expect(useEditorNetworkStore.getState().entries[NET]).toBeUndefined();
+  });
+
+  it("does nothing without a networkId, so frames cannot land on the wrong network", () => {
+    applyFramesToStore(undefined, frame({ connectivity_info: [{ origin: "frontman", tools: [] }] }), undefined, true);
+    expect(useEditorNetworkStore.getState().entries[NET]).toBeUndefined();
+  });
+
+  it("a definition-less frame cannot clobber a definition from the other stream", () => {
+    // progressHelper ranks definition-carrying payloads above definition-less ones,
+    // so a trailing name-only progress frame must not erase a real definition.
+    applyFramesToStore(
+      NET,
+      frame({ agent_network_name: "coffee_shop" }),
+      frame({ connectivity_info: [{ origin: "frontman", tools: ["barista"] }] }),
+      true
+    );
+    expect(useEditorNetworkStore.getState().entries[NET].definition).toEqual([
+      { origin: "frontman", tools: ["barista"] },
+    ]);
+  });
+});
+
+describe("useEditorProgressBridge", () => {
+  beforeEach(() => {
+    useEditorNetworkStore.getState().reset(NET);
+  });
+
+  it("reads frames under targetNetwork but stores them under the edited network", () => {
+    // The regression this guards: in editor mode every progress frame is tagged with
+    // ChatContext's targetNetwork (the designer agent), never with the network the
+    // editor is showing. Looking frames up under the edited network finds an empty
+    // bucket, and the canvas renders nothing at all.
+    const DESIGNER = "agent_network_designer";
+    const progress = frame({ connectivity_info: [{ origin: "frontman", tools: ["barista"] }] });
+
+    Object.assign(chatContext, {
+      targetNetwork: DESIGNER,
+      getLastProgressMessage: ({ network }: { network?: string }) =>
+        network === DESIGNER ? progress : undefined,
+      getLastSlyDataMessage: () => undefined,
+      progressTick: 1,
+      slyDataTick: 0,
+      lastProgressAt: 2,
+      lastSlyDataAt: 1,
+    });
+
+    renderHook(() => useEditorProgressBridge(NET));
+
+    expect(useEditorNetworkStore.getState().entries[NET]?.definition).toEqual([
+      { origin: "frontman", tools: ["barista"] },
+    ]);
+  });
+});

--- a/nsflow/frontend/src/state/progressBridge.ts
+++ b/nsflow/frontend/src/state/progressBridge.ts
@@ -1,0 +1,125 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Feeds the editor store from nsflow's progress and sly_data WebSocket streams.
+ *
+ * This is the chat lane's half of the picture. Manual edits reach the store
+ * directly through `editorRoundTrip`; changes the designer makes during a chat turn
+ * arrive here instead, over the sockets nsflow already proxies. Both end at the
+ * same reducer, so the canvas does not care which produced a change.
+ *
+ * nsflow has two streams to reconcile and two payload dialects to accept: a dict
+ * keyed by agent name under `agent_network_definition` (the designer's default
+ * "internal" progress style), or a connectivity list under `connectivity_info`.
+ * `utils/progressHelper.ts` already handles that and is pure, so it is reused
+ * as-is; this module is the consumer it anticipated.
+ */
+
+import { useEffect } from "react";
+
+import { useChatContext } from "../context/ChatContext";
+import { type ConnectivityInfo } from "../uiCommon";
+import { latestNetworkPayload } from "../utils/progressHelper";
+import { toConnectivityList } from "./definitionShape";
+import { useEditorNetworkStore } from "./editorNetworkStore";
+
+type Frame = { text: string | object } | string | object | undefined;
+
+/**
+ * The freshest definition across the two streams, in list form.
+ *
+ * Returns undefined when neither carries a definition: a definition-less frame must
+ * never overwrite one that has a definition, which is why the ranking lives in
+ * progressHelper rather than here.
+ */
+export const definitionFromFrames = (
+  progressFrame: Frame,
+  slyDataFrame: Frame,
+  preferProgress: boolean
+): ConnectivityInfo[] | undefined => {
+  const payload = latestNetworkPayload(progressFrame, slyDataFrame, preferProgress);
+  const definition = payload?.agent_network_definition;
+  if (!definition) return undefined;
+
+  return toConnectivityList(definition);
+};
+
+export const applyFramesToStore = (
+  networkId: string | undefined,
+  progressFrame: Frame,
+  slyDataFrame: Frame,
+  preferProgress: boolean
+): void => {
+  if (!networkId) return;
+
+  const definition = definitionFromFrames(progressFrame, slyDataFrame, preferProgress);
+  if (!definition) return;
+
+  const payload = latestNetworkPayload(progressFrame, slyDataFrame, preferProgress);
+  useEditorNetworkStore
+    .getState()
+    .reconcileFromServer(networkId, { definition, networkName: payload?.agent_network_name });
+};
+
+/**
+ * Mount inside the editor. Watches the frames ChatContext records and pushes the
+ * freshest definition into the store.
+ *
+ * NOTE the two different network names, which are NOT interchangeable:
+ *
+ *   - frames are looked up under ChatContext's `targetNetwork`, because that is the
+ *     socket they arrived on. In editor mode that is the designer agent's name
+ *     (`wandName`), not the network being edited, since TabbedChatPanel opens
+ *     /ws/progress/{targetNetwork} and tags every frame with it.
+ *   - the store is written under `networkId`, the network the editor is showing.
+ *
+ * Reading frames under `networkId` finds an empty bucket and the canvas stays
+ * blank. The pre-store code avoided this by calling getLatestNetworkPayload() with
+ * no argument, which defaulted to `targetNetwork`.
+ */
+export const useEditorProgressBridge = (networkId: string | undefined): void => {
+  const {
+    getLastProgressMessage,
+    getLastSlyDataMessage,
+    targetNetwork,
+    progressTick,
+    slyDataTick,
+    lastProgressAt,
+    lastSlyDataAt,
+  } = useChatContext();
+
+  useEffect(() => {
+    if (!networkId || !targetNetwork) return;
+    applyFramesToStore(
+      networkId,
+      getLastProgressMessage({ network: targetNetwork }),
+      getLastSlyDataMessage({ network: targetNetwork }),
+      lastProgressAt >= lastSlyDataAt
+    );
+    // progressTick and slyDataTick change on every recorded frame, which is what
+    // makes this run per frame rather than per render.
+  }, [
+    networkId,
+    targetNetwork,
+    progressTick,
+    slyDataTick,
+    lastProgressAt,
+    lastSlyDataAt,
+    getLastProgressMessage,
+    getLastSlyDataMessage,
+  ]);
+};

--- a/nsflow/frontend/src/types/editorCanvas.ts
+++ b/nsflow/frontend/src/types/editorCanvas.ts
@@ -1,0 +1,60 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * nsflow's own contract for an editor canvas, deliberately NOT ui-common's
+ * AgentFlowProps.
+ *
+ * It carries the same information, but the names are ours and stable. ui-common
+ * renamed three of its props between 1.5.1 and 1.11.0 (isEditMode became
+ * isEditingNetwork, isSelectedNetworkTemporary became isTemporaryNetwork, and the
+ * enter/exit edit callbacks became a single setter), so binding nsflow's components
+ * straight to it would mean churning them on every bump.
+ * `uiCommon/agentFlowAdapter.tsx` translates between the two.
+ *
+ * The canvas is intentionally given the definition and a callback rather than
+ * reaching into the store itself. That keeps it a rendering component, and it is
+ * what will let richer editing (drag to add, right-click delete, hover pencil) be
+ * added as UI without touching the data layer: each affordance computes the next
+ * definition and hands it back.
+ */
+
+import type { AgentNetworkDefinitionEntry, ConnectivityInfo } from "../uiCommon";
+
+export type EditorCanvasProps = {
+  readonly id: string;
+  /** Store key for the network being edited. */
+  readonly networkId: string;
+  /** The backend's canonical name for the network, when it has one. */
+  readonly networkName?: string;
+  /** The agent network definition, in canonical connectivity-list form. */
+  readonly definition: ConnectivityInfo[];
+  /** nsflow's own API origin. The canvas never talks to a neuro-san server. */
+  readonly apiUrl: string;
+  readonly isEditing: boolean;
+  readonly isStreaming?: boolean;
+  readonly setIsEditing: (isEditing: boolean) => void;
+  /**
+   * Persist one agent's change. The implementation applies it to the store and
+   * round-trips it through nsflow.
+   */
+  readonly onSaveAgent: (
+    agentName: string,
+    updated: AgentNetworkDefinitionEntry[],
+    agentNetworkName: string | undefined,
+    signal: AbortSignal
+  ) => Promise<void>;
+};

--- a/nsflow/frontend/src/uiCommon/agentFlowAdapter.test.ts
+++ b/nsflow/frontend/src/uiCommon/agentFlowAdapter.test.ts
@@ -1,0 +1,54 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { EditorCanvasProps } from "../types/editorCanvas";
+import { toAgentFlowProps } from "./agentFlowAdapter";
+
+const setIsEditing = vi.fn();
+const onSaveAgent = vi.fn(async () => {});
+
+const base: EditorCanvasProps = {
+  id: "editor-canvas",
+  networkId: "coffee_shop",
+  networkName: "coffee_shop_canonical",
+  definition: [{ origin: "frontman", tools: ["barista"] }],
+  apiUrl: "http://localhost:8005",
+  isEditing: true,
+  isStreaming: false,
+  setIsEditing,
+  onSaveAgent,
+};
+
+describe("toAgentFlowProps", () => {
+  it("maps nsflow's stable names onto ui-common's current ones", () => {
+    // These three are exactly the props ui-common renamed between 1.5.1 and 1.11.0,
+    // which is the whole reason this adapter exists.
+    const mapped = toAgentFlowProps(base);
+    expect(mapped.agentsInNetwork).toEqual(base.definition);
+    expect(mapped.isEditingNetwork).toBe(true);
+    expect(mapped.setIsEditingNetwork).toBe(setIsEditing);
+    expect(mapped.networkDisplayName).toBe("coffee_shop_canonical");
+  });
+
+  it("points ui-common's controller at nsflow, never at a neuro-san server", () => {
+    // nsflow's backend mirrors neuro-san's HTTP contract, so ui-common's internal
+    // controller can be aimed here. This is what keeps the browser from talking to
+    // neuro-san directly.
+    expect(toAgentFlowProps(base).neuroSanURL).toBe("http://localhost:8005");
+  });
+});

--- a/nsflow/frontend/src/uiCommon/agentFlowAdapter.ts
+++ b/nsflow/frontend/src/uiCommon/agentFlowAdapter.ts
@@ -1,0 +1,71 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * The seam between nsflow's visual layer and ui-common's.
+ *
+ * nsflow's components speak `EditorCanvasProps`; ui-common's AgentFlow speaks
+ * `AgentFlowProps`, whose names have already moved once (1.5.1 to 1.11.0). Keeping
+ * that knowledge here means a ui-common bump touches this file alone.
+ *
+ * Note what `neuroSanURL` is set to: nsflow's OWN origin, not a neuro-san server.
+ * ui-common's AgentFlow uses its controller internally, and that controller calls
+ * neuro-san's HTTP contract. Because nsflow's backend now mirrors that contract,
+ * pointing it at nsflow means its components would work here without the browser
+ * ever talking to neuro-san directly. That is precisely why the backend facade was
+ * built before this.
+ *
+ * Rendering ui-common's AgentFlow for real additionally needs its Settings and
+ * TemporaryNetworks stores provided; until then this maps props and keeps nsflow's
+ * own canvas honest about the contract.
+ */
+
+import type { EditorCanvasProps } from "../types/editorCanvas";
+import type { AgentNetworkDefinitionEntry, ConnectivityInfo } from "./index";
+
+/** The subset of ui-common's AgentFlowProps that nsflow actually drives. */
+export type AgentFlowPropsShape = {
+  readonly id: string;
+  readonly agentsInNetwork: ConnectivityInfo[];
+  readonly networkId?: string;
+  readonly networkDisplayName?: string;
+  readonly neuroSanURL?: string;
+  readonly isEditingNetwork?: boolean;
+  readonly isStreaming?: boolean;
+  readonly setIsEditingNetwork?: (value: boolean) => void;
+  readonly onSaveAgent?: (
+    agentName: string,
+    updated: AgentNetworkDefinitionEntry[],
+    agentNetworkName: string | undefined,
+    signal: AbortSignal
+  ) => Promise<void>;
+  readonly thoughtBubbleEdges: Map<string, { edge: unknown; timestamp: number }>;
+};
+
+export const toAgentFlowProps = (props: EditorCanvasProps): AgentFlowPropsShape => ({
+  id: props.id,
+  agentsInNetwork: props.definition,
+  networkId: props.networkId,
+  networkDisplayName: props.networkName,
+  // nsflow's origin, deliberately: see the note at the top of this file.
+  neuroSanURL: props.apiUrl,
+  isEditingNetwork: props.isEditing,
+  isStreaming: props.isStreaming,
+  setIsEditingNetwork: props.setIsEditing,
+  onSaveAgent: props.onSaveAgent,
+  // Required by AgentFlowProps; nsflow does not use thought bubbles.
+  thoughtBubbleEdges: new Map(),
+});

--- a/nsflow/frontend/src/uiCommon/index.ts
+++ b/nsflow/frontend/src/uiCommon/index.ts
@@ -1,0 +1,66 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * The single door between nsflow and @cognizant-ai-lab/ui-common.
+ *
+ * Every ui-common symbol the app uses is re-exported here, and the deep dist
+ * paths behind these specifiers live in ../../aliases.ts (which also records why
+ * the barrel is bypassed and why the xyflow/zustand pins move in lockstep).
+ * Import from "../uiCommon" everywhere else, never from "@ui-common/*" directly,
+ * so a ui-common version bump stays a two-file change.
+ */
+
+/**
+ * DELIBERATELY NOT RE-EXPORTED: ui-common's neuro-san controller
+ * (`sendChatQuery`, `sendNetworkDesignerRequest`, `getConnectivity`,
+ * `getAgentNetworks`) and its `useEnvironmentStore`.
+ *
+ * Those call a neuro-san server straight from the browser, which is how
+ * neuro-san-ui is built. nsflow deliberately does not do that: it already has a
+ * FastAPI backend that owns every conversation with neuro-san, and that stays
+ * the single ingress. Adopting ui-common's *data* layer (sly_data key names, the
+ * connectivity-list shape, graph helpers, the IndexedDB persist adapter) gives us
+ * the shared contract without a second API layer in the frontend.
+ *
+ * The aliases for those modules still exist in ../../aliases.ts, because
+ * ui-common's own AgentFlow imports its controller internally, so they must
+ * resolve if we later render ui-common's visual components. At that point the
+ * controller gets pointed at nsflow's own origin rather than at neuro-san.
+ */
+
+// The IndexedDB persist adapter: pure browser storage, no neuro-san involvement.
+export { indexedDBStorage } from "@ui-common/state/IndexedDBStorage";
+
+export {
+  AGENT_NETWORK_DEFINITION_KEY,
+  AGENT_NETWORK_DESIGNER_ID,
+  AGENT_NETWORK_HOCON,
+  AGENT_NETWORK_NAME_KEY,
+  type AgentNetworkDefinitionEntry,
+} from "@ui-common/mac/const";
+
+export { extractAgentNetworkDesignerProgress } from "@ui-common/mac/AgentNetworkDesigner";
+
+export { getFrontman, getParentAgents, getParents } from "@ui-common/graph/GraphStructure";
+
+export {
+  type AgentInfo,
+  type ChatContext,
+  type ChatMessage,
+  ChatMessageType,
+  type ConnectivityInfo,
+} from "@ui-common/types";

--- a/nsflow/frontend/src/utils/agentLayoutManager.test.ts
+++ b/nsflow/frontend/src/utils/agentLayoutManager.test.ts
@@ -1,0 +1,154 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * The cached-layout path, which decides whether a newly added agent is visible.
+ *
+ * buildEditorGraph hands every node a placeholder position, so "does this node have
+ * numbers in its position" cannot tell a laid-out node from one the cache has never
+ * seen. Getting that wrong left a new agent stacked on the placeholder coordinate,
+ * looking as though the edit had not applied.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { AgentLayoutManager, createLayoutManager } from "./agentLayoutManager";
+
+/** The placeholder buildEditorGraph uses for every node it produces. */
+const PLACEHOLDER = { x: 100, y: 100 };
+
+const node = (id: string): Node => ({
+  id,
+  type: "agent",
+  position: { ...PLACEHOLDER },
+  data: { label: id },
+});
+
+const edge = (source: string, target: string): Edge => ({
+  id: `${source}-${target}`,
+  source,
+  target,
+});
+
+describe("overlap separation", () => {
+  beforeEach(() => localStorage.clear());
+
+  /** Distance below which two cards read as one node with another missing. */
+  const MIN_GAP = 60;
+
+  const anyOverlap = (nodes: Node[]): boolean =>
+    nodes.some((a, i) =>
+      nodes.some(
+        (b, j) =>
+          i !== j &&
+          Math.abs(a.position.x - b.position.x) < MIN_GAP &&
+          Math.abs(a.position.y - b.position.y) < MIN_GAP
+      )
+    );
+
+  /**
+   * Tested directly rather than through applyLayout. The hierarchical layout does
+   * not currently collide even for a dozen siblings, so driving this through the
+   * public API would assert nothing: the pass is a guard against a layout that does,
+   * and against the placeholder collision that made a new agent invisible.
+   */
+  it("pulls stacked nodes apart", () => {
+    const stacked = [node("a"), node("b"), node("c")]; // all on the placeholder
+    expect(anyOverlap(stacked)).toBe(true);
+
+    const separated = AgentLayoutManager.separateOverlaps(stacked);
+
+    expect(anyOverlap(separated)).toBe(false);
+    // The first node keeps its place; only the ones that collide with it move.
+    expect(separated[0].position).toEqual(stacked[0].position);
+  });
+
+  it("leaves an already-spread layout untouched", () => {
+    const spread = [
+      { ...node("a"), position: { x: 0, y: 0 } },
+      { ...node("b"), position: { x: 400, y: 0 } },
+    ];
+    expect(AgentLayoutManager.separateOverlaps(spread).map((n) => n.position)).toEqual([
+      { x: 0, y: 0 },
+      { x: 400, y: 0 },
+    ]);
+  });
+
+  it("is deterministic, so the canvas does not shuffle between renders", () => {
+    const first = createLayoutManager("net_a").applyLayout(
+      [node("frontman"), node("a"), node("b")],
+      [edge("frontman", "a"), edge("frontman", "b")]
+    );
+    const second = createLayoutManager("net_b").applyLayout(
+      [node("frontman"), node("a"), node("b")],
+      [edge("frontman", "a"), edge("frontman", "b")]
+    );
+
+    expect(second.nodes.map((n) => n.position)).toEqual(first.nodes.map((n) => n.position));
+  });
+});
+
+describe("applyLayout", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("lays out a network it has never seen", () => {
+    const manager = createLayoutManager("net_fresh");
+    const { nodes } = manager.applyLayout([node("frontman"), node("barista")], [
+      edge("frontman", "barista"),
+    ]);
+
+    expect(nodes).toHaveLength(2);
+    // Both moved off the placeholder, so neither is stacked on the other.
+    expect(nodes.every((laid) => laid.position.x !== PLACEHOLDER.x || laid.position.y !== PLACEHOLDER.y))
+      .toBe(true);
+  });
+
+  it("reuses cached positions when the graph has not changed", () => {
+    const manager = createLayoutManager("net_stable");
+    const graph: [Node[], Edge[]] = [[node("frontman"), node("barista")], [edge("frontman", "barista")]];
+    const first = manager.applyLayout(...graph);
+
+    const again = manager.applyLayout(
+      [node("frontman"), node("barista")],
+      [edge("frontman", "barista")]
+    );
+
+    // Same positions, so a re-render does not shuffle the canvas or discard a drag.
+    expect(again.nodes.map((laid) => laid.position)).toEqual(first.nodes.map((laid) => laid.position));
+  });
+
+  it("lays out again when an agent is added, rather than leaving it on the placeholder", () => {
+    const manager = createLayoutManager("net_added");
+    manager.applyLayout([node("frontman"), node("barista")], [edge("frontman", "barista")]);
+
+    // "roaster" is not in the cache. Before the fix, the cached path was taken
+    // anyway and roaster kept {100,100} — invisible behind another node.
+    const { nodes } = manager.applyLayout(
+      [node("frontman"), node("barista"), node("roaster")],
+      [edge("frontman", "barista"), edge("frontman", "roaster")]
+    );
+
+    const roaster = nodes.find((laid) => laid.id === "roaster");
+    expect(roaster).toBeDefined();
+    expect(roaster?.position).not.toEqual(PLACEHOLDER);
+    // And it is not sitting on top of anything else.
+    const others = nodes.filter((laid) => laid.id !== "roaster").map((laid) => laid.position);
+    expect(others).not.toContainEqual(roaster?.position);
+  });
+});

--- a/nsflow/frontend/src/utils/agentLayoutManager.ts
+++ b/nsflow/frontend/src/utils/agentLayoutManager.ts
@@ -59,31 +59,78 @@ export class AgentLayoutManager {
       return { nodes: [], edges: [] };
     }
 
-    // Try to use cached positions first (unless forced layout)
-    if (!forceLayout && this.positionCache.hasNetworkPositions(this.networkName)) {
-      const cachedNodes = this.positionCache.applyCachedPositions(this.networkName, nodes);
-      
-      // Verify all nodes have valid positions
-      const allPositioned = cachedNodes.every(node => 
-        node.position && 
-        typeof node.position.x === 'number' && 
-        typeof node.position.y === 'number' &&
-        !isNaN(node.position.x) && 
-        !isNaN(node.position.y)
-      );
+    // Try to use cached positions first (unless forced layout).
+    //
+    // Every node must actually BE in the cache, not merely end up with numbers in
+    // its position. applyCachedPositions returns an uncached node untouched, and
+    // callers hand in placeholder coordinates, so checking the resulting position
+    // (as this did) treats a node the cache has never seen as already laid out: a
+    // newly added agent kept its placeholder and rendered stacked on top of another
+    // node, looking as though the edit had not applied at all. It only appeared
+    // after a reload, which happens to trigger a forced re-layout.
+    //
+    // A missing node means the graph has changed shape, so the whole thing is laid
+    // out again. That does discard manual drags when an agent is added or removed,
+    // which is the same thing the "Reorganize Layout" button does, and is much
+    // better than the new agent being invisible.
+    if (!forceLayout) {
+      const cachedPositions = this.positionCache.getNetworkPositions(this.networkName);
+      const everyNodeCached =
+        Boolean(cachedPositions) && nodes.every((node) => Boolean(cachedPositions?.[node.id]));
 
-      if (allPositioned) {
-        return { nodes: cachedNodes, edges };
+      if (everyNodeCached) {
+        return { nodes: this.positionCache.applyCachedPositions(this.networkName, nodes), edges };
       }
     }
 
     // Apply fresh layout
     const layoutResult = this.calculateLayout(nodes, edges);
-    
-    // Cache the new positions
-    this.positionCache.saveNetworkPositions(this.networkName, layoutResult.nodes);
-    
-    return layoutResult;
+    const spread = { nodes: AgentLayoutManager.separateOverlaps(layoutResult.nodes), edges: layoutResult.edges };
+
+    // Cache the positions actually used, so the nudge is applied once and then
+    // stays put rather than being recomputed differently on the next render.
+    this.positionCache.saveNetworkPositions(this.networkName, spread.nodes);
+
+    return spread;
+  }
+
+  /**
+   * Nudge apart any nodes the layout put on the same spot.
+   *
+   * A safety net rather than the mechanism: the hierarchical layout normally spaces
+   * nodes properly, but a degenerate case (one agent under a parent that already has
+   * a child at that angle, or two free agents at the same index) can collide, and two
+   * nodes on the same coordinate look like one node and a missing one.
+   *
+   * The offset walks a fixed spiral rather than being random, so the same graph
+   * always lays out identically and the canvas does not shuffle on re-render.
+   *
+   * Public only so it can be tested directly: the layouts it guards against are hard
+   * to provoke through applyLayout, which is the point of it being a safety net.
+   */
+  public static separateOverlaps(nodes: Node[]): Node[] {
+    // Node cards are wider than they are tall, so a collision is judged on both axes
+    // at roughly card size.
+    const MIN_GAP = 60;
+    const STEP = MIN_GAP;
+
+    const placed: { x: number; y: number }[] = [];
+    const collides = (x: number, y: number): boolean =>
+      placed.some((seen) => Math.abs(seen.x - x) < MIN_GAP && Math.abs(seen.y - y) < MIN_GAP);
+
+    return nodes.map((node) => {
+      let { x, y } = node.position;
+      // Bounded so a pathological graph cannot spin here; after this many tries the
+      // node is left where it is, which is no worse than before.
+      for (let attempt = 1; collides(x, y) && attempt <= 64; attempt += 1) {
+        const ring = Math.ceil(attempt / 8);
+        const angle = ((attempt % 8) * Math.PI) / 4;
+        x = node.position.x + Math.round(Math.cos(angle) * STEP * ring);
+        y = node.position.y + Math.round(Math.sin(angle) * STEP * ring);
+      }
+      placed.push({ x, y });
+      return x === node.position.x && y === node.position.y ? node : { ...node, position: { x, y } };
+    });
   }
 
   /**

--- a/nsflow/frontend/src/utils/config.ts
+++ b/nsflow/frontend/src/utils/config.ts
@@ -34,7 +34,6 @@ type AppRuntimeConfig = {
   NSFLOW_PLUGIN_CRUSE: boolean;
   NSFLOW_PLUGIN_WAND: boolean;
   NSFLOW_PLUGIN_MULTIMEDIACARD: boolean;
-  NSFLOW_PLUGIN_MANUAL_EDITOR: boolean;
   NSFLOW_PLUGIN_EXPORT: boolean;
   NSFLOW_PLUGIN_ZENMODE: boolean;
 };
@@ -72,7 +71,6 @@ export function getFeatureFlags() {
   return {
     pluginCruse: !!c.NSFLOW_PLUGIN_CRUSE,
     pluginWand: !!c.NSFLOW_PLUGIN_WAND,
-    pluginManualEditor: !!c.NSFLOW_PLUGIN_MANUAL_EDITOR,
     pluginMultiMediaCard: !!c.NSFLOW_PLUGIN_MULTIMEDIACARD,
     pluginExport: !!c.NSFLOW_PLUGIN_EXPORT,
     pluginZenMode: !!c.NSFLOW_PLUGIN_ZENMODE,

--- a/nsflow/frontend/src/utils/focusChat.ts
+++ b/nsflow/frontend/src/utils/focusChat.ts
@@ -1,0 +1,37 @@
+/*
+Copyright © 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Hands the user over from the canvas to the chat box.
+ *
+ * The two live in separate panels with no component relationship, and the editor
+ * has no business knowing how the chat panel is built. A named window event lets
+ * the canvas say "the user wants to describe this instead" and lets the chat panel
+ * decide what that means, without either importing the other.
+ */
+
+const FOCUS_CHAT_EVENT = "nsflow:focus-chat";
+
+/** Ask the chat panel to take focus. Does nothing if no chat panel is mounted. */
+export const requestChatFocus = (): void => {
+  window.dispatchEvent(new CustomEvent(FOCUS_CHAT_EVENT));
+};
+
+/** Run `onFocusRequested` whenever the canvas hands over. Returns an unsubscribe. */
+export const onChatFocusRequested = (onFocusRequested: () => void): (() => void) => {
+  window.addEventListener(FOCUS_CHAT_EVENT, onFocusRequested);
+  return () => window.removeEventListener(FOCUS_CHAT_EVENT, onFocusRequested);
+};


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Fixes

Fixes #257
Fixes #258
Fixes #173
Fixes #176

## Description

Replaces the Editor's server-side state machinery with a browser data layer, so manual editing is immediate and deterministic rather than a round trip through the designer LLM.

**Manual edits never invoke the LLM.** That was the point. Previously a bare `{origin, tools}` entry read as a toolbox tool and the list-shaped payload dropped empty strings, so every hand edit re-summoned the designer and took 30 to 47 seconds. Edits now send the dict definition shape with non-empty defaults, and go out with `skip_designer`.

**No free-floating agents, ever.** Attachment is structural, not advisory: an added agent attaches to the selection, or to the frontman when nothing is selected. A definition that would produce a floater is rejected before it is sent, which is what used to cause "No front man agent found".

**Structural invariants are enforced in the UI.** Toolbox tools cannot take down-chain agents; the frontman cannot be deleted or duplicated. The context menu greys out what the structure forbids rather than letting it fail later.

**Naming ceremony.** A new draft asks for the network name first, then adds a frontman named `<network>_agent`. Nothing can be added before the frontman exists.

**Handover works both ways.** Manual edits feed the sly_data stream, and the chat can pick a network up mid-edit. The chat input is focused and briefly highlighted on handover, because focus alone is easy to miss.

The palette is rebuilt as a floating notch: an add button plus one icon per source (other networks, toolbox, MCP), each opening a short searchable list. Everything works by click and by drag.

Also fixes the layout manager caching incomplete layouts, and a stale closure in force-layout that made a newly added agent invisible until refresh.

## Impact

The 16 modules under `src/state` are pure and carry 139 of this branch's tests, so the data layer is reviewable independently of the canvas. `src/utils/config.ts` drops the dead `NSFLOW_PLUGIN_MANUAL_EDITOR` flag.

Related open issues, for context rather than closure: #257, #258, #259, #262, #267.

## Screenshot
<img width="1726" height="963" alt="Screenshot 2026-09-09 at 10 47 11 PM" src="https://github.com/user-attachments/assets/f891cb9b-674c-48a1-a87b-0030604d9ada" />

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

157 frontend tests across 13 files, up from 11 in 1. `yarn lint` 0 errors, `yarn test` and `yarn build` clean. No new dependencies. Help is documented in-app via a new help dialog rather than in the repo docs.

Stacked on #288.

---